### PR TITLE
policy/v2: add support for policy tests

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -202,6 +202,7 @@ jobs:
           - TestAuthWebFlowAuthenticationPingAll
           - TestAuthWebFlowLogoutAndReloginSameUser
           - TestAuthWebFlowLogoutAndReloginNewUser
+          - TestPolicyCheckCommand
           - TestUserCommand
           - TestPreAuthKeyCommand
           - TestPreAuthKeyCommandWithoutExpiry

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
     rev: v6.0.0
     hooks:
       - id: check-added-large-files
+        args: [--maxkb=1024]
       - id: check-case-conflict
       - id: check-executables-have-shebangs
       - id: check-json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,23 @@ A new `headscale auth` CLI command group supports the approval flow:
 [#1850](https://github.com/juanfont/headscale/pull/1850)
 [#3180](https://github.com/juanfont/headscale/pull/3180)
 
+### Policy tests (beta)
+
+Headscale now evaluates the `tests` block in a policy file. Tests assert reachability between
+named sources and destinations and cover the whole policy — both `acls` and `grants` rules
+contribute. They run on user-initiated writes via `headscale policy set`, on SIGHUP reload
+(`systemctl reload headscale` / `kill -HUP $(pidof headscale)`), and on `headscale policy check`.
+A failing test rejects the write before it is applied, with the same error message Tailscale SaaS
+would return for the same policy.
+
+At boot a stored policy whose tests no longer pass — for example because a referenced user was
+deleted while the server was offline — logs a warning and the server keeps running. Fix the
+policy and reload.
+
+This feature is **beta** while behavioural coverage against Tailscale SaaS broadens.
+
+[#3229](https://github.com/juanfont/headscale/pull/3229)
+
 ### Grants
 
 We now support [Tailscale grants](https://tailscale.com/docs/features/access-control/grants)
@@ -134,6 +151,7 @@ connected" routers that maintain their control session but cannot route packets.
 - Fix exit node approval not triggering filter rule recalculation for peers [#2180](https://github.com/juanfont/headscale/pull/2180)
 - Policy validation error messages now include field context (e.g., `src=`, `dst=`) and are more descriptive [#2180](https://github.com/juanfont/headscale/pull/2180)
 - Reject policies whose `user@` tokens match multiple DB users; rename the duplicate via `headscale users rename` to load [#3160](https://github.com/juanfont/headscale/issues/3160)
+- Evaluate the policy `tests` block on user-initiated writes across both `acls` and `grants`; reject policies whose tests fail (beta) [#1803](https://github.com/juanfont/headscale/issues/1803)
 
 #### Grants
 
@@ -156,6 +174,7 @@ connected" routers that maintain their control session but cannot route packets.
 - Remove deprecated `--namespace` flag from `nodes list`, `nodes register`, and `debug create-node` commands (use `--user` instead) [#3093](https://github.com/juanfont/headscale/pull/3093)
 - Remove deprecated `namespace`/`ns` command aliases for `users` and `machine`/`machines` aliases for `nodes` [#3093](https://github.com/juanfont/headscale/pull/3093)
 - **User deletion**: Fix `DestroyUser` deleting all pre-auth keys in the database instead of only the target user's keys [#3155](https://github.com/juanfont/headscale/pull/3155)
+- `headscale policy check` evaluates the `tests` block when invoked with `--bypass-grpc-and-access-database-directly`; without the flag it warns instead of running the tests against empty data [#1803](https://github.com/juanfont/headscale/issues/1803)
 
 #### API
 

--- a/cmd/headscale/cli/policy.go
+++ b/cmd/headscale/cli/policy.go
@@ -48,7 +48,7 @@ func init() {
 	policyCmd.AddCommand(setPolicy)
 
 	checkPolicy.Flags().StringP("file", "f", "", "Path to a policy file in HuJSON format")
-	checkPolicy.Flags().BoolP(bypassFlag, "", false, "Uses the headscale config to directly access the database, bypassing gRPC and does not require the server to be running. Required to validate that user@ tokens resolve against the user database; without it, the check is syntax-only.")
+	checkPolicy.Flags().BoolP(bypassFlag, "", false, "Open the database directly (no gRPC, no running server) to validate user@ token references and to evaluate the policy's tests block. Required when those checks are needed.")
 	mustMarkRequired(checkPolicy, "file")
 	policyCmd.AddCommand(checkPolicy)
 }
@@ -171,6 +171,11 @@ var setPolicy = &cobra.Command{
 var checkPolicy = &cobra.Command{
 	Use:   "check",
 	Short: "Check the Policy file for errors",
+	Long: `
+	Check validates the policy against the server's live users and nodes,
+	running any "tests" block. By default the command is a thin frontend
+	for a gRPC call to a running headscale; pass --` + bypassFlag + ` to
+	open the database directly when headscale is not running.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		policyPath, _ := cmd.Flags().GetString("file")
 
@@ -178,8 +183,6 @@ var checkPolicy = &cobra.Command{
 		if err != nil {
 			return fmt.Errorf("reading policy file: %w", err)
 		}
-
-		var users []types.User
 
 		if bypass, _ := cmd.Flags().GetBool(bypassFlag); bypass {
 			if !confirmAction(cmd, "DO NOT run this command if an instance of headscale is running, are you sure headscale is not running?") {
@@ -192,22 +195,48 @@ var checkPolicy = &cobra.Command{
 			}
 			defer d.Close()
 
-			users, err = d.ListUsers()
+			users, err := d.ListUsers()
 			if err != nil {
-				return fmt.Errorf("loading users for policy validation: %w", err)
+				return fmt.Errorf("loading users: %w", err)
 			}
-		}
 
-		_, err = policy.NewPolicyManager(policyBytes, users, views.Slice[types.NodeView]{})
-		if err != nil {
-			return fmt.Errorf("parsing policy file: %w", err)
-		}
+			nodes, err := d.ListNodes()
+			if err != nil {
+				return fmt.Errorf("loading nodes: %w", err)
+			}
 
-		if users == nil {
-			fmt.Println("Policy syntax is valid (run with --" + bypassFlag + " to also validate user references against the database)")
-		} else {
+			// NewPolicyManager validates structure and user references
+			// but intentionally skips test evaluation (boot path).
+			// SetPolicy is the user-write boundary and is what runs the
+			// tests block.
+			pm, err := policy.NewPolicyManager(policyBytes, users, nodes.ViewSlice())
+			if err != nil {
+				return fmt.Errorf("parsing policy file: %w", err)
+			}
+
+			_, err = pm.SetPolicy(policyBytes)
+			if err != nil {
+				return err
+			}
+
 			fmt.Println("Policy is valid")
+
+			return nil
 		}
+
+		ctx, client, conn, cancel, err := newHeadscaleCLIWithConfig()
+		if err != nil {
+			return fmt.Errorf("connecting to headscale: %w", err)
+		}
+		defer cancel()
+		defer conn.Close()
+
+		_, err = client.CheckPolicy(ctx, &v1.CheckPolicyRequest{Policy: string(policyBytes)})
+		if err != nil {
+			return err
+		}
+
+		fmt.Println("Policy is valid")
 
 		return nil
 	},

--- a/cmd/headscale/cli/root.go
+++ b/cmd/headscale/cli/root.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"os"
 	"runtime"
-	"slices"
 	"strings"
 
 	"github.com/juanfont/headscale/hscontrol/types"
@@ -19,11 +18,6 @@ var cfgFile string = ""
 func init() {
 	if len(os.Args) > 1 &&
 		(os.Args[1] == "version" || os.Args[1] == "mockoidc" || os.Args[1] == "completion") {
-		return
-	}
-
-	if slices.Contains(os.Args, "policy") && slices.Contains(os.Args, "check") {
-		zerolog.SetGlobalLevel(zerolog.Disabled)
 		return
 	}
 

--- a/gen/go/headscale/v1/headscale.pb.go
+++ b/gen/go/headscale/v1/headscale.pb.go
@@ -109,7 +109,7 @@ const file_headscale_v1_headscale_proto_rawDesc = "" +
 	"\x1cheadscale/v1/headscale.proto\x12\fheadscale.v1\x1a\x1cgoogle/api/annotations.proto\x1a\x17headscale/v1/user.proto\x1a\x1dheadscale/v1/preauthkey.proto\x1a\x17headscale/v1/node.proto\x1a\x19headscale/v1/apikey.proto\x1a\x17headscale/v1/auth.proto\x1a\x19headscale/v1/policy.proto\"\x0f\n" +
 	"\rHealthRequest\"E\n" +
 	"\x0eHealthResponse\x123\n" +
-	"\x15database_connectivity\x18\x01 \x01(\bR\x14databaseConnectivity2\xeb\x19\n" +
+	"\x15database_connectivity\x18\x01 \x01(\bR\x14databaseConnectivity2\xe0\x1a\n" +
 	"\x10HeadscaleService\x12h\n" +
 	"\n" +
 	"CreateUser\x12\x1f.headscale.v1.CreateUserRequest\x1a .headscale.v1.CreateUserResponse\"\x17\x82\xd3\xe4\x93\x02\x11:\x01*\"\f/api/v1/user\x12\x80\x01\n" +
@@ -144,7 +144,8 @@ const file_headscale_v1_headscale_proto_rawDesc = "" +
 	"\vListApiKeys\x12 .headscale.v1.ListApiKeysRequest\x1a!.headscale.v1.ListApiKeysResponse\"\x16\x82\xd3\xe4\x93\x02\x10\x12\x0e/api/v1/apikey\x12v\n" +
 	"\fDeleteApiKey\x12!.headscale.v1.DeleteApiKeyRequest\x1a\".headscale.v1.DeleteApiKeyResponse\"\x1f\x82\xd3\xe4\x93\x02\x19*\x17/api/v1/apikey/{prefix}\x12d\n" +
 	"\tGetPolicy\x12\x1e.headscale.v1.GetPolicyRequest\x1a\x1f.headscale.v1.GetPolicyResponse\"\x16\x82\xd3\xe4\x93\x02\x10\x12\x0e/api/v1/policy\x12g\n" +
-	"\tSetPolicy\x12\x1e.headscale.v1.SetPolicyRequest\x1a\x1f.headscale.v1.SetPolicyResponse\"\x19\x82\xd3\xe4\x93\x02\x13:\x01*\x1a\x0e/api/v1/policy\x12[\n" +
+	"\tSetPolicy\x12\x1e.headscale.v1.SetPolicyRequest\x1a\x1f.headscale.v1.SetPolicyResponse\"\x19\x82\xd3\xe4\x93\x02\x13:\x01*\x1a\x0e/api/v1/policy\x12s\n" +
+	"\vCheckPolicy\x12 .headscale.v1.CheckPolicyRequest\x1a!.headscale.v1.CheckPolicyResponse\"\x1f\x82\xd3\xe4\x93\x02\x19:\x01*\"\x14/api/v1/policy/check\x12[\n" +
 	"\x06Health\x12\x1b.headscale.v1.HealthRequest\x1a\x1c.headscale.v1.HealthResponse\"\x16\x82\xd3\xe4\x93\x02\x10\x12\x0e/api/v1/healthB)Z'github.com/juanfont/headscale/gen/go/v1b\x06proto3"
 
 var (
@@ -190,33 +191,35 @@ var file_headscale_v1_headscale_proto_goTypes = []any{
 	(*DeleteApiKeyRequest)(nil),       // 26: headscale.v1.DeleteApiKeyRequest
 	(*GetPolicyRequest)(nil),          // 27: headscale.v1.GetPolicyRequest
 	(*SetPolicyRequest)(nil),          // 28: headscale.v1.SetPolicyRequest
-	(*CreateUserResponse)(nil),        // 29: headscale.v1.CreateUserResponse
-	(*RenameUserResponse)(nil),        // 30: headscale.v1.RenameUserResponse
-	(*DeleteUserResponse)(nil),        // 31: headscale.v1.DeleteUserResponse
-	(*ListUsersResponse)(nil),         // 32: headscale.v1.ListUsersResponse
-	(*CreatePreAuthKeyResponse)(nil),  // 33: headscale.v1.CreatePreAuthKeyResponse
-	(*ExpirePreAuthKeyResponse)(nil),  // 34: headscale.v1.ExpirePreAuthKeyResponse
-	(*DeletePreAuthKeyResponse)(nil),  // 35: headscale.v1.DeletePreAuthKeyResponse
-	(*ListPreAuthKeysResponse)(nil),   // 36: headscale.v1.ListPreAuthKeysResponse
-	(*DebugCreateNodeResponse)(nil),   // 37: headscale.v1.DebugCreateNodeResponse
-	(*GetNodeResponse)(nil),           // 38: headscale.v1.GetNodeResponse
-	(*SetTagsResponse)(nil),           // 39: headscale.v1.SetTagsResponse
-	(*SetApprovedRoutesResponse)(nil), // 40: headscale.v1.SetApprovedRoutesResponse
-	(*RegisterNodeResponse)(nil),      // 41: headscale.v1.RegisterNodeResponse
-	(*DeleteNodeResponse)(nil),        // 42: headscale.v1.DeleteNodeResponse
-	(*ExpireNodeResponse)(nil),        // 43: headscale.v1.ExpireNodeResponse
-	(*RenameNodeResponse)(nil),        // 44: headscale.v1.RenameNodeResponse
-	(*ListNodesResponse)(nil),         // 45: headscale.v1.ListNodesResponse
-	(*BackfillNodeIPsResponse)(nil),   // 46: headscale.v1.BackfillNodeIPsResponse
-	(*AuthRegisterResponse)(nil),      // 47: headscale.v1.AuthRegisterResponse
-	(*AuthApproveResponse)(nil),       // 48: headscale.v1.AuthApproveResponse
-	(*AuthRejectResponse)(nil),        // 49: headscale.v1.AuthRejectResponse
-	(*CreateApiKeyResponse)(nil),      // 50: headscale.v1.CreateApiKeyResponse
-	(*ExpireApiKeyResponse)(nil),      // 51: headscale.v1.ExpireApiKeyResponse
-	(*ListApiKeysResponse)(nil),       // 52: headscale.v1.ListApiKeysResponse
-	(*DeleteApiKeyResponse)(nil),      // 53: headscale.v1.DeleteApiKeyResponse
-	(*GetPolicyResponse)(nil),         // 54: headscale.v1.GetPolicyResponse
-	(*SetPolicyResponse)(nil),         // 55: headscale.v1.SetPolicyResponse
+	(*CheckPolicyRequest)(nil),        // 29: headscale.v1.CheckPolicyRequest
+	(*CreateUserResponse)(nil),        // 30: headscale.v1.CreateUserResponse
+	(*RenameUserResponse)(nil),        // 31: headscale.v1.RenameUserResponse
+	(*DeleteUserResponse)(nil),        // 32: headscale.v1.DeleteUserResponse
+	(*ListUsersResponse)(nil),         // 33: headscale.v1.ListUsersResponse
+	(*CreatePreAuthKeyResponse)(nil),  // 34: headscale.v1.CreatePreAuthKeyResponse
+	(*ExpirePreAuthKeyResponse)(nil),  // 35: headscale.v1.ExpirePreAuthKeyResponse
+	(*DeletePreAuthKeyResponse)(nil),  // 36: headscale.v1.DeletePreAuthKeyResponse
+	(*ListPreAuthKeysResponse)(nil),   // 37: headscale.v1.ListPreAuthKeysResponse
+	(*DebugCreateNodeResponse)(nil),   // 38: headscale.v1.DebugCreateNodeResponse
+	(*GetNodeResponse)(nil),           // 39: headscale.v1.GetNodeResponse
+	(*SetTagsResponse)(nil),           // 40: headscale.v1.SetTagsResponse
+	(*SetApprovedRoutesResponse)(nil), // 41: headscale.v1.SetApprovedRoutesResponse
+	(*RegisterNodeResponse)(nil),      // 42: headscale.v1.RegisterNodeResponse
+	(*DeleteNodeResponse)(nil),        // 43: headscale.v1.DeleteNodeResponse
+	(*ExpireNodeResponse)(nil),        // 44: headscale.v1.ExpireNodeResponse
+	(*RenameNodeResponse)(nil),        // 45: headscale.v1.RenameNodeResponse
+	(*ListNodesResponse)(nil),         // 46: headscale.v1.ListNodesResponse
+	(*BackfillNodeIPsResponse)(nil),   // 47: headscale.v1.BackfillNodeIPsResponse
+	(*AuthRegisterResponse)(nil),      // 48: headscale.v1.AuthRegisterResponse
+	(*AuthApproveResponse)(nil),       // 49: headscale.v1.AuthApproveResponse
+	(*AuthRejectResponse)(nil),        // 50: headscale.v1.AuthRejectResponse
+	(*CreateApiKeyResponse)(nil),      // 51: headscale.v1.CreateApiKeyResponse
+	(*ExpireApiKeyResponse)(nil),      // 52: headscale.v1.ExpireApiKeyResponse
+	(*ListApiKeysResponse)(nil),       // 53: headscale.v1.ListApiKeysResponse
+	(*DeleteApiKeyResponse)(nil),      // 54: headscale.v1.DeleteApiKeyResponse
+	(*GetPolicyResponse)(nil),         // 55: headscale.v1.GetPolicyResponse
+	(*SetPolicyResponse)(nil),         // 56: headscale.v1.SetPolicyResponse
+	(*CheckPolicyResponse)(nil),       // 57: headscale.v1.CheckPolicyResponse
 }
 var file_headscale_v1_headscale_proto_depIdxs = []int32{
 	2,  // 0: headscale.v1.HeadscaleService.CreateUser:input_type -> headscale.v1.CreateUserRequest
@@ -246,37 +249,39 @@ var file_headscale_v1_headscale_proto_depIdxs = []int32{
 	26, // 24: headscale.v1.HeadscaleService.DeleteApiKey:input_type -> headscale.v1.DeleteApiKeyRequest
 	27, // 25: headscale.v1.HeadscaleService.GetPolicy:input_type -> headscale.v1.GetPolicyRequest
 	28, // 26: headscale.v1.HeadscaleService.SetPolicy:input_type -> headscale.v1.SetPolicyRequest
-	0,  // 27: headscale.v1.HeadscaleService.Health:input_type -> headscale.v1.HealthRequest
-	29, // 28: headscale.v1.HeadscaleService.CreateUser:output_type -> headscale.v1.CreateUserResponse
-	30, // 29: headscale.v1.HeadscaleService.RenameUser:output_type -> headscale.v1.RenameUserResponse
-	31, // 30: headscale.v1.HeadscaleService.DeleteUser:output_type -> headscale.v1.DeleteUserResponse
-	32, // 31: headscale.v1.HeadscaleService.ListUsers:output_type -> headscale.v1.ListUsersResponse
-	33, // 32: headscale.v1.HeadscaleService.CreatePreAuthKey:output_type -> headscale.v1.CreatePreAuthKeyResponse
-	34, // 33: headscale.v1.HeadscaleService.ExpirePreAuthKey:output_type -> headscale.v1.ExpirePreAuthKeyResponse
-	35, // 34: headscale.v1.HeadscaleService.DeletePreAuthKey:output_type -> headscale.v1.DeletePreAuthKeyResponse
-	36, // 35: headscale.v1.HeadscaleService.ListPreAuthKeys:output_type -> headscale.v1.ListPreAuthKeysResponse
-	37, // 36: headscale.v1.HeadscaleService.DebugCreateNode:output_type -> headscale.v1.DebugCreateNodeResponse
-	38, // 37: headscale.v1.HeadscaleService.GetNode:output_type -> headscale.v1.GetNodeResponse
-	39, // 38: headscale.v1.HeadscaleService.SetTags:output_type -> headscale.v1.SetTagsResponse
-	40, // 39: headscale.v1.HeadscaleService.SetApprovedRoutes:output_type -> headscale.v1.SetApprovedRoutesResponse
-	41, // 40: headscale.v1.HeadscaleService.RegisterNode:output_type -> headscale.v1.RegisterNodeResponse
-	42, // 41: headscale.v1.HeadscaleService.DeleteNode:output_type -> headscale.v1.DeleteNodeResponse
-	43, // 42: headscale.v1.HeadscaleService.ExpireNode:output_type -> headscale.v1.ExpireNodeResponse
-	44, // 43: headscale.v1.HeadscaleService.RenameNode:output_type -> headscale.v1.RenameNodeResponse
-	45, // 44: headscale.v1.HeadscaleService.ListNodes:output_type -> headscale.v1.ListNodesResponse
-	46, // 45: headscale.v1.HeadscaleService.BackfillNodeIPs:output_type -> headscale.v1.BackfillNodeIPsResponse
-	47, // 46: headscale.v1.HeadscaleService.AuthRegister:output_type -> headscale.v1.AuthRegisterResponse
-	48, // 47: headscale.v1.HeadscaleService.AuthApprove:output_type -> headscale.v1.AuthApproveResponse
-	49, // 48: headscale.v1.HeadscaleService.AuthReject:output_type -> headscale.v1.AuthRejectResponse
-	50, // 49: headscale.v1.HeadscaleService.CreateApiKey:output_type -> headscale.v1.CreateApiKeyResponse
-	51, // 50: headscale.v1.HeadscaleService.ExpireApiKey:output_type -> headscale.v1.ExpireApiKeyResponse
-	52, // 51: headscale.v1.HeadscaleService.ListApiKeys:output_type -> headscale.v1.ListApiKeysResponse
-	53, // 52: headscale.v1.HeadscaleService.DeleteApiKey:output_type -> headscale.v1.DeleteApiKeyResponse
-	54, // 53: headscale.v1.HeadscaleService.GetPolicy:output_type -> headscale.v1.GetPolicyResponse
-	55, // 54: headscale.v1.HeadscaleService.SetPolicy:output_type -> headscale.v1.SetPolicyResponse
-	1,  // 55: headscale.v1.HeadscaleService.Health:output_type -> headscale.v1.HealthResponse
-	28, // [28:56] is the sub-list for method output_type
-	0,  // [0:28] is the sub-list for method input_type
+	29, // 27: headscale.v1.HeadscaleService.CheckPolicy:input_type -> headscale.v1.CheckPolicyRequest
+	0,  // 28: headscale.v1.HeadscaleService.Health:input_type -> headscale.v1.HealthRequest
+	30, // 29: headscale.v1.HeadscaleService.CreateUser:output_type -> headscale.v1.CreateUserResponse
+	31, // 30: headscale.v1.HeadscaleService.RenameUser:output_type -> headscale.v1.RenameUserResponse
+	32, // 31: headscale.v1.HeadscaleService.DeleteUser:output_type -> headscale.v1.DeleteUserResponse
+	33, // 32: headscale.v1.HeadscaleService.ListUsers:output_type -> headscale.v1.ListUsersResponse
+	34, // 33: headscale.v1.HeadscaleService.CreatePreAuthKey:output_type -> headscale.v1.CreatePreAuthKeyResponse
+	35, // 34: headscale.v1.HeadscaleService.ExpirePreAuthKey:output_type -> headscale.v1.ExpirePreAuthKeyResponse
+	36, // 35: headscale.v1.HeadscaleService.DeletePreAuthKey:output_type -> headscale.v1.DeletePreAuthKeyResponse
+	37, // 36: headscale.v1.HeadscaleService.ListPreAuthKeys:output_type -> headscale.v1.ListPreAuthKeysResponse
+	38, // 37: headscale.v1.HeadscaleService.DebugCreateNode:output_type -> headscale.v1.DebugCreateNodeResponse
+	39, // 38: headscale.v1.HeadscaleService.GetNode:output_type -> headscale.v1.GetNodeResponse
+	40, // 39: headscale.v1.HeadscaleService.SetTags:output_type -> headscale.v1.SetTagsResponse
+	41, // 40: headscale.v1.HeadscaleService.SetApprovedRoutes:output_type -> headscale.v1.SetApprovedRoutesResponse
+	42, // 41: headscale.v1.HeadscaleService.RegisterNode:output_type -> headscale.v1.RegisterNodeResponse
+	43, // 42: headscale.v1.HeadscaleService.DeleteNode:output_type -> headscale.v1.DeleteNodeResponse
+	44, // 43: headscale.v1.HeadscaleService.ExpireNode:output_type -> headscale.v1.ExpireNodeResponse
+	45, // 44: headscale.v1.HeadscaleService.RenameNode:output_type -> headscale.v1.RenameNodeResponse
+	46, // 45: headscale.v1.HeadscaleService.ListNodes:output_type -> headscale.v1.ListNodesResponse
+	47, // 46: headscale.v1.HeadscaleService.BackfillNodeIPs:output_type -> headscale.v1.BackfillNodeIPsResponse
+	48, // 47: headscale.v1.HeadscaleService.AuthRegister:output_type -> headscale.v1.AuthRegisterResponse
+	49, // 48: headscale.v1.HeadscaleService.AuthApprove:output_type -> headscale.v1.AuthApproveResponse
+	50, // 49: headscale.v1.HeadscaleService.AuthReject:output_type -> headscale.v1.AuthRejectResponse
+	51, // 50: headscale.v1.HeadscaleService.CreateApiKey:output_type -> headscale.v1.CreateApiKeyResponse
+	52, // 51: headscale.v1.HeadscaleService.ExpireApiKey:output_type -> headscale.v1.ExpireApiKeyResponse
+	53, // 52: headscale.v1.HeadscaleService.ListApiKeys:output_type -> headscale.v1.ListApiKeysResponse
+	54, // 53: headscale.v1.HeadscaleService.DeleteApiKey:output_type -> headscale.v1.DeleteApiKeyResponse
+	55, // 54: headscale.v1.HeadscaleService.GetPolicy:output_type -> headscale.v1.GetPolicyResponse
+	56, // 55: headscale.v1.HeadscaleService.SetPolicy:output_type -> headscale.v1.SetPolicyResponse
+	57, // 56: headscale.v1.HeadscaleService.CheckPolicy:output_type -> headscale.v1.CheckPolicyResponse
+	1,  // 57: headscale.v1.HeadscaleService.Health:output_type -> headscale.v1.HealthResponse
+	29, // [29:58] is the sub-list for method output_type
+	0,  // [0:29] is the sub-list for method input_type
 	0,  // [0:0] is the sub-list for extension type_name
 	0,  // [0:0] is the sub-list for extension extendee
 	0,  // [0:0] is the sub-list for field type_name

--- a/gen/go/headscale/v1/headscale.pb.gw.go
+++ b/gen/go/headscale/v1/headscale.pb.gw.go
@@ -966,6 +966,33 @@ func local_request_HeadscaleService_SetPolicy_0(ctx context.Context, marshaler r
 	return msg, metadata, err
 }
 
+func request_HeadscaleService_CheckPolicy_0(ctx context.Context, marshaler runtime.Marshaler, client HeadscaleServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CheckPolicyRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	if req.Body != nil {
+		_, _ = io.Copy(io.Discard, req.Body)
+	}
+	msg, err := client.CheckPolicy(ctx, &protoReq, grpc.Header(&metadata.HeaderMD), grpc.Trailer(&metadata.TrailerMD))
+	return msg, metadata, err
+}
+
+func local_request_HeadscaleService_CheckPolicy_0(ctx context.Context, marshaler runtime.Marshaler, server HeadscaleServiceServer, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
+	var (
+		protoReq CheckPolicyRequest
+		metadata runtime.ServerMetadata
+	)
+	if err := marshaler.NewDecoder(req.Body).Decode(&protoReq); err != nil && !errors.Is(err, io.EOF) {
+		return nil, metadata, status.Errorf(codes.InvalidArgument, "%v", err)
+	}
+	msg, err := server.CheckPolicy(ctx, &protoReq)
+	return msg, metadata, err
+}
+
 func request_HeadscaleService_Health_0(ctx context.Context, marshaler runtime.Marshaler, client HeadscaleServiceClient, req *http.Request, pathParams map[string]string) (proto.Message, runtime.ServerMetadata, error) {
 	var (
 		protoReq HealthRequest
@@ -1533,6 +1560,26 @@ func RegisterHeadscaleServiceHandlerServer(ctx context.Context, mux *runtime.Ser
 		}
 		forward_HeadscaleService_SetPolicy_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_HeadscaleService_CheckPolicy_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		var stream runtime.ServerTransportStream
+		ctx = grpc.NewContextWithServerTransportStream(ctx, &stream)
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateIncomingContext(ctx, mux, req, "/headscale.v1.HeadscaleService/CheckPolicy", runtime.WithHTTPPathPattern("/api/v1/policy/check"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := local_request_HeadscaleService_CheckPolicy_0(annotatedContext, inboundMarshaler, server, req, pathParams)
+		md.HeaderMD, md.TrailerMD = metadata.Join(md.HeaderMD, stream.Header()), metadata.Join(md.TrailerMD, stream.Trailer())
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_HeadscaleService_CheckPolicy_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_HeadscaleService_Health_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2052,6 +2099,23 @@ func RegisterHeadscaleServiceHandlerClient(ctx context.Context, mux *runtime.Ser
 		}
 		forward_HeadscaleService_SetPolicy_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
 	})
+	mux.Handle(http.MethodPost, pattern_HeadscaleService_CheckPolicy_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
+		ctx, cancel := context.WithCancel(req.Context())
+		defer cancel()
+		inboundMarshaler, outboundMarshaler := runtime.MarshalerForRequest(mux, req)
+		annotatedContext, err := runtime.AnnotateContext(ctx, mux, req, "/headscale.v1.HeadscaleService/CheckPolicy", runtime.WithHTTPPathPattern("/api/v1/policy/check"))
+		if err != nil {
+			runtime.HTTPError(ctx, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		resp, md, err := request_HeadscaleService_CheckPolicy_0(annotatedContext, inboundMarshaler, client, req, pathParams)
+		annotatedContext = runtime.NewServerMetadataContext(annotatedContext, md)
+		if err != nil {
+			runtime.HTTPError(annotatedContext, mux, outboundMarshaler, w, req, err)
+			return
+		}
+		forward_HeadscaleService_CheckPolicy_0(annotatedContext, mux, outboundMarshaler, w, req, resp, mux.GetForwardResponseOptions()...)
+	})
 	mux.Handle(http.MethodGet, pattern_HeadscaleService_Health_0, func(w http.ResponseWriter, req *http.Request, pathParams map[string]string) {
 		ctx, cancel := context.WithCancel(req.Context())
 		defer cancel()
@@ -2100,6 +2164,7 @@ var (
 	pattern_HeadscaleService_DeleteApiKey_0      = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 1, 0, 4, 1, 5, 3}, []string{"api", "v1", "apikey", "prefix"}, ""))
 	pattern_HeadscaleService_GetPolicy_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "policy"}, ""))
 	pattern_HeadscaleService_SetPolicy_0         = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "policy"}, ""))
+	pattern_HeadscaleService_CheckPolicy_0       = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2, 2, 3}, []string{"api", "v1", "policy", "check"}, ""))
 	pattern_HeadscaleService_Health_0            = runtime.MustPattern(runtime.NewPattern(1, []int{2, 0, 2, 1, 2, 2}, []string{"api", "v1", "health"}, ""))
 )
 
@@ -2131,5 +2196,6 @@ var (
 	forward_HeadscaleService_DeleteApiKey_0      = runtime.ForwardResponseMessage
 	forward_HeadscaleService_GetPolicy_0         = runtime.ForwardResponseMessage
 	forward_HeadscaleService_SetPolicy_0         = runtime.ForwardResponseMessage
+	forward_HeadscaleService_CheckPolicy_0       = runtime.ForwardResponseMessage
 	forward_HeadscaleService_Health_0            = runtime.ForwardResponseMessage
 )

--- a/gen/go/headscale/v1/headscale_grpc.pb.go
+++ b/gen/go/headscale/v1/headscale_grpc.pb.go
@@ -46,6 +46,7 @@ const (
 	HeadscaleService_DeleteApiKey_FullMethodName      = "/headscale.v1.HeadscaleService/DeleteApiKey"
 	HeadscaleService_GetPolicy_FullMethodName         = "/headscale.v1.HeadscaleService/GetPolicy"
 	HeadscaleService_SetPolicy_FullMethodName         = "/headscale.v1.HeadscaleService/SetPolicy"
+	HeadscaleService_CheckPolicy_FullMethodName       = "/headscale.v1.HeadscaleService/CheckPolicy"
 	HeadscaleService_Health_FullMethodName            = "/headscale.v1.HeadscaleService/Health"
 )
 
@@ -86,6 +87,7 @@ type HeadscaleServiceClient interface {
 	// --- Policy start ---
 	GetPolicy(ctx context.Context, in *GetPolicyRequest, opts ...grpc.CallOption) (*GetPolicyResponse, error)
 	SetPolicy(ctx context.Context, in *SetPolicyRequest, opts ...grpc.CallOption) (*SetPolicyResponse, error)
+	CheckPolicy(ctx context.Context, in *CheckPolicyRequest, opts ...grpc.CallOption) (*CheckPolicyResponse, error)
 	// --- Health start ---
 	Health(ctx context.Context, in *HealthRequest, opts ...grpc.CallOption) (*HealthResponse, error)
 }
@@ -368,6 +370,16 @@ func (c *headscaleServiceClient) SetPolicy(ctx context.Context, in *SetPolicyReq
 	return out, nil
 }
 
+func (c *headscaleServiceClient) CheckPolicy(ctx context.Context, in *CheckPolicyRequest, opts ...grpc.CallOption) (*CheckPolicyResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CheckPolicyResponse)
+	err := c.cc.Invoke(ctx, HeadscaleService_CheckPolicy_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 func (c *headscaleServiceClient) Health(ctx context.Context, in *HealthRequest, opts ...grpc.CallOption) (*HealthResponse, error) {
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(HealthResponse)
@@ -415,6 +427,7 @@ type HeadscaleServiceServer interface {
 	// --- Policy start ---
 	GetPolicy(context.Context, *GetPolicyRequest) (*GetPolicyResponse, error)
 	SetPolicy(context.Context, *SetPolicyRequest) (*SetPolicyResponse, error)
+	CheckPolicy(context.Context, *CheckPolicyRequest) (*CheckPolicyResponse, error)
 	// --- Health start ---
 	Health(context.Context, *HealthRequest) (*HealthResponse, error)
 	mustEmbedUnimplementedHeadscaleServiceServer()
@@ -507,6 +520,9 @@ func (UnimplementedHeadscaleServiceServer) GetPolicy(context.Context, *GetPolicy
 }
 func (UnimplementedHeadscaleServiceServer) SetPolicy(context.Context, *SetPolicyRequest) (*SetPolicyResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method SetPolicy not implemented")
+}
+func (UnimplementedHeadscaleServiceServer) CheckPolicy(context.Context, *CheckPolicyRequest) (*CheckPolicyResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CheckPolicy not implemented")
 }
 func (UnimplementedHeadscaleServiceServer) Health(context.Context, *HealthRequest) (*HealthResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Health not implemented")
@@ -1018,6 +1034,24 @@ func _HeadscaleService_SetPolicy_Handler(srv interface{}, ctx context.Context, d
 	return interceptor(ctx, in, info, handler)
 }
 
+func _HeadscaleService_CheckPolicy_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CheckPolicyRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(HeadscaleServiceServer).CheckPolicy(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: HeadscaleService_CheckPolicy_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(HeadscaleServiceServer).CheckPolicy(ctx, req.(*CheckPolicyRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 func _HeadscaleService_Health_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
 	in := new(HealthRequest)
 	if err := dec(in); err != nil {
@@ -1150,6 +1184,10 @@ var HeadscaleService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "SetPolicy",
 			Handler:    _HeadscaleService_SetPolicy_Handler,
+		},
+		{
+			MethodName: "CheckPolicy",
+			Handler:    _HeadscaleService_CheckPolicy_Handler,
 		},
 		{
 			MethodName: "Health",

--- a/gen/go/headscale/v1/policy.pb.go
+++ b/gen/go/headscale/v1/policy.pb.go
@@ -206,6 +206,86 @@ func (x *GetPolicyResponse) GetUpdatedAt() *timestamppb.Timestamp {
 	return nil
 }
 
+type CheckPolicyRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Policy        string                 `protobuf:"bytes,1,opt,name=policy,proto3" json:"policy,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CheckPolicyRequest) Reset() {
+	*x = CheckPolicyRequest{}
+	mi := &file_headscale_v1_policy_proto_msgTypes[4]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CheckPolicyRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CheckPolicyRequest) ProtoMessage() {}
+
+func (x *CheckPolicyRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_headscale_v1_policy_proto_msgTypes[4]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CheckPolicyRequest.ProtoReflect.Descriptor instead.
+func (*CheckPolicyRequest) Descriptor() ([]byte, []int) {
+	return file_headscale_v1_policy_proto_rawDescGZIP(), []int{4}
+}
+
+func (x *CheckPolicyRequest) GetPolicy() string {
+	if x != nil {
+		return x.Policy
+	}
+	return ""
+}
+
+type CheckPolicyResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CheckPolicyResponse) Reset() {
+	*x = CheckPolicyResponse{}
+	mi := &file_headscale_v1_policy_proto_msgTypes[5]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CheckPolicyResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CheckPolicyResponse) ProtoMessage() {}
+
+func (x *CheckPolicyResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_headscale_v1_policy_proto_msgTypes[5]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CheckPolicyResponse.ProtoReflect.Descriptor instead.
+func (*CheckPolicyResponse) Descriptor() ([]byte, []int) {
+	return file_headscale_v1_policy_proto_rawDescGZIP(), []int{5}
+}
+
 var File_headscale_v1_policy_proto protoreflect.FileDescriptor
 
 const file_headscale_v1_policy_proto_rawDesc = "" +
@@ -221,7 +301,10 @@ const file_headscale_v1_policy_proto_rawDesc = "" +
 	"\x11GetPolicyResponse\x12\x16\n" +
 	"\x06policy\x18\x01 \x01(\tR\x06policy\x129\n" +
 	"\n" +
-	"updated_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAtB)Z'github.com/juanfont/headscale/gen/go/v1b\x06proto3"
+	"updated_at\x18\x02 \x01(\v2\x1a.google.protobuf.TimestampR\tupdatedAt\",\n" +
+	"\x12CheckPolicyRequest\x12\x16\n" +
+	"\x06policy\x18\x01 \x01(\tR\x06policy\"\x15\n" +
+	"\x13CheckPolicyResponseB)Z'github.com/juanfont/headscale/gen/go/v1b\x06proto3"
 
 var (
 	file_headscale_v1_policy_proto_rawDescOnce sync.Once
@@ -235,17 +318,19 @@ func file_headscale_v1_policy_proto_rawDescGZIP() []byte {
 	return file_headscale_v1_policy_proto_rawDescData
 }
 
-var file_headscale_v1_policy_proto_msgTypes = make([]protoimpl.MessageInfo, 4)
+var file_headscale_v1_policy_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
 var file_headscale_v1_policy_proto_goTypes = []any{
 	(*SetPolicyRequest)(nil),      // 0: headscale.v1.SetPolicyRequest
 	(*SetPolicyResponse)(nil),     // 1: headscale.v1.SetPolicyResponse
 	(*GetPolicyRequest)(nil),      // 2: headscale.v1.GetPolicyRequest
 	(*GetPolicyResponse)(nil),     // 3: headscale.v1.GetPolicyResponse
-	(*timestamppb.Timestamp)(nil), // 4: google.protobuf.Timestamp
+	(*CheckPolicyRequest)(nil),    // 4: headscale.v1.CheckPolicyRequest
+	(*CheckPolicyResponse)(nil),   // 5: headscale.v1.CheckPolicyResponse
+	(*timestamppb.Timestamp)(nil), // 6: google.protobuf.Timestamp
 }
 var file_headscale_v1_policy_proto_depIdxs = []int32{
-	4, // 0: headscale.v1.SetPolicyResponse.updated_at:type_name -> google.protobuf.Timestamp
-	4, // 1: headscale.v1.GetPolicyResponse.updated_at:type_name -> google.protobuf.Timestamp
+	6, // 0: headscale.v1.SetPolicyResponse.updated_at:type_name -> google.protobuf.Timestamp
+	6, // 1: headscale.v1.GetPolicyResponse.updated_at:type_name -> google.protobuf.Timestamp
 	2, // [2:2] is the sub-list for method output_type
 	2, // [2:2] is the sub-list for method input_type
 	2, // [2:2] is the sub-list for extension type_name
@@ -264,7 +349,7 @@ func file_headscale_v1_policy_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_headscale_v1_policy_proto_rawDesc), len(file_headscale_v1_policy_proto_rawDesc)),
 			NumEnums:      0,
-			NumMessages:   4,
+			NumMessages:   6,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/gen/openapiv2/headscale/v1/headscale.swagger.json
+++ b/gen/openapiv2/headscale/v1/headscale.swagger.json
@@ -660,6 +660,38 @@
         ]
       }
     },
+    "/api/v1/policy/check": {
+      "post": {
+        "operationId": "HeadscaleService_CheckPolicy",
+        "responses": {
+          "200": {
+            "description": "A successful response.",
+            "schema": {
+              "$ref": "#/definitions/v1CheckPolicyResponse"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "#/definitions/rpcStatus"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/v1CheckPolicyRequest"
+            }
+          }
+        ],
+        "tags": [
+          "HeadscaleService"
+        ]
+      }
+    },
     "/api/v1/preauthkey": {
       "get": {
         "operationId": "HeadscaleService_ListPreAuthKeys",
@@ -1043,6 +1075,17 @@
           }
         }
       }
+    },
+    "v1CheckPolicyRequest": {
+      "type": "object",
+      "properties": {
+        "policy": {
+          "type": "string"
+        }
+      }
+    },
+    "v1CheckPolicyResponse": {
+      "type": "object"
     },
     "v1CreateApiKeyRequest": {
       "type": "object",

--- a/hscontrol/grpcv1.go
+++ b/hscontrol/grpcv1.go
@@ -26,6 +26,7 @@ import (
 	"tailscale.com/types/views"
 
 	v1 "github.com/juanfont/headscale/gen/go/headscale/v1"
+	policyv2 "github.com/juanfont/headscale/hscontrol/policy/v2"
 	"github.com/juanfont/headscale/hscontrol/state"
 	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/juanfont/headscale/hscontrol/util"
@@ -779,6 +780,35 @@ func (api headscaleV1APIServer) SetPolicy(
 		Msg("gRPC SetPolicy completed successfully because response prepared")
 
 	return response, nil
+}
+
+// CheckPolicy validates the given policy against the server's live users
+// and nodes, running its `tests` block as a sandbox. Nothing is persisted
+// and the live PolicyManager is not touched. Works regardless of
+// policy.mode so operators can validate a policy file before storing it.
+func (api headscaleV1APIServer) CheckPolicy(
+	_ context.Context,
+	request *v1.CheckPolicyRequest,
+) (*v1.CheckPolicyResponse, error) {
+	polB := []byte(request.GetPolicy())
+
+	users, err := api.h.state.ListAllUsers()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "loading users: %s", err)
+	}
+
+	nodes := api.h.state.ListNodes()
+
+	pm, err := policyv2.NewPolicyManager(polB, users, nodes)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	if _, err := pm.SetPolicy(polB); err != nil {
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+
+	return &v1.CheckPolicyResponse{}, nil
 }
 
 // The following service calls are for testing and debugging

--- a/hscontrol/policy/v2/policy.go
+++ b/hscontrol/policy/v2/policy.go
@@ -187,6 +187,16 @@ func NewPolicyManager(b []byte, users []types.User, nodes views.Slice[types.Node
 		return nil, err
 	}
 
+	// Boot path: log a warning if the stored policy's tests would
+	// fail against the current users and nodes, but keep the server
+	// running. A stale stored policy (e.g. referencing a user that
+	// was deleted while the server was offline) should not block
+	// boot; the operator finds out via logs and re-runs the write
+	// boundary when they are ready.
+	if testErr := pm.RunTests(); testErr != nil { //nolint:noinlineerr // boot path: warn-and-continue, not return
+		log.Warn().Err(testErr).Msg("policy tests failed at boot; server starting anyway, fix the policy and reload")
+	}
+
 	return &pm, nil
 }
 
@@ -447,6 +457,15 @@ func (pm *PolicyManager) SetPolicy(polB []byte) (bool, error) {
 		return false, fmt.Errorf("validating policy user references: %w", err)
 	}
 
+	// SetPolicy is the user-write boundary. Tests evaluate against a
+	// sandbox compiled from the new policy + current users/nodes; if
+	// they fail, return without mutating the live PolicyManager so the
+	// failed write does not knock the running config offline.
+	err = evaluateTests(pol, pm.users, pm.nodes)
+	if err != nil {
+		return false, err
+	}
+
 	// Log policy metadata for debugging
 	log.Debug().
 		Int("policy.bytes", len(polB)).
@@ -455,6 +474,7 @@ func (pm *PolicyManager) SetPolicy(polB []byte) (bool, error) {
 		Int("hosts.count", len(pol.Hosts)).
 		Int("tagOwners.count", len(pol.TagOwners)).
 		Int("autoApprovers.routes.count", len(pol.AutoApprovers.Routes)).
+		Int("tests.count", len(pol.Tests)).
 		Msg("Policy parsed successfully")
 
 	pm.pol = pol

--- a/hscontrol/policy/v2/policytester_compat_test.go
+++ b/hscontrol/policy/v2/policytester_compat_test.go
@@ -36,9 +36,7 @@ import (
 // disagrees with Tailscale SaaS on whether the policy should be accepted.
 // Each entry is a real bug to fix in a follow-up; documenting them here
 // keeps the compat suite green and the divergence list visible.
-var knownPolicyTesterDivergences = map[string]string{ //nolint:gosec // strings here are human-readable notes, not credentials
-	"policytest-allpass-acls-and-grants-mixed": "evaluator denies tag:client → webserver:80 in mixed acls+grants policy; SaaS accepts (Updates #1803)",
-}
+var knownPolicyTesterDivergences = map[string]string{} //nolint:gosec // strings here are human-readable notes, not credentials
 
 // policyTesterCompatUsers / policyTesterCompatNodes mirror the small
 // shared topology used to record the captures. When more captures land

--- a/hscontrol/policy/v2/policytester_compat_test.go
+++ b/hscontrol/policy/v2/policytester_compat_test.go
@@ -37,9 +37,7 @@ import (
 // Each entry is a real bug to fix in a follow-up; documenting them here
 // keeps the compat suite green and the divergence list visible.
 var knownPolicyTesterDivergences = map[string]string{ //nolint:gosec // strings here are human-readable notes, not credentials
-	"policytest-allpass-acls-and-grants-mixed":      "evaluator denies tag:client → webserver:80 in mixed acls+grants policy; SaaS accepts (Updates #1803)",
-	"policytest-proto-numeric":                      "validateProtocolPortCompatibility rejects numeric proto \"6\" with specific ports; SaaS accepts (Updates #1803)",
-	"policytest-accept-fail-proto-numeric-mismatch": "validateProtocolPortCompatibility rejects numeric proto \"6\" with specific ports; SaaS accepts (Updates #1803)",
+	"policytest-allpass-acls-and-grants-mixed": "evaluator denies tag:client → webserver:80 in mixed acls+grants policy; SaaS accepts (Updates #1803)",
 }
 
 // policyTesterCompatUsers / policyTesterCompatNodes mirror the small

--- a/hscontrol/policy/v2/policytester_compat_test.go
+++ b/hscontrol/policy/v2/policytester_compat_test.go
@@ -1,0 +1,170 @@
+// Compatibility tests for the policy `tests` block, replaying captures
+// recorded against a real Tailscale SaaS tailnet. The runner mirrors the
+// pattern in tailscale_grants_compat_test.go: a single Glob over a
+// testdata directory, one t.Run per file. Each capture is one of:
+//
+//   - APIResponseCode != 200 — the policy was rejected by the SaaS, the
+//     captured Message is the byte-exact body the user saw, and headscale
+//     must reject the same input with an error string that contains the
+//     same body (substring match, allowing wrapping like "test(s)
+//     failed:\n…").
+//   - APIResponseCode == 200 — the SaaS accepted the policy (its `tests`
+//     block passed); headscale's RunTests must also pass.
+//
+// Captures live in testdata/policytest_results/*.hujson. Scenarios in
+// knownPolicyTesterDivergences are skipped with their tracking note —
+// these are real Tailscale ↔ headscale divergences uncovered by the
+// captures that need engine-level fixes in follow-up PRs.
+//
+// Source format: github.com/juanfont/headscale/hscontrol/types/testcapture
+
+package v2
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/juanfont/headscale/hscontrol/types/testcapture"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+	"tailscale.com/tailcfg"
+)
+
+// knownPolicyTesterDivergences lists scenarios where headscale's evaluator
+// disagrees with Tailscale SaaS on whether the policy should be accepted.
+// Each entry is a real bug to fix in a follow-up; documenting them here
+// keeps the compat suite green and the divergence list visible.
+var knownPolicyTesterDivergences = map[string]string{ //nolint:gosec // strings here are human-readable notes, not credentials
+	"policytest-allpass-acls-and-grants-mixed":                   "evaluator denies tag:client → webserver:80 in mixed acls+grants policy; SaaS accepts (Updates #1803)",
+	"policytest-proto-numeric":                                   "validateProtocolPortCompatibility rejects numeric proto \"6\" with specific ports; SaaS accepts (Updates #1803)",
+	"policytest-accept-fail-proto-numeric-mismatch":              "validateProtocolPortCompatibility rejects numeric proto \"6\" with specific ports; SaaS accepts (Updates #1803)",
+	"policytest-port-shape-range":                                "SaaS rejects port-range syntax in test dst; evaluator accepts (Updates #1803)",
+	"policytest-port-shape-list":                                 "SaaS rejects port-list syntax in test dst; evaluator accepts (Updates #1803)",
+	"policytest-port-shape-wildcard":                             "SaaS rejects port-wildcard in test dst when paired with non-wildcard rule; evaluator accepts (Updates #1803)",
+	"policytest-proto-icmp":                                      "SaaS rejects proto=icmp tests; evaluator accepts (Updates #1803)",
+	"policytest-deny-fail-autogroup-internet-dst":                "SaaS rejects deny-fail with autogroup:internet dst; evaluator passes (Updates #1803)",
+	"policytest-malformed-test-missing-accept-and-deny":          "SaaS rejects test entry with neither accept nor deny; evaluator passes (Updates #1803)",
+	"policytest-allpass-grants-only-tag-src-cidr-dst":            "SaaS rejects test dst that resolves to a multi-host CIDR; evaluator accepts based on filter coverage (Updates #1803)",
+	"policytest-allpass-grants-only-tag-src-prefix32-dst":        "SaaS rejects /32 CIDR dst (distinct from bare IP literal); evaluator accepts (Updates #1803)",
+	"policytest-allpass-grants-only-tag-src-host-alias-cidr-dst": "SaaS rejects hosts:-alias to CIDR as test dst; evaluator accepts (Updates #1803)",
+}
+
+// policyTesterCompatUsers / policyTesterCompatNodes mirror the small
+// shared topology used to record the captures. When more captures land
+// we'll also exercise an autogroup-heavy second topology — for now this
+// minimal one is enough to make the runner go.
+func policyTesterCompatUsers() types.Users {
+	return types.Users{
+		{Model: gorm.Model{ID: 1}, Name: "odin", Email: "odin@example.com"},
+		{Model: gorm.Model{ID: 2}, Name: "thor", Email: "thor@example.org"},
+		{Model: gorm.Model{ID: 3}, Name: "freya", Email: "freya@example.com"},
+	}
+}
+
+func policyTesterCompatNodes(users types.Users) types.Nodes {
+	return types.Nodes{
+		{
+			ID:        1,
+			GivenName: "bulbasaur",
+			User:      &users[0],
+			UserID:    &users[0].ID,
+			IPv4:      ptrAddr("100.90.199.68"),
+			IPv6:      ptrAddr("fd7a:115c:a1e0::2d01:c747"),
+			Hostinfo:  &tailcfg.Hostinfo{},
+		},
+		{
+			ID:        2,
+			GivenName: "ivysaur",
+			User:      &users[1],
+			UserID:    &users[1].ID,
+			IPv4:      ptrAddr("100.110.121.96"),
+			IPv6:      ptrAddr("fd7a:115c:a1e0::1737:7960"),
+			Hostinfo:  &tailcfg.Hostinfo{},
+		},
+		{
+			ID:        3,
+			GivenName: "venusaur",
+			User:      &users[2],
+			UserID:    &users[2].ID,
+			IPv4:      ptrAddr("100.103.90.82"),
+			IPv6:      ptrAddr("fd7a:115c:a1e0::9e37:5a52"),
+			Hostinfo:  &tailcfg.Hostinfo{},
+		},
+		{
+			ID:        4,
+			GivenName: "beedrill",
+			IPv4:      ptrAddr("100.108.74.26"),
+			IPv6:      ptrAddr("fd7a:115c:a1e0::b901:4a87"),
+			Tags:      []string{"tag:server"},
+			Hostinfo:  &tailcfg.Hostinfo{},
+		},
+		{
+			ID:        5,
+			GivenName: "kakuna",
+			IPv4:      ptrAddr("100.103.8.15"),
+			IPv6:      ptrAddr("fd7a:115c:a1e0::5b37:80f"),
+			Tags:      []string{"tag:client"},
+			Hostinfo:  &tailcfg.Hostinfo{},
+		},
+	}
+}
+
+// TestPolicyTesterCompat replays every capture under
+// testdata/policytest_results/ against the engine. With no captures the
+// test is a no-op — committed early so the layout/wiring lands before
+// the bulk import.
+func TestPolicyTesterCompat(t *testing.T) {
+	t.Parallel()
+
+	files, err := filepath.Glob(filepath.Join("testdata", "policytest_results", "*.hujson"))
+	require.NoError(t, err, "failed to glob test files")
+
+	if len(files) == 0 {
+		t.Skip("no policytest captures yet")
+	}
+
+	users := policyTesterCompatUsers()
+	nodes := policyTesterCompatNodes(users)
+
+	for _, file := range files {
+		c, err := testcapture.Read(file)
+		require.NoError(t, err, "reading %s", file)
+
+		t.Run(c.TestID, func(t *testing.T) {
+			t.Parallel()
+
+			if reason, skip := knownPolicyTesterDivergences[c.TestID]; skip {
+				t.Skip(reason)
+			}
+
+			policyJSON := []byte(c.Input.FullPolicy)
+
+			pm, err := NewPolicyManager(policyJSON, users, nodes.ViewSlice())
+			require.NoError(t, err, "policy must parse during boot path")
+
+			_, setErr := pm.SetPolicy(policyJSON)
+
+			if c.Input.APIResponseCode == 200 {
+				require.NoError(t, setErr, "tailscale accepted this policy; headscale tests should pass")
+
+				return
+			}
+
+			// Failure case: tailscale rejected the policy with a body
+			// captured in APIResponseBody.Message. Our error must
+			// contain that body as a substring.
+			require.Error(t, setErr, "tailscale rejected; headscale tests should also fail")
+
+			if c.Input.APIResponseBody == nil || c.Input.APIResponseBody.Message == "" {
+				return
+			}
+
+			want := c.Input.APIResponseBody.Message
+			if !strings.Contains(setErr.Error(), want) {
+				t.Errorf("error body mismatch\n  tailscale wants: %q\n  headscale got:   %q", want, setErr.Error())
+			}
+		})
+	}
+}

--- a/hscontrol/policy/v2/policytester_compat_test.go
+++ b/hscontrol/policy/v2/policytester_compat_test.go
@@ -37,18 +37,9 @@ import (
 // Each entry is a real bug to fix in a follow-up; documenting them here
 // keeps the compat suite green and the divergence list visible.
 var knownPolicyTesterDivergences = map[string]string{ //nolint:gosec // strings here are human-readable notes, not credentials
-	"policytest-allpass-acls-and-grants-mixed":                   "evaluator denies tag:client → webserver:80 in mixed acls+grants policy; SaaS accepts (Updates #1803)",
-	"policytest-proto-numeric":                                   "validateProtocolPortCompatibility rejects numeric proto \"6\" with specific ports; SaaS accepts (Updates #1803)",
-	"policytest-accept-fail-proto-numeric-mismatch":              "validateProtocolPortCompatibility rejects numeric proto \"6\" with specific ports; SaaS accepts (Updates #1803)",
-	"policytest-port-shape-range":                                "SaaS rejects port-range syntax in test dst; evaluator accepts (Updates #1803)",
-	"policytest-port-shape-list":                                 "SaaS rejects port-list syntax in test dst; evaluator accepts (Updates #1803)",
-	"policytest-port-shape-wildcard":                             "SaaS rejects port-wildcard in test dst when paired with non-wildcard rule; evaluator accepts (Updates #1803)",
-	"policytest-proto-icmp":                                      "SaaS rejects proto=icmp tests; evaluator accepts (Updates #1803)",
-	"policytest-deny-fail-autogroup-internet-dst":                "SaaS rejects deny-fail with autogroup:internet dst; evaluator passes (Updates #1803)",
-	"policytest-malformed-test-missing-accept-and-deny":          "SaaS rejects test entry with neither accept nor deny; evaluator passes (Updates #1803)",
-	"policytest-allpass-grants-only-tag-src-cidr-dst":            "SaaS rejects test dst that resolves to a multi-host CIDR; evaluator accepts based on filter coverage (Updates #1803)",
-	"policytest-allpass-grants-only-tag-src-prefix32-dst":        "SaaS rejects /32 CIDR dst (distinct from bare IP literal); evaluator accepts (Updates #1803)",
-	"policytest-allpass-grants-only-tag-src-host-alias-cidr-dst": "SaaS rejects hosts:-alias to CIDR as test dst; evaluator accepts (Updates #1803)",
+	"policytest-allpass-acls-and-grants-mixed":      "evaluator denies tag:client → webserver:80 in mixed acls+grants policy; SaaS accepts (Updates #1803)",
+	"policytest-proto-numeric":                      "validateProtocolPortCompatibility rejects numeric proto \"6\" with specific ports; SaaS accepts (Updates #1803)",
+	"policytest-accept-fail-proto-numeric-mismatch": "validateProtocolPortCompatibility rejects numeric proto \"6\" with specific ports; SaaS accepts (Updates #1803)",
 }
 
 // policyTesterCompatUsers / policyTesterCompatNodes mirror the small
@@ -141,29 +132,42 @@ func TestPolicyTesterCompat(t *testing.T) {
 
 			policyJSON := []byte(c.Input.FullPolicy)
 
-			pm, err := NewPolicyManager(policyJSON, users, nodes.ViewSlice())
-			require.NoError(t, err, "policy must parse during boot path")
+			pm, parseErr := NewPolicyManager(policyJSON, users, nodes.ViewSlice())
 
-			_, setErr := pm.SetPolicy(policyJSON)
-
+			// Tailscale validates and runs tests as one POST step:
+			// either failure mode produces the same 400. Headscale
+			// splits structural validation (parse) from test
+			// evaluation (SetPolicy). For the compat assertion, the
+			// two are equivalent — whichever surfaces first carries
+			// the captured body.
 			if c.Input.APIResponseCode == 200 {
+				require.NoError(t, parseErr, "tailscale accepted this policy; headscale must parse it")
+
+				_, setErr := pm.SetPolicy(policyJSON)
 				require.NoError(t, setErr, "tailscale accepted this policy; headscale tests should pass")
 
 				return
 			}
 
-			// Failure case: tailscale rejected the policy with a body
-			// captured in APIResponseBody.Message. Our error must
-			// contain that body as a substring.
-			require.Error(t, setErr, "tailscale rejected; headscale tests should also fail")
+			var got error
+
+			switch {
+			case parseErr != nil:
+				got = parseErr
+			default:
+				_, setErr := pm.SetPolicy(policyJSON)
+				got = setErr
+			}
+
+			require.Error(t, got, "tailscale rejected; headscale must reject too")
 
 			if c.Input.APIResponseBody == nil || c.Input.APIResponseBody.Message == "" {
 				return
 			}
 
 			want := c.Input.APIResponseBody.Message
-			if !strings.Contains(setErr.Error(), want) {
-				t.Errorf("error body mismatch\n  tailscale wants: %q\n  headscale got:   %q", want, setErr.Error())
+			if !strings.Contains(got.Error(), want) {
+				t.Errorf("error body mismatch\n  tailscale wants: %q\n  headscale got:   %q", want, got.Error())
 			}
 		})
 	}

--- a/hscontrol/policy/v2/test.go
+++ b/hscontrol/policy/v2/test.go
@@ -1,0 +1,420 @@
+package v2
+
+import (
+	"errors"
+	"fmt"
+	"net/netip"
+	"slices"
+	"strings"
+
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/juanfont/headscale/hscontrol/util"
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/views"
+)
+
+// Tailscale's policy file `tests` block validates a policy against operator
+// assertions: from a given src, named dst:port pairs must be accepted, and
+// (optionally) other dst:port pairs must be denied. They run at user-write
+// boundaries — `headscale policy set`, file-mode reload after a change,
+// `headscale policy check` — and reject the write if any assertion fails.
+// Boot-time reload of an already-stored policy does not run them, so a
+// stale referenced entity (e.g. a deleted user) cannot lock the server out.
+//
+// The tests evaluate against the compiled global filter rules, which fold in
+// both `acls` and `grants`, so the `tests` block validates the whole policy.
+
+// errPolicyTestsFailed wraps the rendered failure body so callers can
+// type-assert when they need to react differently to test failures vs. parse
+// errors. The Error() output is the user-facing message and is intended to
+// match Tailscale SaaS verbatim once the corpus is captured via tscap.
+var (
+	errPolicyTestsFailed   = errors.New("policy tests failed")
+	errTestDestinationNoIP = errors.New("destination resolved to no IP addresses")
+)
+
+// PolicyTest is one entry in the policy's `tests` block.
+type PolicyTest struct {
+	// Src is a single source alias (user, group, tag, host, autogroup, or IP).
+	// Tailscale only supports a single src per test entry.
+	Src string `json:"src"`
+
+	// Proto restricts the test to one protocol. Empty matches the default
+	// set the client applies when proto is omitted (TCP/UDP/ICMP).
+	Proto Protocol `json:"proto,omitempty"`
+
+	// Accept lists destinations in `host:port` form that must be reachable
+	// from Src. A test fails if any entry is denied by the compiled filter.
+	Accept []string `json:"accept,omitempty"`
+
+	// Deny lists destinations in `host:port` form that must NOT be reachable
+	// from Src. A test fails if any entry is allowed by the compiled filter.
+	Deny []string `json:"deny,omitempty"`
+}
+
+// PolicyTestResult is the outcome of a single PolicyTest.
+type PolicyTestResult struct {
+	Src    string   `json:"src"`
+	Proto  Protocol `json:"proto,omitempty"`
+	Passed bool     `json:"passed"`
+
+	// Errors are non-assertion problems: src failed to resolve, dst was
+	// malformed, etc. These cause the test to fail.
+	Errors []string `json:"errors,omitempty"`
+
+	// AcceptOK / AcceptFail / DenyOK / DenyFail partition the per-dst
+	// outcomes for diagnostics.
+	AcceptOK   []string `json:"accept_ok,omitempty"`
+	AcceptFail []string `json:"accept_fail,omitempty"`
+	DenyOK     []string `json:"deny_ok,omitempty"`
+	DenyFail   []string `json:"deny_fail,omitempty"`
+}
+
+// PolicyTestResults aggregates a run.
+type PolicyTestResults struct {
+	AllPassed bool               `json:"all_passed"`
+	Results   []PolicyTestResult `json:"results"`
+}
+
+// Errors renders the failure body. Format is intended to byte-exact match
+// Tailscale SaaS once captured via tscap; until the corpus lands, the
+// strings below are best-effort and will be updated to match.
+func (r PolicyTestResults) Errors() string {
+	if r.AllPassed {
+		return ""
+	}
+
+	var lines []string
+
+	for _, res := range r.Results {
+		if res.Passed {
+			continue
+		}
+
+		protoSuffix := ""
+		if res.Proto != "" {
+			protoSuffix = fmt.Sprintf(" (%s)", res.Proto)
+		}
+
+		for _, e := range res.Errors {
+			lines = append(lines, fmt.Sprintf("%s%s: %s", res.Src, protoSuffix, e))
+		}
+
+		for _, dst := range res.AcceptFail {
+			lines = append(lines, fmt.Sprintf("%s -> %s%s: expected ALLOWED, got DENIED", res.Src, dst, protoSuffix))
+		}
+
+		for _, dst := range res.DenyFail {
+			lines = append(lines, fmt.Sprintf("%s -> %s%s: expected DENIED, got ALLOWED", res.Src, dst, protoSuffix))
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// RunTests evaluates the policy's own `tests` block against the live compiled
+// filter and returns a wrapped error when any test fails. Callers that need
+// the per-test breakdown can call runPolicyTests directly.
+func (pm *PolicyManager) RunTests() error {
+	if pm == nil || pm.pol == nil || len(pm.pol.Tests) == 0 {
+		return nil
+	}
+
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	results := runPolicyTests(pm.pol, pm.filter, pm.users, pm.nodes)
+	if results.AllPassed {
+		return nil
+	}
+
+	return fmt.Errorf("%w:\n%s", errPolicyTestsFailed, results.Errors())
+}
+
+// evaluateTests runs the `tests` block against a fresh compilation of pol.
+// It is the user-write sandbox: the live PolicyManager state is left
+// untouched, so a failing test rejects the write without side effects.
+func evaluateTests(pol *Policy, users []types.User, nodes views.Slice[types.NodeView]) error {
+	if pol == nil || len(pol.Tests) == 0 {
+		return nil
+	}
+
+	grants := pol.compileGrants(users, nodes)
+
+	var filter []tailcfg.FilterRule
+	if pol.ACLs == nil && pol.Grants == nil {
+		filter = tailcfg.FilterAllowAll
+	} else {
+		filter = globalFilterRules(grants)
+	}
+
+	results := runPolicyTests(pol, filter, users, nodes)
+	if results.AllPassed {
+		return nil
+	}
+
+	return fmt.Errorf("%w:\n%s", errPolicyTestsFailed, results.Errors())
+}
+
+// runPolicyTests is the pure evaluation function: given a policy, the
+// compiled filter rules derived from it, and the active users/nodes, run
+// every test and return the aggregated outcome. It does not lock anything
+// or mutate any input.
+func runPolicyTests(pol *Policy, filter []tailcfg.FilterRule, users []types.User, nodes views.Slice[types.NodeView]) PolicyTestResults {
+	results := PolicyTestResults{
+		AllPassed: true,
+		Results:   make([]PolicyTestResult, 0, len(pol.Tests)),
+	}
+
+	for _, test := range pol.Tests {
+		res := runPolicyTest(test, pol, filter, users, nodes)
+		if !res.Passed {
+			results.AllPassed = false
+		}
+
+		results.Results = append(results.Results, res)
+	}
+
+	return results
+}
+
+// runPolicyTest evaluates one PolicyTest.
+func runPolicyTest(test PolicyTest, pol *Policy, filter []tailcfg.FilterRule, users []types.User, nodes views.Slice[types.NodeView]) PolicyTestResult {
+	res := PolicyTestResult{
+		Src:    test.Src,
+		Proto:  test.Proto,
+		Passed: true,
+	}
+
+	srcPrefixes, err := resolveTestSource(test.Src, pol, users, nodes)
+	if err != nil {
+		res.Passed = false
+		res.Errors = append(res.Errors, fmt.Sprintf("failed to resolve source %q: %v", test.Src, err))
+
+		return res
+	}
+
+	if len(srcPrefixes) == 0 {
+		res.Passed = false
+		res.Errors = append(res.Errors, fmt.Sprintf("source %q resolved to no IP addresses", test.Src))
+
+		return res
+	}
+
+	for _, dst := range test.Accept {
+		allowed, err := evalReachability(srcPrefixes, dst, test.Proto, pol, filter, users, nodes)
+		if err != nil {
+			res.Passed = false
+			res.Errors = append(res.Errors, fmt.Sprintf("error testing %q: %v", dst, err))
+
+			continue
+		}
+
+		if allowed {
+			res.AcceptOK = append(res.AcceptOK, dst)
+		} else {
+			res.Passed = false
+			res.AcceptFail = append(res.AcceptFail, dst)
+		}
+	}
+
+	for _, dst := range test.Deny {
+		allowed, err := evalReachability(srcPrefixes, dst, test.Proto, pol, filter, users, nodes)
+		if err != nil {
+			res.Passed = false
+			res.Errors = append(res.Errors, fmt.Sprintf("error testing %q: %v", dst, err))
+
+			continue
+		}
+
+		if !allowed {
+			res.DenyOK = append(res.DenyOK, dst)
+		} else {
+			res.Passed = false
+			res.DenyFail = append(res.DenyFail, dst)
+		}
+	}
+
+	return res
+}
+
+// resolveTestSource resolves the Src alias of a PolicyTest into a slice of
+// netip.Prefix. parseAlias + Alias.Resolve cover every alias type the rest
+// of the policy engine supports, so tests inherit alias semantics for free.
+func resolveTestSource(src string, pol *Policy, users []types.User, nodes views.Slice[types.NodeView]) ([]netip.Prefix, error) {
+	alias, err := parseAlias(src)
+	if err != nil {
+		return nil, fmt.Errorf("invalid alias: %w", err)
+	}
+
+	addrs, err := alias.Resolve(pol, users, nodes)
+	if err != nil {
+		return nil, fmt.Errorf("resolving: %w", err)
+	}
+
+	if addrs == nil || addrs.Empty() {
+		return nil, nil
+	}
+
+	return addrs.Prefixes(), nil
+}
+
+// evalReachability reports whether traffic from any srcPrefix to dst (in
+// `host:port` form) is allowed by filter for the requested protocol.
+//
+// Empty proto means the default set the client applies when proto is
+// omitted (TCP/UDP/ICMP) — we accept a rule whose IPProto list contains
+// any of those, or rules with no IPProto restriction at all.
+func evalReachability(srcPrefixes []netip.Prefix, dst string, proto Protocol, pol *Policy, filter []tailcfg.FilterRule, users []types.User, nodes views.Slice[types.NodeView]) (bool, error) {
+	awp, err := parseDestinationAlias(dst)
+	if err != nil {
+		return false, fmt.Errorf("invalid destination %q: %w", dst, err)
+	}
+
+	dstAddrs, err := awp.Resolve(pol, users, nodes)
+	if err != nil {
+		return false, fmt.Errorf("resolving destination: %w", err)
+	}
+
+	if dstAddrs == nil || dstAddrs.Empty() {
+		return false, fmt.Errorf("%w: %q", errTestDestinationNoIP, dst)
+	}
+
+	dstPrefixes := dstAddrs.Prefixes()
+
+	// Tailscale's tests semantics: ALL src prefixes must reach the dst for
+	// the test to consider it allowed. A partial allow is a fail.
+	for _, src := range srcPrefixes {
+		if !srcReachesDst(src, dstPrefixes, awp.Ports, proto, filter) {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// parseDestinationAlias is a thin wrapper over AliasWithPorts.UnmarshalJSON
+// so callers can hand it a bare `"host:port"` string without re-implementing
+// the parse logic.
+func parseDestinationAlias(dst string) (*AliasWithPorts, error) {
+	var awp AliasWithPorts
+
+	// AliasWithPorts.UnmarshalJSON expects a quoted JSON string, so wrap.
+	err := awp.UnmarshalJSON([]byte(`"` + dst + `"`))
+	if err != nil {
+		return nil, err
+	}
+
+	return &awp, nil
+}
+
+// srcReachesDst walks the compiled filter rules and reports whether
+// traffic from src to any prefix in dstPrefixes on at least one of ports
+// (or any port when ports is empty) is allowed under proto.
+func srcReachesDst(src netip.Prefix, dstPrefixes []netip.Prefix, ports []tailcfg.PortRange, proto Protocol, filter []tailcfg.FilterRule) bool {
+	requestedProtos := proto.toIANAProtocolNumbers()
+
+	for _, rule := range filter {
+		if !ruleMatchesSource(rule, src) {
+			continue
+		}
+
+		if !ruleMatchesProto(rule, requestedProtos) {
+			continue
+		}
+
+		if ruleAllowsAnyDest(rule, dstPrefixes, ports) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ruleMatchesSource reports whether the rule's source list contains src.
+// SrcIPs may be CIDR, single addresses, IP ranges (`a-b`), or `*`; we use
+// util.ParseIPSet to cover all of those uniformly. Unparseable entries
+// are skipped (the rule compiler emits well-formed strings, so this is
+// defence-in-depth, not error handling).
+func ruleMatchesSource(rule tailcfg.FilterRule, src netip.Prefix) bool {
+	for _, raw := range rule.SrcIPs {
+		set, err := util.ParseIPSet(raw, nil)
+		if err != nil {
+			continue
+		}
+
+		if set.OverlapsPrefix(src) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ruleMatchesProto reports whether the rule permits the requested
+// protocols. An unset rule.IPProto means "any protocol" and matches
+// everything; an empty requestedProtos (proto == "") means the default
+// set, which matches any rule including unset ones.
+func ruleMatchesProto(rule tailcfg.FilterRule, requestedProtos []int) bool {
+	if len(rule.IPProto) == 0 {
+		return true
+	}
+
+	if len(requestedProtos) == 0 {
+		// Default set: a rule restricted to a non-default protocol does
+		// not match the default request.
+		return false
+	}
+
+	for _, ruleProto := range rule.IPProto {
+		if slices.Contains(requestedProtos, ruleProto) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// ruleAllowsAnyDest reports whether at least one destination prefix in
+// dstPrefixes is allowed by at least one of the rule's DstPorts entries
+// for at least one of ports (or any port when ports is empty).
+func ruleAllowsAnyDest(rule tailcfg.FilterRule, dstPrefixes []netip.Prefix, ports []tailcfg.PortRange) bool {
+	for _, dp := range rule.DstPorts {
+		if !destEntryMatchesPrefixes(dp, dstPrefixes) {
+			continue
+		}
+
+		if portsAllowed(ports, dp.Ports) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// destEntryMatchesPrefixes reports whether the rule's NetPortRange.IP
+// (CIDR, single IP, IP range, or "*") covers any prefix in dstPrefixes.
+func destEntryMatchesPrefixes(dp tailcfg.NetPortRange, dstPrefixes []netip.Prefix) bool {
+	set, err := util.ParseIPSet(dp.IP, nil)
+	if err != nil {
+		return false
+	}
+
+	return slices.ContainsFunc(dstPrefixes, set.OverlapsPrefix)
+}
+
+// portsAllowed reports whether at least one requested port is contained
+// in allowed. Empty requested means "any port".
+func portsAllowed(requested []tailcfg.PortRange, allowed tailcfg.PortRange) bool {
+	if len(requested) == 0 {
+		return true
+	}
+
+	for _, r := range requested {
+		if r.First >= allowed.First && r.Last <= allowed.Last {
+			return true
+		}
+	}
+
+	return false
+}

--- a/hscontrol/policy/v2/test.go
+++ b/hscontrol/policy/v2/test.go
@@ -314,8 +314,17 @@ func parseDestinationAlias(dst string) (*AliasWithPorts, error) {
 // srcReachesDst walks the compiled filter rules and reports whether
 // traffic from src to any prefix in dstPrefixes on at least one of ports
 // (or any port when ports is empty) is allowed under proto.
+//
+// An empty test proto means the Tailscale client default set
+// {TCP, UDP, ICMP, ICMPv6} — the protocols the client tries when proto
+// is omitted. The captured Tailscale matches show these four IANA
+// numbers explicitly when no proto is set, so a rule restricted to any
+// of them satisfies an empty-proto test.
 func srcReachesDst(src netip.Prefix, dstPrefixes []netip.Prefix, ports []tailcfg.PortRange, proto Protocol, filter []tailcfg.FilterRule) bool {
 	requestedProtos := proto.toIANAProtocolNumbers()
+	if len(requestedProtos) == 0 {
+		requestedProtos = []int{ProtocolTCP, ProtocolUDP, ProtocolICMP, ProtocolIPv6ICMP}
+	}
 
 	for _, rule := range filter {
 		if !ruleMatchesSource(rule, src) {
@@ -354,19 +363,13 @@ func ruleMatchesSource(rule tailcfg.FilterRule, src netip.Prefix) bool {
 	return false
 }
 
-// ruleMatchesProto reports whether the rule permits the requested
-// protocols. An unset rule.IPProto means "any protocol" and matches
-// everything; an empty requestedProtos (proto == "") means the default
-// set, which matches any rule including unset ones.
+// ruleMatchesProto reports whether the rule permits any of requestedProtos.
+// An unset rule.IPProto means "any protocol" and matches everything.
+// requestedProtos is the per-test protocol set: a single proto for an
+// explicit test.Proto, or the default set when test.Proto is empty.
 func ruleMatchesProto(rule tailcfg.FilterRule, requestedProtos []int) bool {
 	if len(rule.IPProto) == 0 {
 		return true
-	}
-
-	if len(requestedProtos) == 0 {
-		// Default set: a rule restricted to a non-default protocol does
-		// not match the default request.
-		return false
 	}
 
 	for _, ruleProto := range rule.IPProto {

--- a/hscontrol/policy/v2/test.go
+++ b/hscontrol/policy/v2/test.go
@@ -26,10 +26,11 @@ import (
 
 // errPolicyTestsFailed wraps the rendered failure body so callers can
 // type-assert when they need to react differently to test failures vs. parse
-// errors. The Error() output is the user-facing message and is intended to
-// match Tailscale SaaS verbatim once the corpus is captured via tscap.
+// errors. The Error() prefix is "test(s) failed", the same string Tailscale
+// SaaS returns in the api_response_body.message — see
+// hscontrol/policy/v2/testdata/policytest_results/.
 var (
-	errPolicyTestsFailed   = errors.New("policy tests failed")
+	errPolicyTestsFailed   = errors.New("test(s) failed")
 	errTestDestinationNoIP = errors.New("destination resolved to no IP addresses")
 )
 
@@ -76,9 +77,11 @@ type PolicyTestResults struct {
 	Results   []PolicyTestResult `json:"results"`
 }
 
-// Errors renders the failure body. Format is intended to byte-exact match
-// Tailscale SaaS once captured via tscap; until the corpus lands, the
-// strings below are best-effort and will be updated to match.
+// Errors renders the per-test failure breakdown joined by newlines.
+// Tailscale SaaS itself only returns the literal "test(s) failed" — we
+// keep the per-test detail because it is significantly more useful in
+// CLI / config-reload paths where the user does not have a separate
+// audit endpoint to consult.
 func (r PolicyTestResults) Errors() string {
 	if r.AllPassed {
 		return ""

--- a/hscontrol/policy/v2/test_test.go
+++ b/hscontrol/policy/v2/test_test.go
@@ -338,6 +338,61 @@ func TestNewPolicyManagerSkipsTests(t *testing.T) {
 	require.ErrorIs(t, err, errPolicyTestsFailed)
 }
 
+// TestRunTestsEmptyProtoMatchesDefaultProtocols captures the bug where a
+// test entry with no `proto` field fails to match a filter rule whose
+// IPProto is restricted to a default protocol (TCP, UDP, ICMP, ICMPv6).
+// Tailscale's client default set is {6, 17, 1, 58} when proto is omitted,
+// so a TCP-only rule must satisfy an empty-proto test.
+//
+// The capture
+// testdata/policytest_results/policytest-allpass-acls-and-grants-mixed.hujson
+// is the captured signal for this same bug (api_response_code 200, two
+// passing tests including `tag:client → webserver:80` with no proto over
+// a `ip: tcp:80` grant).
+func TestRunTestsEmptyProtoMatchesDefaultProtocols(t *testing.T) {
+	users := types.Users{
+		{Model: gorm.Model{ID: 1}, Name: "odin", Email: "odin@example.com"},
+	}
+	nodes := types.Nodes{
+		{
+			ID:       1,
+			Hostname: "client",
+			IPv4:     ap("100.64.0.10"),
+			IPv6:     ap("fd7a:115c:a1e0::a"),
+			Tags:     []string{"tag:client"},
+		},
+		{
+			ID:       2,
+			Hostname: "webserver",
+			IPv4:     ap("100.64.0.16"),
+			IPv6:     ap("fd7a:115c:a1e0::10"),
+			Tags:     []string{"tag:server"},
+		},
+	}
+
+	policy := `{
+		"tagOwners": {
+			"tag:client": ["odin@example.com"],
+			"tag:server": ["odin@example.com"]
+		},
+		"hosts": {
+			"webserver": "100.64.0.16"
+		},
+		"grants": [
+			{"src": ["tag:client"], "dst": ["webserver"], "ip": ["tcp:80"]}
+		],
+		"tests": [
+			{"src": "tag:client", "accept": ["webserver:80"]}
+		]
+	}`
+
+	pm, err := NewPolicyManager([]byte(policy), users, nodes.ViewSlice())
+	require.NoError(t, err, "policy must parse and compile")
+
+	require.NoError(t, pm.RunTests(),
+		"empty-proto test must match a tcp-only grant rule (TCP is in the client default set)")
+}
+
 // TestPolicyTestResultsErrorsRendering checks the multi-line render layout
 // since the body becomes the user-facing error.
 func TestPolicyTestResultsErrorsRendering(t *testing.T) {

--- a/hscontrol/policy/v2/test_test.go
+++ b/hscontrol/policy/v2/test_test.go
@@ -138,23 +138,10 @@ func TestRunTests(t *testing.T) {
 			wantErrSub:  []string{"ghost@headscale.net", "failed to resolve source"},
 			wantNoErrIs: errPolicyTestsFailed,
 		},
-		{
-			name: "malformed-dst-missing-port",
-			policy: `{
-				"acls": [{
-					"action": "accept",
-					"src": ["*"],
-					"dst": ["*:*"]
-				}],
-				"tests": [{
-					"src": "alice@headscale.net",
-					"accept": ["alice-laptop"]
-				}]
-			}`,
-			wantPass:    false,
-			wantErrSub:  []string{"alice-laptop", "error testing"},
-			wantNoErrIs: errPolicyTestsFailed,
-		},
+		// "malformed-dst-missing-port" used to live here; structural
+		// shape errors are now caught at parse by validateTests, so
+		// RunTests no longer sees them. The parse-side behaviour is
+		// covered by TestUnmarshalPolicy/tests-* in types_test.go.
 		{
 			name: "wildcard-src-passes",
 			policy: `{

--- a/hscontrol/policy/v2/test_test.go
+++ b/hscontrol/policy/v2/test_test.go
@@ -1,0 +1,382 @@
+package v2
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// policyTestUsers/policyTestNodes are reused across the test cases below to
+// keep each table row focussed on the policy + tests under exercise.
+func policyTestUsers() types.Users {
+	return types.Users{
+		{Model: gorm.Model{ID: 1}, Name: "alice", Email: "alice@headscale.net"},
+		{Model: gorm.Model{ID: 2}, Name: "bob", Email: "bob@headscale.net"},
+	}
+}
+
+func policyTestNodes(users types.Users) types.Nodes {
+	nodes := types.Nodes{
+		// alice's user-owned laptop
+		{
+			ID:       1,
+			Hostname: "alice-laptop",
+			IPv4:     ap("100.64.0.1"),
+			IPv6:     ap("fd7a:115c:a1e0::1"),
+			User:     &users[0],
+			UserID:   &users[0].ID,
+		},
+		// bob's user-owned laptop
+		{
+			ID:       2,
+			Hostname: "bob-laptop",
+			IPv4:     ap("100.64.0.2"),
+			IPv6:     ap("fd7a:115c:a1e0::2"),
+			User:     &users[1],
+			UserID:   &users[1].ID,
+		},
+		// tagged server (created via tagged preauth key from alice)
+		{
+			ID:       3,
+			Hostname: "server",
+			IPv4:     ap("100.64.0.3"),
+			IPv6:     ap("fd7a:115c:a1e0::3"),
+			User:     &users[0],
+			UserID:   &users[0].ID,
+			Tags:     []string{"tag:server"},
+		},
+	}
+
+	return nodes
+}
+
+// TestRunTests covers the engine's per-test outcome reporting. Each row
+// constructs a PolicyManager (which also runs SetPolicy's sandbox) and
+// checks the resulting RunTests behaviour. SetPolicy gating is exercised
+// separately in TestSetPolicyRejectsFailingTests.
+func TestRunTests(t *testing.T) {
+	users := policyTestUsers()
+	nodes := policyTestNodes(users)
+
+	tests := []struct {
+		name        string
+		policy      string
+		wantPass    bool
+		wantErrSub  []string // substrings expected in the rendered error
+		wantNoErrIs error    // sentinel the error must wrap
+	}{
+		{
+			name: "all-pass-user-to-tag",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"acls": [{
+					"action": "accept",
+					"src": ["alice@headscale.net"],
+					"dst": ["tag:server:22"]
+				}],
+				"tests": [{
+					"src": "alice@headscale.net",
+					"accept": ["tag:server:22"]
+				}]
+			}`,
+			wantPass: true,
+		},
+		{
+			name: "accept-fail-blocked-by-policy",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"acls": [{
+					"action": "accept",
+					"src": ["alice@headscale.net"],
+					"dst": ["tag:server:22"]
+				}],
+				"tests": [{
+					"src": "bob@headscale.net",
+					"accept": ["tag:server:22"]
+				}]
+			}`,
+			wantPass:    false,
+			wantErrSub:  []string{"bob@headscale.net", "tag:server:22", "expected ALLOWED"},
+			wantNoErrIs: errPolicyTestsFailed,
+		},
+		{
+			name: "deny-fail-policy-allows-traffic",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"acls": [{
+					"action": "accept",
+					"src": ["alice@headscale.net"],
+					"dst": ["tag:server:22"]
+				}],
+				"tests": [{
+					"src": "alice@headscale.net",
+					"deny": ["tag:server:22"]
+				}]
+			}`,
+			wantPass:    false,
+			wantErrSub:  []string{"alice@headscale.net", "tag:server:22", "expected DENIED"},
+			wantNoErrIs: errPolicyTestsFailed,
+		},
+		{
+			name: "unknown-src-user",
+			policy: `{
+				"acls": [{
+					"action": "accept",
+					"src": ["*"],
+					"dst": ["*:*"]
+				}],
+				"tests": [{
+					"src": "ghost@headscale.net",
+					"accept": ["alice-laptop:22"]
+				}]
+			}`,
+			wantPass:    false,
+			wantErrSub:  []string{"ghost@headscale.net", "failed to resolve source"},
+			wantNoErrIs: errPolicyTestsFailed,
+		},
+		{
+			name: "malformed-dst-missing-port",
+			policy: `{
+				"acls": [{
+					"action": "accept",
+					"src": ["*"],
+					"dst": ["*:*"]
+				}],
+				"tests": [{
+					"src": "alice@headscale.net",
+					"accept": ["alice-laptop"]
+				}]
+			}`,
+			wantPass:    false,
+			wantErrSub:  []string{"alice-laptop", "error testing"},
+			wantNoErrIs: errPolicyTestsFailed,
+		},
+		{
+			name: "wildcard-src-passes",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"acls": [{
+					"action": "accept",
+					"src": ["*"],
+					"dst": ["tag:server:80"]
+				}],
+				"tests": [{
+					"src": "alice@headscale.net",
+					"accept": ["tag:server:80"]
+				}]
+			}`,
+			wantPass: true,
+		},
+		{
+			name: "proto-restrict-tcp-only",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"acls": [{
+					"action": "accept",
+					"proto": "tcp",
+					"src": ["alice@headscale.net"],
+					"dst": ["tag:server:22"]
+				}],
+				"tests": [
+					{
+						"src": "alice@headscale.net",
+						"proto": "tcp",
+						"accept": ["tag:server:22"]
+					},
+					{
+						"src": "alice@headscale.net",
+						"proto": "udp",
+						"deny": ["tag:server:22"]
+					}
+				]
+			}`,
+			wantPass: true,
+		},
+		{
+			name: "grants-only-policy-evaluated",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"grants": [{
+					"src": ["alice@headscale.net"],
+					"dst": ["tag:server"],
+					"ip":  ["22"]
+				}],
+				"tests": [{
+					"src": "alice@headscale.net",
+					"accept": ["tag:server:22"]
+				}]
+			}`,
+			wantPass: true,
+		},
+		{
+			name: "mixed-pass-and-fail-reports-failure",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"acls": [{
+					"action": "accept",
+					"src": ["alice@headscale.net"],
+					"dst": ["tag:server:22"]
+				}],
+				"tests": [
+					{
+						"src": "alice@headscale.net",
+						"accept": ["tag:server:22"]
+					},
+					{
+						"src": "bob@headscale.net",
+						"accept": ["tag:server:22"]
+					}
+				]
+			}`,
+			wantPass:    false,
+			wantErrSub:  []string{"bob@headscale.net", "expected ALLOWED"},
+			wantNoErrIs: errPolicyTestsFailed,
+		},
+		{
+			name: "no-tests-block-is-no-op",
+			policy: `{
+				"acls": [{
+					"action": "accept",
+					"src": ["*"],
+					"dst": ["*:*"]
+				}]
+			}`,
+			wantPass: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm, err := NewPolicyManager([]byte(tt.policy), users, nodes.ViewSlice())
+			require.NoError(t, err, "policy must parse and compile")
+
+			runErr := pm.RunTests()
+			if tt.wantPass {
+				require.NoError(t, runErr, "tests should pass")
+
+				return
+			}
+
+			require.Error(t, runErr, "tests should fail")
+			require.ErrorIs(t, runErr, tt.wantNoErrIs, "error should wrap errPolicyTestsFailed")
+
+			for _, sub := range tt.wantErrSub {
+				assert.Contains(t, runErr.Error(), sub, "rendered error should mention %q", sub)
+			}
+		})
+	}
+}
+
+// TestSetPolicyRejectsFailingTests asserts that SetPolicy is the user-write
+// boundary: a policy whose tests fail must be rejected without mutating the
+// live PolicyManager. NewPolicyManager (boot path) does not run tests.
+func TestSetPolicyRejectsFailingTests(t *testing.T) {
+	users := policyTestUsers()
+	nodes := policyTestNodes(users)
+
+	good := `{
+		"tagOwners": { "tag:server": ["alice@headscale.net"] },
+		"acls": [{
+			"action": "accept",
+			"src": ["alice@headscale.net"],
+			"dst": ["tag:server:22"]
+		}],
+		"tests": [{
+			"src": "alice@headscale.net",
+			"accept": ["tag:server:22"]
+		}]
+	}`
+
+	bad := `{
+		"tagOwners": { "tag:server": ["alice@headscale.net"] },
+		"acls": [{
+			"action": "accept",
+			"src": ["alice@headscale.net"],
+			"dst": ["tag:server:22"]
+		}],
+		"tests": [{
+			"src": "bob@headscale.net",
+			"accept": ["tag:server:22"]
+		}]
+	}`
+
+	pm, err := NewPolicyManager([]byte(good), users, nodes.ViewSlice())
+	require.NoError(t, err)
+
+	beforeFilter, _ := pm.Filter()
+
+	changed, err := pm.SetPolicy([]byte(bad))
+	require.Error(t, err, "SetPolicy must reject a policy whose tests fail")
+	require.False(t, changed, "SetPolicy must report no change when rejected")
+	require.ErrorIs(t, err, errPolicyTestsFailed)
+	require.Contains(t, err.Error(), "expected ALLOWED")
+
+	afterFilter, _ := pm.Filter()
+	require.Len(t, afterFilter, len(beforeFilter), "live filter must not change after a rejected SetPolicy")
+}
+
+// TestNewPolicyManagerSkipsTests asserts the boot path does not evaluate
+// tests, so a stale stored policy referencing a now-deleted user does not
+// stop the server from booting.
+func TestNewPolicyManagerSkipsTests(t *testing.T) {
+	users := policyTestUsers()
+	nodes := policyTestNodes(users)
+
+	// Tests reference "ghost@headscale.net" which doesn't exist. Boot
+	// must not error.
+	stale := `{
+		"acls": [{
+			"action": "accept",
+			"src": ["*"],
+			"dst": ["*:*"]
+		}],
+		"tests": [{
+			"src": "ghost@headscale.net",
+			"accept": ["alice-laptop:22"]
+		}]
+	}`
+
+	pm, err := NewPolicyManager([]byte(stale), users, nodes.ViewSlice())
+	require.NoError(t, err, "boot must not run tests")
+	require.NotNil(t, pm)
+
+	// And a subsequent SetPolicy of the same body must reject — that's
+	// the user-write path.
+	_, err = pm.SetPolicy([]byte(stale))
+	require.Error(t, err)
+	require.ErrorIs(t, err, errPolicyTestsFailed)
+}
+
+// TestPolicyTestResultsErrorsRendering checks the multi-line render layout
+// since the body becomes the user-facing error.
+func TestPolicyTestResultsErrorsRendering(t *testing.T) {
+	results := PolicyTestResults{
+		AllPassed: false,
+		Results: []PolicyTestResult{
+			{
+				Src:        "alice@headscale.net",
+				AcceptFail: []string{"tag:server:22"},
+			},
+			{
+				Src:      "bob@headscale.net",
+				Proto:    "tcp",
+				DenyFail: []string{"tag:server:443"},
+			},
+		},
+	}
+
+	rendered := results.Errors()
+	for _, sub := range []string{
+		"alice@headscale.net -> tag:server:22: expected ALLOWED, got DENIED",
+		"bob@headscale.net -> tag:server:443 (tcp): expected DENIED, got ALLOWED",
+	} {
+		assert.Contains(t, rendered, sub)
+	}
+
+	// Lines should be newline-separated, not space-joined.
+	assert.Equal(t, 2, strings.Count(rendered, "\n")+1, "expected one line per failing assertion")
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-accept-fail-autogroup-member-src-wildcard-dst.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-accept-fail-autogroup-member-src-wildcard-dst.hujson
@@ -1,0 +1,8837 @@
+// policytest-accept-fail-autogroup-member-src-wildcard-dst
+//
+// tests block accept-fail: autogroup:member src to wildcard dst, deny-all policy
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:36:34Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-accept-fail-autogroup-member-src-wildcard-dst",
+	"description":    "tests block accept-fail: autogroup:member src to wildcard dst, deny-all policy",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:36:34.43316915Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                           \n  \n                                                                     \n                                                                            \n{\n\t\"id\":          \"policytest-accept-fail-autogroup-member-src-wildcard-dst\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block accept-fail: autogroup:member src to wildcard dst, deny-all policy\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"autogroup:member\", \"accept\": [\"*:*\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-accept-fail-autogroup-member-src-wildcard-dst.hujson",
+		"full_policy": {"acls": [], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [{"accept": ["*:*"], "src": "autogroup:member"}]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3753901613885802,
+				"StableID":   "nj1FzXd9KW11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       3753901613885802,
+				"Key":        "nodekey:d0ec695ad8eae63714c6717aebf1b7edee749b365af74fffb479d4a7f070ea3e",
+				"DiscoKey":   "discokey:d5d852971186ca6b1c85c34c43ff849a50c7e16a2b17badaf845369248be8c24",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42808", "10.65.0.27:42808", "172.17.0.1:42808"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:36:42.242105063Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d0ec695ad8eae63714c6717aebf1b7edee749b365af74fffb479d4a7f070ea3e",
+			"MachineKey": "mkey:243eff48463649e9a4b89511625676616ad39cbc5abe244d74bb4a4ad8dcac29",
+			"Peers": [{
+				"ID":         2525705451013642,
+				"StableID":   "nmrNqxztiL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30564cedd5b8cd41e06717b554eb99333e713337015caee92e7a7dc0bb401e69",
+				"DiscoKey":   "discokey:21aac1fa1d5379fd8d8269beea7af4df82a19f4720919a2a6a46f54ffa5b9d77",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41112", "10.65.0.27:41112", "172.17.0.1:41112"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:36:40.047929656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         293439400253082,
+				"StableID":   "nV4wx1AuH311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35bfef9d106bfeb51b6cf9521a6d051a24edc48d34e62c87518b89b7bd87316e",
+				"DiscoKey":   "discokey:468510f3633138afe3add46f8cad35b4feac80497c5fb109ee1c1c2f90e3fc50",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:45880", "10.65.0.27:45880", "172.17.0.1:45880"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:36:40.564794361Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6579416599059571,
+				"StableID":   "n2Nuho7qNt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:716fdfaecb97cf60fd6d7be044f4a5ec6fda346fd35ad917808657732efdb049",
+				"DiscoKey":   "discokey:05f9e4402e2400367e4a5646bd6ae092d4185e00633a474b8676291987630972",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:46304", "10.65.0.27:46304", "172.17.0.1:46304"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:36:41.155363446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3816178153122669,
+				"StableID":   "n86CWgXMoW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2d9d5b66137fc4ce4c55ef957b91a4f63fff9ada05da923513d313e1417b420",
+				"DiscoKey":   "discokey:d6fc40056cf1162f4feb8d05d9464ca3830edbeec59ae2c41e18405055cf0921",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:39515", "10.65.0.27:39515", "172.17.0.1:39515"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:36:41.648109821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6847430561048820,
+				"StableID":   "n1ZpkbPDUv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:12c5cd3fce1db5beda9ef9c0fa092c47df4791ce11f6db8783641a61b5622100",
+				"KeyExpiry":  "2026-10-26T10:36:42Z",
+				"DiscoKey":   "discokey:f75bdc6c5d847f0be16e5274ccd8fab6b740066c30c0b09f9c7586f648935115",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:35788", "10.65.0.27:35788", "172.17.0.1:35788"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:36:42.804731621Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2697471125307530,
+				"StableID":   "nqCgHZzg4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2437a0c14b2eb017817ff67890afff0d00dae9369709865781def6b089d67922",
+				"KeyExpiry":  "2026-10-26T10:36:43Z",
+				"DiscoKey":   "discokey:be24451d715e3c37cfb1a6742db013b61675d273b4dd61fef9e4e9ff5291fb3c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:47988", "10.65.0.27:47988", "172.17.0.1:47988"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:36:43.289850931Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2968883161406861,
+				"StableID":   "nQCdWXXcBQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:14c8cce036eea38c0da7cfe48ae571f26df544f0f776cd9a8b724c378b0cab26",
+				"KeyExpiry":  "2026-10-26T10:36:43Z",
+				"DiscoKey":   "discokey:30de3fd3818b6e7af6ae42a63ba88a63ac554839c0515f5d7592e81a338a5c66",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55085", "10.65.0.27:55085", "172.17.0.1:55085"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:36:43.82871054Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3753901613885802": {
+				"ID":          3753901613885802,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2968883161406861,
+				"StableID":   "nQCdWXXcBQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:14c8cce036eea38c0da7cfe48ae571f26df544f0f776cd9a8b724c378b0cab26",
+				"KeyExpiry":  "2026-10-26T10:36:43Z",
+				"DiscoKey":   "discokey:30de3fd3818b6e7af6ae42a63ba88a63ac554839c0515f5d7592e81a338a5c66",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55085", "10.65.0.27:55085", "172.17.0.1:55085"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:36:43.82871054Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:14c8cce036eea38c0da7cfe48ae571f26df544f0f776cd9a8b724c378b0cab26",
+			"MachineKey": "mkey:5a3a2c7a7d670aad9e8d7c1e2899fbfd2193df15050af16e9e702df046f14972",
+			"Peers": [{
+				"ID":         2525705451013642,
+				"StableID":   "nmrNqxztiL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30564cedd5b8cd41e06717b554eb99333e713337015caee92e7a7dc0bb401e69",
+				"DiscoKey":   "discokey:21aac1fa1d5379fd8d8269beea7af4df82a19f4720919a2a6a46f54ffa5b9d77",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41112", "10.65.0.27:41112", "172.17.0.1:41112"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:36:40.047929656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         293439400253082,
+				"StableID":   "nV4wx1AuH311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35bfef9d106bfeb51b6cf9521a6d051a24edc48d34e62c87518b89b7bd87316e",
+				"DiscoKey":   "discokey:468510f3633138afe3add46f8cad35b4feac80497c5fb109ee1c1c2f90e3fc50",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:45880", "10.65.0.27:45880", "172.17.0.1:45880"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:36:40.564794361Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6579416599059571,
+				"StableID":   "n2Nuho7qNt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:716fdfaecb97cf60fd6d7be044f4a5ec6fda346fd35ad917808657732efdb049",
+				"DiscoKey":   "discokey:05f9e4402e2400367e4a5646bd6ae092d4185e00633a474b8676291987630972",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:46304", "10.65.0.27:46304", "172.17.0.1:46304"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:36:41.155363446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3816178153122669,
+				"StableID":   "n86CWgXMoW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2d9d5b66137fc4ce4c55ef957b91a4f63fff9ada05da923513d313e1417b420",
+				"DiscoKey":   "discokey:d6fc40056cf1162f4feb8d05d9464ca3830edbeec59ae2c41e18405055cf0921",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:39515", "10.65.0.27:39515", "172.17.0.1:39515"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:36:41.648109821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3753901613885802,
+				"StableID":   "nj1FzXd9KW11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0ec695ad8eae63714c6717aebf1b7edee749b365af74fffb479d4a7f070ea3e",
+				"DiscoKey":   "discokey:d5d852971186ca6b1c85c34c43ff849a50c7e16a2b17badaf845369248be8c24",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42808", "10.65.0.27:42808", "172.17.0.1:42808"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:36:42.242105063Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6847430561048820,
+				"StableID":   "n1ZpkbPDUv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:12c5cd3fce1db5beda9ef9c0fa092c47df4791ce11f6db8783641a61b5622100",
+				"KeyExpiry":  "2026-10-26T10:36:42Z",
+				"DiscoKey":   "discokey:f75bdc6c5d847f0be16e5274ccd8fab6b740066c30c0b09f9c7586f648935115",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:35788", "10.65.0.27:35788", "172.17.0.1:35788"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:36:42.804731621Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2697471125307530,
+				"StableID":   "nqCgHZzg4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2437a0c14b2eb017817ff67890afff0d00dae9369709865781def6b089d67922",
+				"KeyExpiry":  "2026-10-26T10:36:43Z",
+				"DiscoKey":   "discokey:be24451d715e3c37cfb1a6742db013b61675d273b4dd61fef9e4e9ff5291fb3c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:47988", "10.65.0.27:47988", "172.17.0.1:47988"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:36:43.289850931Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2525705451013642,
+				"StableID":   "nmrNqxztiL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       2525705451013642,
+				"Key":        "nodekey:30564cedd5b8cd41e06717b554eb99333e713337015caee92e7a7dc0bb401e69",
+				"DiscoKey":   "discokey:21aac1fa1d5379fd8d8269beea7af4df82a19f4720919a2a6a46f54ffa5b9d77",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41112", "10.65.0.27:41112", "172.17.0.1:41112"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:36:40.047929656Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:30564cedd5b8cd41e06717b554eb99333e713337015caee92e7a7dc0bb401e69",
+			"MachineKey": "mkey:406fbd33c289ee4859b4e5e8be1ef0897d6aa26f1fac671e0d51d4036308fc3b",
+			"Peers": [{
+				"ID":         293439400253082,
+				"StableID":   "nV4wx1AuH311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35bfef9d106bfeb51b6cf9521a6d051a24edc48d34e62c87518b89b7bd87316e",
+				"DiscoKey":   "discokey:468510f3633138afe3add46f8cad35b4feac80497c5fb109ee1c1c2f90e3fc50",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:45880", "10.65.0.27:45880", "172.17.0.1:45880"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:36:40.564794361Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6579416599059571,
+				"StableID":   "n2Nuho7qNt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:716fdfaecb97cf60fd6d7be044f4a5ec6fda346fd35ad917808657732efdb049",
+				"DiscoKey":   "discokey:05f9e4402e2400367e4a5646bd6ae092d4185e00633a474b8676291987630972",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:46304", "10.65.0.27:46304", "172.17.0.1:46304"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:36:41.155363446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3816178153122669,
+				"StableID":   "n86CWgXMoW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2d9d5b66137fc4ce4c55ef957b91a4f63fff9ada05da923513d313e1417b420",
+				"DiscoKey":   "discokey:d6fc40056cf1162f4feb8d05d9464ca3830edbeec59ae2c41e18405055cf0921",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:39515", "10.65.0.27:39515", "172.17.0.1:39515"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:36:41.648109821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3753901613885802,
+				"StableID":   "nj1FzXd9KW11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0ec695ad8eae63714c6717aebf1b7edee749b365af74fffb479d4a7f070ea3e",
+				"DiscoKey":   "discokey:d5d852971186ca6b1c85c34c43ff849a50c7e16a2b17badaf845369248be8c24",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42808", "10.65.0.27:42808", "172.17.0.1:42808"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:36:42.242105063Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6847430561048820,
+				"StableID":   "n1ZpkbPDUv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:12c5cd3fce1db5beda9ef9c0fa092c47df4791ce11f6db8783641a61b5622100",
+				"KeyExpiry":  "2026-10-26T10:36:42Z",
+				"DiscoKey":   "discokey:f75bdc6c5d847f0be16e5274ccd8fab6b740066c30c0b09f9c7586f648935115",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:35788", "10.65.0.27:35788", "172.17.0.1:35788"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:36:42.804731621Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2697471125307530,
+				"StableID":   "nqCgHZzg4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2437a0c14b2eb017817ff67890afff0d00dae9369709865781def6b089d67922",
+				"KeyExpiry":  "2026-10-26T10:36:43Z",
+				"DiscoKey":   "discokey:be24451d715e3c37cfb1a6742db013b61675d273b4dd61fef9e4e9ff5291fb3c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:47988", "10.65.0.27:47988", "172.17.0.1:47988"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:36:43.289850931Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2968883161406861,
+				"StableID":   "nQCdWXXcBQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:14c8cce036eea38c0da7cfe48ae571f26df544f0f776cd9a8b724c378b0cab26",
+				"KeyExpiry":  "2026-10-26T10:36:43Z",
+				"DiscoKey":   "discokey:30de3fd3818b6e7af6ae42a63ba88a63ac554839c0515f5d7592e81a338a5c66",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55085", "10.65.0.27:55085", "172.17.0.1:55085"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:36:43.82871054Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2525705451013642": {
+				"ID":          2525705451013642,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6847430561048820,
+				"StableID":   "n1ZpkbPDUv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:12c5cd3fce1db5beda9ef9c0fa092c47df4791ce11f6db8783641a61b5622100",
+				"KeyExpiry":  "2026-10-26T10:36:42Z",
+				"DiscoKey":   "discokey:f75bdc6c5d847f0be16e5274ccd8fab6b740066c30c0b09f9c7586f648935115",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:35788", "10.65.0.27:35788", "172.17.0.1:35788"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:36:42.804731621Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:12c5cd3fce1db5beda9ef9c0fa092c47df4791ce11f6db8783641a61b5622100",
+			"MachineKey": "mkey:899eadeaf27bcef23cf16365a7ec39f052499570ad0be70ecc6868e01183bc38",
+			"Peers": [{
+				"ID":         2525705451013642,
+				"StableID":   "nmrNqxztiL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30564cedd5b8cd41e06717b554eb99333e713337015caee92e7a7dc0bb401e69",
+				"DiscoKey":   "discokey:21aac1fa1d5379fd8d8269beea7af4df82a19f4720919a2a6a46f54ffa5b9d77",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41112", "10.65.0.27:41112", "172.17.0.1:41112"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:36:40.047929656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         293439400253082,
+				"StableID":   "nV4wx1AuH311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35bfef9d106bfeb51b6cf9521a6d051a24edc48d34e62c87518b89b7bd87316e",
+				"DiscoKey":   "discokey:468510f3633138afe3add46f8cad35b4feac80497c5fb109ee1c1c2f90e3fc50",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:45880", "10.65.0.27:45880", "172.17.0.1:45880"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:36:40.564794361Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6579416599059571,
+				"StableID":   "n2Nuho7qNt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:716fdfaecb97cf60fd6d7be044f4a5ec6fda346fd35ad917808657732efdb049",
+				"DiscoKey":   "discokey:05f9e4402e2400367e4a5646bd6ae092d4185e00633a474b8676291987630972",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:46304", "10.65.0.27:46304", "172.17.0.1:46304"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:36:41.155363446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3816178153122669,
+				"StableID":   "n86CWgXMoW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2d9d5b66137fc4ce4c55ef957b91a4f63fff9ada05da923513d313e1417b420",
+				"DiscoKey":   "discokey:d6fc40056cf1162f4feb8d05d9464ca3830edbeec59ae2c41e18405055cf0921",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:39515", "10.65.0.27:39515", "172.17.0.1:39515"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:36:41.648109821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3753901613885802,
+				"StableID":   "nj1FzXd9KW11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0ec695ad8eae63714c6717aebf1b7edee749b365af74fffb479d4a7f070ea3e",
+				"DiscoKey":   "discokey:d5d852971186ca6b1c85c34c43ff849a50c7e16a2b17badaf845369248be8c24",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42808", "10.65.0.27:42808", "172.17.0.1:42808"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:36:42.242105063Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2697471125307530,
+				"StableID":   "nqCgHZzg4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2437a0c14b2eb017817ff67890afff0d00dae9369709865781def6b089d67922",
+				"KeyExpiry":  "2026-10-26T10:36:43Z",
+				"DiscoKey":   "discokey:be24451d715e3c37cfb1a6742db013b61675d273b4dd61fef9e4e9ff5291fb3c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:47988", "10.65.0.27:47988", "172.17.0.1:47988"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:36:43.289850931Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2968883161406861,
+				"StableID":   "nQCdWXXcBQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:14c8cce036eea38c0da7cfe48ae571f26df544f0f776cd9a8b724c378b0cab26",
+				"KeyExpiry":  "2026-10-26T10:36:43Z",
+				"DiscoKey":   "discokey:30de3fd3818b6e7af6ae42a63ba88a63ac554839c0515f5d7592e81a338a5c66",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55085", "10.65.0.27:55085", "172.17.0.1:55085"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:36:43.82871054Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3816178153122669,
+				"StableID":   "n86CWgXMoW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       3816178153122669,
+				"Key":        "nodekey:f2d9d5b66137fc4ce4c55ef957b91a4f63fff9ada05da923513d313e1417b420",
+				"DiscoKey":   "discokey:d6fc40056cf1162f4feb8d05d9464ca3830edbeec59ae2c41e18405055cf0921",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:39515", "10.65.0.27:39515", "172.17.0.1:39515"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:36:41.648109821Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f2d9d5b66137fc4ce4c55ef957b91a4f63fff9ada05da923513d313e1417b420",
+			"MachineKey": "mkey:750d3068c28e62f6afef72fd80e4c9fd9d5e8c5763d22075c63aae27a2018247",
+			"Peers": [{
+				"ID":         2525705451013642,
+				"StableID":   "nmrNqxztiL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30564cedd5b8cd41e06717b554eb99333e713337015caee92e7a7dc0bb401e69",
+				"DiscoKey":   "discokey:21aac1fa1d5379fd8d8269beea7af4df82a19f4720919a2a6a46f54ffa5b9d77",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41112", "10.65.0.27:41112", "172.17.0.1:41112"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:36:40.047929656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         293439400253082,
+				"StableID":   "nV4wx1AuH311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35bfef9d106bfeb51b6cf9521a6d051a24edc48d34e62c87518b89b7bd87316e",
+				"DiscoKey":   "discokey:468510f3633138afe3add46f8cad35b4feac80497c5fb109ee1c1c2f90e3fc50",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:45880", "10.65.0.27:45880", "172.17.0.1:45880"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:36:40.564794361Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6579416599059571,
+				"StableID":   "n2Nuho7qNt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:716fdfaecb97cf60fd6d7be044f4a5ec6fda346fd35ad917808657732efdb049",
+				"DiscoKey":   "discokey:05f9e4402e2400367e4a5646bd6ae092d4185e00633a474b8676291987630972",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:46304", "10.65.0.27:46304", "172.17.0.1:46304"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:36:41.155363446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3753901613885802,
+				"StableID":   "nj1FzXd9KW11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0ec695ad8eae63714c6717aebf1b7edee749b365af74fffb479d4a7f070ea3e",
+				"DiscoKey":   "discokey:d5d852971186ca6b1c85c34c43ff849a50c7e16a2b17badaf845369248be8c24",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42808", "10.65.0.27:42808", "172.17.0.1:42808"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:36:42.242105063Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6847430561048820,
+				"StableID":   "n1ZpkbPDUv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:12c5cd3fce1db5beda9ef9c0fa092c47df4791ce11f6db8783641a61b5622100",
+				"KeyExpiry":  "2026-10-26T10:36:42Z",
+				"DiscoKey":   "discokey:f75bdc6c5d847f0be16e5274ccd8fab6b740066c30c0b09f9c7586f648935115",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:35788", "10.65.0.27:35788", "172.17.0.1:35788"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:36:42.804731621Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2697471125307530,
+				"StableID":   "nqCgHZzg4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2437a0c14b2eb017817ff67890afff0d00dae9369709865781def6b089d67922",
+				"KeyExpiry":  "2026-10-26T10:36:43Z",
+				"DiscoKey":   "discokey:be24451d715e3c37cfb1a6742db013b61675d273b4dd61fef9e4e9ff5291fb3c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:47988", "10.65.0.27:47988", "172.17.0.1:47988"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:36:43.289850931Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2968883161406861,
+				"StableID":   "nQCdWXXcBQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:14c8cce036eea38c0da7cfe48ae571f26df544f0f776cd9a8b724c378b0cab26",
+				"KeyExpiry":  "2026-10-26T10:36:43Z",
+				"DiscoKey":   "discokey:30de3fd3818b6e7af6ae42a63ba88a63ac554839c0515f5d7592e81a338a5c66",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55085", "10.65.0.27:55085", "172.17.0.1:55085"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:36:43.82871054Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3816178153122669": {
+				"ID":          3816178153122669,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         293439400253082,
+				"StableID":   "nV4wx1AuH311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       293439400253082,
+				"Key":        "nodekey:35bfef9d106bfeb51b6cf9521a6d051a24edc48d34e62c87518b89b7bd87316e",
+				"DiscoKey":   "discokey:468510f3633138afe3add46f8cad35b4feac80497c5fb109ee1c1c2f90e3fc50",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:45880", "10.65.0.27:45880", "172.17.0.1:45880"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:36:40.564794361Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:35bfef9d106bfeb51b6cf9521a6d051a24edc48d34e62c87518b89b7bd87316e",
+			"MachineKey": "mkey:1dfddd443fd1a5bc47be846a6fc089ca58800206de2de588a54b55b672091e11",
+			"Peers": [{
+				"ID":         2525705451013642,
+				"StableID":   "nmrNqxztiL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30564cedd5b8cd41e06717b554eb99333e713337015caee92e7a7dc0bb401e69",
+				"DiscoKey":   "discokey:21aac1fa1d5379fd8d8269beea7af4df82a19f4720919a2a6a46f54ffa5b9d77",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41112", "10.65.0.27:41112", "172.17.0.1:41112"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:36:40.047929656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6579416599059571,
+				"StableID":   "n2Nuho7qNt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:716fdfaecb97cf60fd6d7be044f4a5ec6fda346fd35ad917808657732efdb049",
+				"DiscoKey":   "discokey:05f9e4402e2400367e4a5646bd6ae092d4185e00633a474b8676291987630972",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:46304", "10.65.0.27:46304", "172.17.0.1:46304"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:36:41.155363446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3816178153122669,
+				"StableID":   "n86CWgXMoW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2d9d5b66137fc4ce4c55ef957b91a4f63fff9ada05da923513d313e1417b420",
+				"DiscoKey":   "discokey:d6fc40056cf1162f4feb8d05d9464ca3830edbeec59ae2c41e18405055cf0921",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:39515", "10.65.0.27:39515", "172.17.0.1:39515"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:36:41.648109821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3753901613885802,
+				"StableID":   "nj1FzXd9KW11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0ec695ad8eae63714c6717aebf1b7edee749b365af74fffb479d4a7f070ea3e",
+				"DiscoKey":   "discokey:d5d852971186ca6b1c85c34c43ff849a50c7e16a2b17badaf845369248be8c24",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42808", "10.65.0.27:42808", "172.17.0.1:42808"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:36:42.242105063Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6847430561048820,
+				"StableID":   "n1ZpkbPDUv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:12c5cd3fce1db5beda9ef9c0fa092c47df4791ce11f6db8783641a61b5622100",
+				"KeyExpiry":  "2026-10-26T10:36:42Z",
+				"DiscoKey":   "discokey:f75bdc6c5d847f0be16e5274ccd8fab6b740066c30c0b09f9c7586f648935115",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:35788", "10.65.0.27:35788", "172.17.0.1:35788"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:36:42.804731621Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2697471125307530,
+				"StableID":   "nqCgHZzg4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2437a0c14b2eb017817ff67890afff0d00dae9369709865781def6b089d67922",
+				"KeyExpiry":  "2026-10-26T10:36:43Z",
+				"DiscoKey":   "discokey:be24451d715e3c37cfb1a6742db013b61675d273b4dd61fef9e4e9ff5291fb3c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:47988", "10.65.0.27:47988", "172.17.0.1:47988"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:36:43.289850931Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2968883161406861,
+				"StableID":   "nQCdWXXcBQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:14c8cce036eea38c0da7cfe48ae571f26df544f0f776cd9a8b724c378b0cab26",
+				"KeyExpiry":  "2026-10-26T10:36:43Z",
+				"DiscoKey":   "discokey:30de3fd3818b6e7af6ae42a63ba88a63ac554839c0515f5d7592e81a338a5c66",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55085", "10.65.0.27:55085", "172.17.0.1:55085"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:36:43.82871054Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "293439400253082": {
+				"ID":          293439400253082,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2697471125307530,
+				"StableID":   "nqCgHZzg4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2437a0c14b2eb017817ff67890afff0d00dae9369709865781def6b089d67922",
+				"KeyExpiry":  "2026-10-26T10:36:43Z",
+				"DiscoKey":   "discokey:be24451d715e3c37cfb1a6742db013b61675d273b4dd61fef9e4e9ff5291fb3c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:47988", "10.65.0.27:47988", "172.17.0.1:47988"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:36:43.289850931Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2437a0c14b2eb017817ff67890afff0d00dae9369709865781def6b089d67922",
+			"MachineKey": "mkey:c0ca5e4324ad849bed36d4eeb2158fc1f344aed1cf360b3adcdf9f767002f30d",
+			"Peers": [{
+				"ID":         2525705451013642,
+				"StableID":   "nmrNqxztiL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30564cedd5b8cd41e06717b554eb99333e713337015caee92e7a7dc0bb401e69",
+				"DiscoKey":   "discokey:21aac1fa1d5379fd8d8269beea7af4df82a19f4720919a2a6a46f54ffa5b9d77",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41112", "10.65.0.27:41112", "172.17.0.1:41112"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:36:40.047929656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         293439400253082,
+				"StableID":   "nV4wx1AuH311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35bfef9d106bfeb51b6cf9521a6d051a24edc48d34e62c87518b89b7bd87316e",
+				"DiscoKey":   "discokey:468510f3633138afe3add46f8cad35b4feac80497c5fb109ee1c1c2f90e3fc50",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:45880", "10.65.0.27:45880", "172.17.0.1:45880"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:36:40.564794361Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6579416599059571,
+				"StableID":   "n2Nuho7qNt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:716fdfaecb97cf60fd6d7be044f4a5ec6fda346fd35ad917808657732efdb049",
+				"DiscoKey":   "discokey:05f9e4402e2400367e4a5646bd6ae092d4185e00633a474b8676291987630972",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:46304", "10.65.0.27:46304", "172.17.0.1:46304"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:36:41.155363446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3816178153122669,
+				"StableID":   "n86CWgXMoW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2d9d5b66137fc4ce4c55ef957b91a4f63fff9ada05da923513d313e1417b420",
+				"DiscoKey":   "discokey:d6fc40056cf1162f4feb8d05d9464ca3830edbeec59ae2c41e18405055cf0921",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:39515", "10.65.0.27:39515", "172.17.0.1:39515"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:36:41.648109821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3753901613885802,
+				"StableID":   "nj1FzXd9KW11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0ec695ad8eae63714c6717aebf1b7edee749b365af74fffb479d4a7f070ea3e",
+				"DiscoKey":   "discokey:d5d852971186ca6b1c85c34c43ff849a50c7e16a2b17badaf845369248be8c24",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42808", "10.65.0.27:42808", "172.17.0.1:42808"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:36:42.242105063Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6847430561048820,
+				"StableID":   "n1ZpkbPDUv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:12c5cd3fce1db5beda9ef9c0fa092c47df4791ce11f6db8783641a61b5622100",
+				"KeyExpiry":  "2026-10-26T10:36:42Z",
+				"DiscoKey":   "discokey:f75bdc6c5d847f0be16e5274ccd8fab6b740066c30c0b09f9c7586f648935115",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:35788", "10.65.0.27:35788", "172.17.0.1:35788"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:36:42.804731621Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2968883161406861,
+				"StableID":   "nQCdWXXcBQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:14c8cce036eea38c0da7cfe48ae571f26df544f0f776cd9a8b724c378b0cab26",
+				"KeyExpiry":  "2026-10-26T10:36:43Z",
+				"DiscoKey":   "discokey:30de3fd3818b6e7af6ae42a63ba88a63ac554839c0515f5d7592e81a338a5c66",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55085", "10.65.0.27:55085", "172.17.0.1:55085"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:36:43.82871054Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6579416599059571,
+				"StableID":   "n2Nuho7qNt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       6579416599059571,
+				"Key":        "nodekey:716fdfaecb97cf60fd6d7be044f4a5ec6fda346fd35ad917808657732efdb049",
+				"DiscoKey":   "discokey:05f9e4402e2400367e4a5646bd6ae092d4185e00633a474b8676291987630972",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:46304", "10.65.0.27:46304", "172.17.0.1:46304"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:36:41.155363446Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:716fdfaecb97cf60fd6d7be044f4a5ec6fda346fd35ad917808657732efdb049",
+			"MachineKey": "mkey:dbd9443210424151445bf080f21861492c7b36581b5d834da3608bce92e3e826",
+			"Peers": [{
+				"ID":         2525705451013642,
+				"StableID":   "nmrNqxztiL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30564cedd5b8cd41e06717b554eb99333e713337015caee92e7a7dc0bb401e69",
+				"DiscoKey":   "discokey:21aac1fa1d5379fd8d8269beea7af4df82a19f4720919a2a6a46f54ffa5b9d77",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41112", "10.65.0.27:41112", "172.17.0.1:41112"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:36:40.047929656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         293439400253082,
+				"StableID":   "nV4wx1AuH311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35bfef9d106bfeb51b6cf9521a6d051a24edc48d34e62c87518b89b7bd87316e",
+				"DiscoKey":   "discokey:468510f3633138afe3add46f8cad35b4feac80497c5fb109ee1c1c2f90e3fc50",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:45880", "10.65.0.27:45880", "172.17.0.1:45880"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:36:40.564794361Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3816178153122669,
+				"StableID":   "n86CWgXMoW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2d9d5b66137fc4ce4c55ef957b91a4f63fff9ada05da923513d313e1417b420",
+				"DiscoKey":   "discokey:d6fc40056cf1162f4feb8d05d9464ca3830edbeec59ae2c41e18405055cf0921",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:39515", "10.65.0.27:39515", "172.17.0.1:39515"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:36:41.648109821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3753901613885802,
+				"StableID":   "nj1FzXd9KW11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0ec695ad8eae63714c6717aebf1b7edee749b365af74fffb479d4a7f070ea3e",
+				"DiscoKey":   "discokey:d5d852971186ca6b1c85c34c43ff849a50c7e16a2b17badaf845369248be8c24",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42808", "10.65.0.27:42808", "172.17.0.1:42808"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:36:42.242105063Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6847430561048820,
+				"StableID":   "n1ZpkbPDUv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:12c5cd3fce1db5beda9ef9c0fa092c47df4791ce11f6db8783641a61b5622100",
+				"KeyExpiry":  "2026-10-26T10:36:42Z",
+				"DiscoKey":   "discokey:f75bdc6c5d847f0be16e5274ccd8fab6b740066c30c0b09f9c7586f648935115",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:35788", "10.65.0.27:35788", "172.17.0.1:35788"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:36:42.804731621Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2697471125307530,
+				"StableID":   "nqCgHZzg4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2437a0c14b2eb017817ff67890afff0d00dae9369709865781def6b089d67922",
+				"KeyExpiry":  "2026-10-26T10:36:43Z",
+				"DiscoKey":   "discokey:be24451d715e3c37cfb1a6742db013b61675d273b4dd61fef9e4e9ff5291fb3c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:47988", "10.65.0.27:47988", "172.17.0.1:47988"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:36:43.289850931Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2968883161406861,
+				"StableID":   "nQCdWXXcBQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:14c8cce036eea38c0da7cfe48ae571f26df544f0f776cd9a8b724c378b0cab26",
+				"KeyExpiry":  "2026-10-26T10:36:43Z",
+				"DiscoKey":   "discokey:30de3fd3818b6e7af6ae42a63ba88a63ac554839c0515f5d7592e81a338a5c66",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55085", "10.65.0.27:55085", "172.17.0.1:55085"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:36:43.82871054Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6579416599059571": {
+				"ID":          6579416599059571,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-accept-fail-autogroup-tagged-src-tag-dst.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-accept-fail-autogroup-tagged-src-tag-dst.hujson
@@ -1,0 +1,18748 @@
+// policytest-accept-fail-autogroup-tagged-src-tag-dst
+//
+// tests block accept-fail: autogroup:tagged src, no matching rule
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-04-29T10:37:05Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-accept-fail-autogroup-tagged-src-tag-dst",
+	"description":    "tests block accept-fail: autogroup:tagged src, no matching rule",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:37:05.586211876Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                      \n  \n                                                                      \n                                                                      \n                \n{\n\t\"id\":          \"policytest-accept-fail-autogroup-tagged-src-tag-dst\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block accept-fail: autogroup:tagged src, no matching rule\",\n\n\t\"topology\": \"../_topologies/grant.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"tag:group-a\"], \"dst\": [\"tag:group-b:80\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"autogroup:tagged\", \"accept\": [\"tag:server:443\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-accept-fail-autogroup-tagged-src-tag-dst.hujson",
+		"full_policy": {"acls": [
+			{"action": "accept", "dst": ["tag:group-b:80"], "src": ["tag:group-a"]}
+		], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [{"accept": ["tag:server:443"], "src": "autogroup:tagged"}]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2284538893417771,
+				"StableID":   "nEJayqxfqJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       2284538893417771,
+				"Key":        "nodekey:ea10bbbd8b5a1b7516a0504210cf8f425e65ab38d147aa51a8f2b6530dfb3433",
+				"DiscoKey":   "discokey:1e18bb3ce1cd7bc3edbb8719a4f277670578ce6f377b71bfcdce3d22a9b3012c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:54687", "10.65.0.27:54687", "172.17.0.1:54687"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:37:13.898365139Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ea10bbbd8b5a1b7516a0504210cf8f425e65ab38d147aa51a8f2b6530dfb3433",
+			"MachineKey": "mkey:099a03b8624ff3df623bd53c27235d5c623fe69683813e2e50d70cfb37ffde0c",
+			"Peers": [{
+				"ID":         5929189856736284,
+				"StableID":   "nPAp5HmLJo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3bf658ed4080adc6fe4dc9b7c37a8e69d4b0c63ae9b394244cd9ac80c8171671",
+				"DiscoKey":   "discokey:57421e94d25e0bcd2816149272418869d5bb17e73fd63c15e976ec2aeb4c670e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56453", "10.65.0.27:56453", "172.17.0.1:56453"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-04-29T10:37:07.975665979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8348306496752619,
+				"StableID":   "nvvkgcrxB821CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f19a42efb93765bb12f0835af513179e374740e70e6da961d85d5ad0179f652",
+				"DiscoKey":   "discokey:a34fc7e0a237ac96888f00d22312f91de3f8710a8b51b99d826e1a109bd3a527",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48392", "10.65.0.27:48392", "172.17.0.1:48392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-04-29T10:37:08.600288499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3815936141756581,
+				"StableID":   "nzVgnxAFoW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1077a122e095de6dbd6fcdd256cc59cae2cb865fb39808f2b7fdf894002f597e",
+				"DiscoKey":   "discokey:7fb808aeb38f320cf08a74df37451f8567de5a34679856ac987ff0a50a65f530",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:37:09.082860078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8723586042244426,
+				"StableID":   "nyc639pv7B21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fce7ddc34fa31ab8d4a14d2208bf512f2873f5f80a7dd606612223eab242a804",
+				"DiscoKey":   "discokey:eda3fff8e661d72db3f6601ba7e58dc039b6b6ef3e2954fac1a44f10d638c504",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37990", "10.65.0.27:37990", "172.17.0.1:37990"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-04-29T10:37:09.591475371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2355217814779799,
+				"StableID":   "nzaCEYagPK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03681e64541003cc91c3fa0320d1b279259a801c7408307ca9f3c3646618f621",
+				"DiscoKey":   "discokey:8f78666b0546b1edbfa4058bac8296c5e13fff1f0580affbfa2fd73fca1ef40c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:47345", "10.65.0.27:47345", "172.17.0.1:47345"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-04-29T10:37:10.206713507Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1237546863892983,
+				"StableID":   "nc7mawFVfA11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:099ec6871bace965661a73025385b5c72a7997436196b5bc1b97db77b945625e",
+				"DiscoKey":   "discokey:552d917d18f3216ad42671758af9b130d38c15cee69278a264cc99d43533aa11",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:48096", "10.65.0.27:48096", "172.17.0.1:48096"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-04-29T10:37:10.729355923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5252274305086416,
+				"StableID":   "nhKnmhLm1i11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:768788310560e7083962a2a7af6f63f7aa6013317b83428c2ec0ce27fdbb1b65",
+				"DiscoKey":   "discokey:814f92740a9942bf59da5e59243c7f732e5a276399caee6ff44e0e11606f7a29",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52846", "10.65.0.27:52846", "172.17.0.1:52846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-04-29T10:37:11.221902163Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1955550606113046,
+				"StableID":   "nmQSbuzfGG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b92842410a14465a0e71bb9acd64596c1541d3b3a7ffd1a659b9e4614386308",
+				"DiscoKey":   "discokey:c032b6b6888b71df493b18a277a0d2f20f280717c59af7c1f1c72bdb769c7b4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:40575", "10.65.0.27:40575", "172.17.0.1:40575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-04-29T10:37:11.740883692Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8667026658105573,
+				"StableID":   "nWVRwR6KgA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2445a32fdd2290631fb4c48fc8e14893aabc558a84cb192e1d13ec9868fa9136",
+				"DiscoKey":   "discokey:f2ddcb0abce8b8dd7d75fb599878776367200641e75e17314fbd068920a9123f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46720", "10.65.0.27:46720", "172.17.0.1:46720"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:37:12.336513932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6311013070122196,
+				"StableID":   "ndoYxUcGHr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eb18226b58bb79dc4c3c526f8eb88e7f41ae44c9019a973695576b093eea959",
+				"DiscoKey":   "discokey:c9bf4e9b9020bc9b79aa3c5efd0ae8466513c69ea2d52b86bcf1a843ddea4322",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:37:12.879412093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         736461048989189,
+				"StableID":   "n4rP1paYk611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c0b5194821bef8dea2bb3fe5823c2df4e2effb43c283852003d3d9b195ee156",
+				"DiscoKey":   "discokey:894945b756d14352c21ded55d19ca9d2bdfffd6ac7d04c3b8072573d2af03e19",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50776", "10.65.0.27:50776", "172.17.0.1:50776"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:37:13.36837485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1392263296418239,
+				"StableID":   "nvJXvxPZsB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bc4120981bc4c4e53b47df956708d08cfc2705e38937d775cd9a85009b65c20",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:e4f0a75739178486bb1f4d6de939224eb514645fc39c9fd876c74495c3069407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45519", "10.65.0.27:45519", "172.17.0.1:45519"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:37:14.478923535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7803420051703008,
+				"StableID":   "nDMvQXcBw321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd849edeb8074e4b10e317a66771ac3667e9db59f3b587a604d9e2aa7509ea04",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:0cd91dc17c8ed1d0a79b887dce785e84a05c4515d811b72fded4d7282c370e41",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59292", "10.65.0.27:59292", "172.17.0.1:59292"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:37:14.994061648Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4947965436736474,
+				"StableID":   "nZeh8Pfwdf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ad8a1d9a17eccfe183cc852d00c2ed5bd0119fc90a661ec52465af89e9e7984f",
+				"KeyExpiry":  "2026-10-26T10:37:15Z",
+				"DiscoKey":   "discokey:9dda5a367574c2ff8f6e1ca34a446b5bbc9faaacff27dd81769def363886335d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59342", "10.65.0.27:59342", "172.17.0.1:59342"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:37:15.529441336Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2284538893417771": {
+				"ID":          2284538893417771,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1237546863892983,
+				"StableID":   "nc7mawFVfA11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1237546863892983,
+				"Key":        "nodekey:099ec6871bace965661a73025385b5c72a7997436196b5bc1b97db77b945625e",
+				"DiscoKey":   "discokey:552d917d18f3216ad42671758af9b130d38c15cee69278a264cc99d43533aa11",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:48096", "10.65.0.27:48096", "172.17.0.1:48096"],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:37:10.729355923Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:099ec6871bace965661a73025385b5c72a7997436196b5bc1b97db77b945625e",
+			"MachineKey": "mkey:9eb3c03698fff5ed4e8a1119afe0eabbdb04910521dcc00b9d52ca42a544272f",
+			"Peers": [{
+				"ID":         5929189856736284,
+				"StableID":   "nPAp5HmLJo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3bf658ed4080adc6fe4dc9b7c37a8e69d4b0c63ae9b394244cd9ac80c8171671",
+				"DiscoKey":   "discokey:57421e94d25e0bcd2816149272418869d5bb17e73fd63c15e976ec2aeb4c670e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56453", "10.65.0.27:56453", "172.17.0.1:56453"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-04-29T10:37:07.975665979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8348306496752619,
+				"StableID":   "nvvkgcrxB821CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f19a42efb93765bb12f0835af513179e374740e70e6da961d85d5ad0179f652",
+				"DiscoKey":   "discokey:a34fc7e0a237ac96888f00d22312f91de3f8710a8b51b99d826e1a109bd3a527",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48392", "10.65.0.27:48392", "172.17.0.1:48392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-04-29T10:37:08.600288499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3815936141756581,
+				"StableID":   "nzVgnxAFoW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1077a122e095de6dbd6fcdd256cc59cae2cb865fb39808f2b7fdf894002f597e",
+				"DiscoKey":   "discokey:7fb808aeb38f320cf08a74df37451f8567de5a34679856ac987ff0a50a65f530",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:37:09.082860078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8723586042244426,
+				"StableID":   "nyc639pv7B21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fce7ddc34fa31ab8d4a14d2208bf512f2873f5f80a7dd606612223eab242a804",
+				"DiscoKey":   "discokey:eda3fff8e661d72db3f6601ba7e58dc039b6b6ef3e2954fac1a44f10d638c504",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37990", "10.65.0.27:37990", "172.17.0.1:37990"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-04-29T10:37:09.591475371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2355217814779799,
+				"StableID":   "nzaCEYagPK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03681e64541003cc91c3fa0320d1b279259a801c7408307ca9f3c3646618f621",
+				"DiscoKey":   "discokey:8f78666b0546b1edbfa4058bac8296c5e13fff1f0580affbfa2fd73fca1ef40c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:47345", "10.65.0.27:47345", "172.17.0.1:47345"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-04-29T10:37:10.206713507Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5252274305086416,
+				"StableID":   "nhKnmhLm1i11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:768788310560e7083962a2a7af6f63f7aa6013317b83428c2ec0ce27fdbb1b65",
+				"DiscoKey":   "discokey:814f92740a9942bf59da5e59243c7f732e5a276399caee6ff44e0e11606f7a29",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52846", "10.65.0.27:52846", "172.17.0.1:52846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-04-29T10:37:11.221902163Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1955550606113046,
+				"StableID":   "nmQSbuzfGG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b92842410a14465a0e71bb9acd64596c1541d3b3a7ffd1a659b9e4614386308",
+				"DiscoKey":   "discokey:c032b6b6888b71df493b18a277a0d2f20f280717c59af7c1f1c72bdb769c7b4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:40575", "10.65.0.27:40575", "172.17.0.1:40575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-04-29T10:37:11.740883692Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8667026658105573,
+				"StableID":   "nWVRwR6KgA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2445a32fdd2290631fb4c48fc8e14893aabc558a84cb192e1d13ec9868fa9136",
+				"DiscoKey":   "discokey:f2ddcb0abce8b8dd7d75fb599878776367200641e75e17314fbd068920a9123f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46720", "10.65.0.27:46720", "172.17.0.1:46720"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:37:12.336513932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6311013070122196,
+				"StableID":   "ndoYxUcGHr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eb18226b58bb79dc4c3c526f8eb88e7f41ae44c9019a973695576b093eea959",
+				"DiscoKey":   "discokey:c9bf4e9b9020bc9b79aa3c5efd0ae8466513c69ea2d52b86bcf1a843ddea4322",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:37:12.879412093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         736461048989189,
+				"StableID":   "n4rP1paYk611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c0b5194821bef8dea2bb3fe5823c2df4e2effb43c283852003d3d9b195ee156",
+				"DiscoKey":   "discokey:894945b756d14352c21ded55d19ca9d2bdfffd6ac7d04c3b8072573d2af03e19",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50776", "10.65.0.27:50776", "172.17.0.1:50776"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:37:13.36837485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2284538893417771,
+				"StableID":   "nEJayqxfqJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea10bbbd8b5a1b7516a0504210cf8f425e65ab38d147aa51a8f2b6530dfb3433",
+				"DiscoKey":   "discokey:1e18bb3ce1cd7bc3edbb8719a4f277670578ce6f377b71bfcdce3d22a9b3012c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:54687", "10.65.0.27:54687", "172.17.0.1:54687"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:37:13.898365139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1392263296418239,
+				"StableID":   "nvJXvxPZsB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bc4120981bc4c4e53b47df956708d08cfc2705e38937d775cd9a85009b65c20",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:e4f0a75739178486bb1f4d6de939224eb514645fc39c9fd876c74495c3069407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45519", "10.65.0.27:45519", "172.17.0.1:45519"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:37:14.478923535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7803420051703008,
+				"StableID":   "nDMvQXcBw321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd849edeb8074e4b10e317a66771ac3667e9db59f3b587a604d9e2aa7509ea04",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:0cd91dc17c8ed1d0a79b887dce785e84a05c4515d811b72fded4d7282c370e41",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59292", "10.65.0.27:59292", "172.17.0.1:59292"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:37:14.994061648Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4947965436736474,
+				"StableID":   "nZeh8Pfwdf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ad8a1d9a17eccfe183cc852d00c2ed5bd0119fc90a661ec52465af89e9e7984f",
+				"KeyExpiry":  "2026-10-26T10:37:15Z",
+				"DiscoKey":   "discokey:9dda5a367574c2ff8f6e1ca34a446b5bbc9faaacff27dd81769def363886335d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59342", "10.65.0.27:59342", "172.17.0.1:59342"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:37:15.529441336Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1237546863892983": {
+				"ID":          1237546863892983,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4947965436736474,
+				"StableID":   "nZeh8Pfwdf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ad8a1d9a17eccfe183cc852d00c2ed5bd0119fc90a661ec52465af89e9e7984f",
+				"KeyExpiry":  "2026-10-26T10:37:15Z",
+				"DiscoKey":   "discokey:9dda5a367574c2ff8f6e1ca34a446b5bbc9faaacff27dd81769def363886335d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59342", "10.65.0.27:59342", "172.17.0.1:59342"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:37:15.529441336Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ad8a1d9a17eccfe183cc852d00c2ed5bd0119fc90a661ec52465af89e9e7984f",
+			"MachineKey": "mkey:481a778e3ab62302aee5343acf9d52749470d87423e08bab6293fbdc9d900462",
+			"Peers": [{
+				"ID":         5929189856736284,
+				"StableID":   "nPAp5HmLJo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3bf658ed4080adc6fe4dc9b7c37a8e69d4b0c63ae9b394244cd9ac80c8171671",
+				"DiscoKey":   "discokey:57421e94d25e0bcd2816149272418869d5bb17e73fd63c15e976ec2aeb4c670e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56453", "10.65.0.27:56453", "172.17.0.1:56453"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-04-29T10:37:07.975665979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8348306496752619,
+				"StableID":   "nvvkgcrxB821CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f19a42efb93765bb12f0835af513179e374740e70e6da961d85d5ad0179f652",
+				"DiscoKey":   "discokey:a34fc7e0a237ac96888f00d22312f91de3f8710a8b51b99d826e1a109bd3a527",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48392", "10.65.0.27:48392", "172.17.0.1:48392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-04-29T10:37:08.600288499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3815936141756581,
+				"StableID":   "nzVgnxAFoW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1077a122e095de6dbd6fcdd256cc59cae2cb865fb39808f2b7fdf894002f597e",
+				"DiscoKey":   "discokey:7fb808aeb38f320cf08a74df37451f8567de5a34679856ac987ff0a50a65f530",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:37:09.082860078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8723586042244426,
+				"StableID":   "nyc639pv7B21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fce7ddc34fa31ab8d4a14d2208bf512f2873f5f80a7dd606612223eab242a804",
+				"DiscoKey":   "discokey:eda3fff8e661d72db3f6601ba7e58dc039b6b6ef3e2954fac1a44f10d638c504",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37990", "10.65.0.27:37990", "172.17.0.1:37990"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-04-29T10:37:09.591475371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2355217814779799,
+				"StableID":   "nzaCEYagPK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03681e64541003cc91c3fa0320d1b279259a801c7408307ca9f3c3646618f621",
+				"DiscoKey":   "discokey:8f78666b0546b1edbfa4058bac8296c5e13fff1f0580affbfa2fd73fca1ef40c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:47345", "10.65.0.27:47345", "172.17.0.1:47345"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-04-29T10:37:10.206713507Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1237546863892983,
+				"StableID":   "nc7mawFVfA11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:099ec6871bace965661a73025385b5c72a7997436196b5bc1b97db77b945625e",
+				"DiscoKey":   "discokey:552d917d18f3216ad42671758af9b130d38c15cee69278a264cc99d43533aa11",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:48096", "10.65.0.27:48096", "172.17.0.1:48096"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-04-29T10:37:10.729355923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5252274305086416,
+				"StableID":   "nhKnmhLm1i11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:768788310560e7083962a2a7af6f63f7aa6013317b83428c2ec0ce27fdbb1b65",
+				"DiscoKey":   "discokey:814f92740a9942bf59da5e59243c7f732e5a276399caee6ff44e0e11606f7a29",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52846", "10.65.0.27:52846", "172.17.0.1:52846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-04-29T10:37:11.221902163Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1955550606113046,
+				"StableID":   "nmQSbuzfGG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b92842410a14465a0e71bb9acd64596c1541d3b3a7ffd1a659b9e4614386308",
+				"DiscoKey":   "discokey:c032b6b6888b71df493b18a277a0d2f20f280717c59af7c1f1c72bdb769c7b4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:40575", "10.65.0.27:40575", "172.17.0.1:40575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-04-29T10:37:11.740883692Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8667026658105573,
+				"StableID":   "nWVRwR6KgA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2445a32fdd2290631fb4c48fc8e14893aabc558a84cb192e1d13ec9868fa9136",
+				"DiscoKey":   "discokey:f2ddcb0abce8b8dd7d75fb599878776367200641e75e17314fbd068920a9123f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46720", "10.65.0.27:46720", "172.17.0.1:46720"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:37:12.336513932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6311013070122196,
+				"StableID":   "ndoYxUcGHr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eb18226b58bb79dc4c3c526f8eb88e7f41ae44c9019a973695576b093eea959",
+				"DiscoKey":   "discokey:c9bf4e9b9020bc9b79aa3c5efd0ae8466513c69ea2d52b86bcf1a843ddea4322",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:37:12.879412093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         736461048989189,
+				"StableID":   "n4rP1paYk611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c0b5194821bef8dea2bb3fe5823c2df4e2effb43c283852003d3d9b195ee156",
+				"DiscoKey":   "discokey:894945b756d14352c21ded55d19ca9d2bdfffd6ac7d04c3b8072573d2af03e19",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50776", "10.65.0.27:50776", "172.17.0.1:50776"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:37:13.36837485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2284538893417771,
+				"StableID":   "nEJayqxfqJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea10bbbd8b5a1b7516a0504210cf8f425e65ab38d147aa51a8f2b6530dfb3433",
+				"DiscoKey":   "discokey:1e18bb3ce1cd7bc3edbb8719a4f277670578ce6f377b71bfcdce3d22a9b3012c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:54687", "10.65.0.27:54687", "172.17.0.1:54687"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:37:13.898365139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1392263296418239,
+				"StableID":   "nvJXvxPZsB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bc4120981bc4c4e53b47df956708d08cfc2705e38937d775cd9a85009b65c20",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:e4f0a75739178486bb1f4d6de939224eb514645fc39c9fd876c74495c3069407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45519", "10.65.0.27:45519", "172.17.0.1:45519"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:37:14.478923535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7803420051703008,
+				"StableID":   "nDMvQXcBw321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd849edeb8074e4b10e317a66771ac3667e9db59f3b587a604d9e2aa7509ea04",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:0cd91dc17c8ed1d0a79b887dce785e84a05c4515d811b72fded4d7282c370e41",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59292", "10.65.0.27:59292", "172.17.0.1:59292"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:37:14.994061648Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3815936141756581,
+				"StableID":   "nzVgnxAFoW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       3815936141756581,
+				"Key":        "nodekey:1077a122e095de6dbd6fcdd256cc59cae2cb865fb39808f2b7fdf894002f597e",
+				"DiscoKey":   "discokey:7fb808aeb38f320cf08a74df37451f8567de5a34679856ac987ff0a50a65f530",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:37:09.082860078Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1077a122e095de6dbd6fcdd256cc59cae2cb865fb39808f2b7fdf894002f597e",
+			"MachineKey": "mkey:8a16d4d40d4863b7269920751489c00defbf322697f2ee7e323ba056d4e9b70e",
+			"Peers": [{
+				"ID":         5929189856736284,
+				"StableID":   "nPAp5HmLJo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3bf658ed4080adc6fe4dc9b7c37a8e69d4b0c63ae9b394244cd9ac80c8171671",
+				"DiscoKey":   "discokey:57421e94d25e0bcd2816149272418869d5bb17e73fd63c15e976ec2aeb4c670e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56453", "10.65.0.27:56453", "172.17.0.1:56453"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-04-29T10:37:07.975665979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8348306496752619,
+				"StableID":   "nvvkgcrxB821CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f19a42efb93765bb12f0835af513179e374740e70e6da961d85d5ad0179f652",
+				"DiscoKey":   "discokey:a34fc7e0a237ac96888f00d22312f91de3f8710a8b51b99d826e1a109bd3a527",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48392", "10.65.0.27:48392", "172.17.0.1:48392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-04-29T10:37:08.600288499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8723586042244426,
+				"StableID":   "nyc639pv7B21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fce7ddc34fa31ab8d4a14d2208bf512f2873f5f80a7dd606612223eab242a804",
+				"DiscoKey":   "discokey:eda3fff8e661d72db3f6601ba7e58dc039b6b6ef3e2954fac1a44f10d638c504",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37990", "10.65.0.27:37990", "172.17.0.1:37990"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-04-29T10:37:09.591475371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2355217814779799,
+				"StableID":   "nzaCEYagPK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03681e64541003cc91c3fa0320d1b279259a801c7408307ca9f3c3646618f621",
+				"DiscoKey":   "discokey:8f78666b0546b1edbfa4058bac8296c5e13fff1f0580affbfa2fd73fca1ef40c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:47345", "10.65.0.27:47345", "172.17.0.1:47345"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-04-29T10:37:10.206713507Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1237546863892983,
+				"StableID":   "nc7mawFVfA11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:099ec6871bace965661a73025385b5c72a7997436196b5bc1b97db77b945625e",
+				"DiscoKey":   "discokey:552d917d18f3216ad42671758af9b130d38c15cee69278a264cc99d43533aa11",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:48096", "10.65.0.27:48096", "172.17.0.1:48096"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-04-29T10:37:10.729355923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5252274305086416,
+				"StableID":   "nhKnmhLm1i11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:768788310560e7083962a2a7af6f63f7aa6013317b83428c2ec0ce27fdbb1b65",
+				"DiscoKey":   "discokey:814f92740a9942bf59da5e59243c7f732e5a276399caee6ff44e0e11606f7a29",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52846", "10.65.0.27:52846", "172.17.0.1:52846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-04-29T10:37:11.221902163Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1955550606113046,
+				"StableID":   "nmQSbuzfGG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b92842410a14465a0e71bb9acd64596c1541d3b3a7ffd1a659b9e4614386308",
+				"DiscoKey":   "discokey:c032b6b6888b71df493b18a277a0d2f20f280717c59af7c1f1c72bdb769c7b4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:40575", "10.65.0.27:40575", "172.17.0.1:40575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-04-29T10:37:11.740883692Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8667026658105573,
+				"StableID":   "nWVRwR6KgA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2445a32fdd2290631fb4c48fc8e14893aabc558a84cb192e1d13ec9868fa9136",
+				"DiscoKey":   "discokey:f2ddcb0abce8b8dd7d75fb599878776367200641e75e17314fbd068920a9123f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46720", "10.65.0.27:46720", "172.17.0.1:46720"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:37:12.336513932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6311013070122196,
+				"StableID":   "ndoYxUcGHr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eb18226b58bb79dc4c3c526f8eb88e7f41ae44c9019a973695576b093eea959",
+				"DiscoKey":   "discokey:c9bf4e9b9020bc9b79aa3c5efd0ae8466513c69ea2d52b86bcf1a843ddea4322",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:37:12.879412093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         736461048989189,
+				"StableID":   "n4rP1paYk611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c0b5194821bef8dea2bb3fe5823c2df4e2effb43c283852003d3d9b195ee156",
+				"DiscoKey":   "discokey:894945b756d14352c21ded55d19ca9d2bdfffd6ac7d04c3b8072573d2af03e19",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50776", "10.65.0.27:50776", "172.17.0.1:50776"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:37:13.36837485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2284538893417771,
+				"StableID":   "nEJayqxfqJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea10bbbd8b5a1b7516a0504210cf8f425e65ab38d147aa51a8f2b6530dfb3433",
+				"DiscoKey":   "discokey:1e18bb3ce1cd7bc3edbb8719a4f277670578ce6f377b71bfcdce3d22a9b3012c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:54687", "10.65.0.27:54687", "172.17.0.1:54687"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:37:13.898365139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1392263296418239,
+				"StableID":   "nvJXvxPZsB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bc4120981bc4c4e53b47df956708d08cfc2705e38937d775cd9a85009b65c20",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:e4f0a75739178486bb1f4d6de939224eb514645fc39c9fd876c74495c3069407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45519", "10.65.0.27:45519", "172.17.0.1:45519"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:37:14.478923535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7803420051703008,
+				"StableID":   "nDMvQXcBw321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd849edeb8074e4b10e317a66771ac3667e9db59f3b587a604d9e2aa7509ea04",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:0cd91dc17c8ed1d0a79b887dce785e84a05c4515d811b72fded4d7282c370e41",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59292", "10.65.0.27:59292", "172.17.0.1:59292"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:37:14.994061648Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4947965436736474,
+				"StableID":   "nZeh8Pfwdf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ad8a1d9a17eccfe183cc852d00c2ed5bd0119fc90a661ec52465af89e9e7984f",
+				"KeyExpiry":  "2026-10-26T10:37:15Z",
+				"DiscoKey":   "discokey:9dda5a367574c2ff8f6e1ca34a446b5bbc9faaacff27dd81769def363886335d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59342", "10.65.0.27:59342", "172.17.0.1:59342"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:37:15.529441336Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3815936141756581": {
+				"ID":          3815936141756581,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1955550606113046,
+				"StableID":   "nmQSbuzfGG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1955550606113046,
+				"Key":        "nodekey:9b92842410a14465a0e71bb9acd64596c1541d3b3a7ffd1a659b9e4614386308",
+				"DiscoKey":   "discokey:c032b6b6888b71df493b18a277a0d2f20f280717c59af7c1f1c72bdb769c7b4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:40575", "10.65.0.27:40575", "172.17.0.1:40575"],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:37:11.740883692Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9b92842410a14465a0e71bb9acd64596c1541d3b3a7ffd1a659b9e4614386308",
+			"MachineKey": "mkey:5cf6909671cd3bae6e3eb930bd406912300d5c8eb29b71ec268ad509820da41f",
+			"Peers": [{
+				"ID":         5929189856736284,
+				"StableID":   "nPAp5HmLJo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3bf658ed4080adc6fe4dc9b7c37a8e69d4b0c63ae9b394244cd9ac80c8171671",
+				"DiscoKey":   "discokey:57421e94d25e0bcd2816149272418869d5bb17e73fd63c15e976ec2aeb4c670e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56453", "10.65.0.27:56453", "172.17.0.1:56453"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-04-29T10:37:07.975665979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8348306496752619,
+				"StableID":   "nvvkgcrxB821CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f19a42efb93765bb12f0835af513179e374740e70e6da961d85d5ad0179f652",
+				"DiscoKey":   "discokey:a34fc7e0a237ac96888f00d22312f91de3f8710a8b51b99d826e1a109bd3a527",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48392", "10.65.0.27:48392", "172.17.0.1:48392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-04-29T10:37:08.600288499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3815936141756581,
+				"StableID":   "nzVgnxAFoW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1077a122e095de6dbd6fcdd256cc59cae2cb865fb39808f2b7fdf894002f597e",
+				"DiscoKey":   "discokey:7fb808aeb38f320cf08a74df37451f8567de5a34679856ac987ff0a50a65f530",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:37:09.082860078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8723586042244426,
+				"StableID":   "nyc639pv7B21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fce7ddc34fa31ab8d4a14d2208bf512f2873f5f80a7dd606612223eab242a804",
+				"DiscoKey":   "discokey:eda3fff8e661d72db3f6601ba7e58dc039b6b6ef3e2954fac1a44f10d638c504",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37990", "10.65.0.27:37990", "172.17.0.1:37990"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-04-29T10:37:09.591475371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2355217814779799,
+				"StableID":   "nzaCEYagPK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03681e64541003cc91c3fa0320d1b279259a801c7408307ca9f3c3646618f621",
+				"DiscoKey":   "discokey:8f78666b0546b1edbfa4058bac8296c5e13fff1f0580affbfa2fd73fca1ef40c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:47345", "10.65.0.27:47345", "172.17.0.1:47345"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-04-29T10:37:10.206713507Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1237546863892983,
+				"StableID":   "nc7mawFVfA11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:099ec6871bace965661a73025385b5c72a7997436196b5bc1b97db77b945625e",
+				"DiscoKey":   "discokey:552d917d18f3216ad42671758af9b130d38c15cee69278a264cc99d43533aa11",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:48096", "10.65.0.27:48096", "172.17.0.1:48096"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-04-29T10:37:10.729355923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5252274305086416,
+				"StableID":   "nhKnmhLm1i11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:768788310560e7083962a2a7af6f63f7aa6013317b83428c2ec0ce27fdbb1b65",
+				"DiscoKey":   "discokey:814f92740a9942bf59da5e59243c7f732e5a276399caee6ff44e0e11606f7a29",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52846", "10.65.0.27:52846", "172.17.0.1:52846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-04-29T10:37:11.221902163Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8667026658105573,
+				"StableID":   "nWVRwR6KgA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2445a32fdd2290631fb4c48fc8e14893aabc558a84cb192e1d13ec9868fa9136",
+				"DiscoKey":   "discokey:f2ddcb0abce8b8dd7d75fb599878776367200641e75e17314fbd068920a9123f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46720", "10.65.0.27:46720", "172.17.0.1:46720"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:37:12.336513932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6311013070122196,
+				"StableID":   "ndoYxUcGHr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eb18226b58bb79dc4c3c526f8eb88e7f41ae44c9019a973695576b093eea959",
+				"DiscoKey":   "discokey:c9bf4e9b9020bc9b79aa3c5efd0ae8466513c69ea2d52b86bcf1a843ddea4322",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:37:12.879412093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         736461048989189,
+				"StableID":   "n4rP1paYk611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c0b5194821bef8dea2bb3fe5823c2df4e2effb43c283852003d3d9b195ee156",
+				"DiscoKey":   "discokey:894945b756d14352c21ded55d19ca9d2bdfffd6ac7d04c3b8072573d2af03e19",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50776", "10.65.0.27:50776", "172.17.0.1:50776"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:37:13.36837485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2284538893417771,
+				"StableID":   "nEJayqxfqJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea10bbbd8b5a1b7516a0504210cf8f425e65ab38d147aa51a8f2b6530dfb3433",
+				"DiscoKey":   "discokey:1e18bb3ce1cd7bc3edbb8719a4f277670578ce6f377b71bfcdce3d22a9b3012c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:54687", "10.65.0.27:54687", "172.17.0.1:54687"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:37:13.898365139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1392263296418239,
+				"StableID":   "nvJXvxPZsB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bc4120981bc4c4e53b47df956708d08cfc2705e38937d775cd9a85009b65c20",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:e4f0a75739178486bb1f4d6de939224eb514645fc39c9fd876c74495c3069407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45519", "10.65.0.27:45519", "172.17.0.1:45519"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:37:14.478923535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7803420051703008,
+				"StableID":   "nDMvQXcBw321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd849edeb8074e4b10e317a66771ac3667e9db59f3b587a604d9e2aa7509ea04",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:0cd91dc17c8ed1d0a79b887dce785e84a05c4515d811b72fded4d7282c370e41",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59292", "10.65.0.27:59292", "172.17.0.1:59292"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:37:14.994061648Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4947965436736474,
+				"StableID":   "nZeh8Pfwdf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ad8a1d9a17eccfe183cc852d00c2ed5bd0119fc90a661ec52465af89e9e7984f",
+				"KeyExpiry":  "2026-10-26T10:37:15Z",
+				"DiscoKey":   "discokey:9dda5a367574c2ff8f6e1ca34a446b5bbc9faaacff27dd81769def363886335d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59342", "10.65.0.27:59342", "172.17.0.1:59342"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:37:15.529441336Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1955550606113046": {
+				"ID":          1955550606113046,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1392263296418239,
+				"StableID":   "nvJXvxPZsB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bc4120981bc4c4e53b47df956708d08cfc2705e38937d775cd9a85009b65c20",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:e4f0a75739178486bb1f4d6de939224eb514645fc39c9fd876c74495c3069407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45519", "10.65.0.27:45519", "172.17.0.1:45519"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:37:14.478923535Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6bc4120981bc4c4e53b47df956708d08cfc2705e38937d775cd9a85009b65c20",
+			"MachineKey": "mkey:776d9cc34747ca8de4869a4adef8655f629f532c64b5a31ce55414d556c9c56a",
+			"Peers": [{
+				"ID":         5929189856736284,
+				"StableID":   "nPAp5HmLJo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3bf658ed4080adc6fe4dc9b7c37a8e69d4b0c63ae9b394244cd9ac80c8171671",
+				"DiscoKey":   "discokey:57421e94d25e0bcd2816149272418869d5bb17e73fd63c15e976ec2aeb4c670e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56453", "10.65.0.27:56453", "172.17.0.1:56453"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-04-29T10:37:07.975665979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8348306496752619,
+				"StableID":   "nvvkgcrxB821CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f19a42efb93765bb12f0835af513179e374740e70e6da961d85d5ad0179f652",
+				"DiscoKey":   "discokey:a34fc7e0a237ac96888f00d22312f91de3f8710a8b51b99d826e1a109bd3a527",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48392", "10.65.0.27:48392", "172.17.0.1:48392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-04-29T10:37:08.600288499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3815936141756581,
+				"StableID":   "nzVgnxAFoW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1077a122e095de6dbd6fcdd256cc59cae2cb865fb39808f2b7fdf894002f597e",
+				"DiscoKey":   "discokey:7fb808aeb38f320cf08a74df37451f8567de5a34679856ac987ff0a50a65f530",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:37:09.082860078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8723586042244426,
+				"StableID":   "nyc639pv7B21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fce7ddc34fa31ab8d4a14d2208bf512f2873f5f80a7dd606612223eab242a804",
+				"DiscoKey":   "discokey:eda3fff8e661d72db3f6601ba7e58dc039b6b6ef3e2954fac1a44f10d638c504",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37990", "10.65.0.27:37990", "172.17.0.1:37990"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-04-29T10:37:09.591475371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2355217814779799,
+				"StableID":   "nzaCEYagPK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03681e64541003cc91c3fa0320d1b279259a801c7408307ca9f3c3646618f621",
+				"DiscoKey":   "discokey:8f78666b0546b1edbfa4058bac8296c5e13fff1f0580affbfa2fd73fca1ef40c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:47345", "10.65.0.27:47345", "172.17.0.1:47345"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-04-29T10:37:10.206713507Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1237546863892983,
+				"StableID":   "nc7mawFVfA11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:099ec6871bace965661a73025385b5c72a7997436196b5bc1b97db77b945625e",
+				"DiscoKey":   "discokey:552d917d18f3216ad42671758af9b130d38c15cee69278a264cc99d43533aa11",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:48096", "10.65.0.27:48096", "172.17.0.1:48096"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-04-29T10:37:10.729355923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5252274305086416,
+				"StableID":   "nhKnmhLm1i11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:768788310560e7083962a2a7af6f63f7aa6013317b83428c2ec0ce27fdbb1b65",
+				"DiscoKey":   "discokey:814f92740a9942bf59da5e59243c7f732e5a276399caee6ff44e0e11606f7a29",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52846", "10.65.0.27:52846", "172.17.0.1:52846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-04-29T10:37:11.221902163Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1955550606113046,
+				"StableID":   "nmQSbuzfGG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b92842410a14465a0e71bb9acd64596c1541d3b3a7ffd1a659b9e4614386308",
+				"DiscoKey":   "discokey:c032b6b6888b71df493b18a277a0d2f20f280717c59af7c1f1c72bdb769c7b4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:40575", "10.65.0.27:40575", "172.17.0.1:40575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-04-29T10:37:11.740883692Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8667026658105573,
+				"StableID":   "nWVRwR6KgA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2445a32fdd2290631fb4c48fc8e14893aabc558a84cb192e1d13ec9868fa9136",
+				"DiscoKey":   "discokey:f2ddcb0abce8b8dd7d75fb599878776367200641e75e17314fbd068920a9123f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46720", "10.65.0.27:46720", "172.17.0.1:46720"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:37:12.336513932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6311013070122196,
+				"StableID":   "ndoYxUcGHr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eb18226b58bb79dc4c3c526f8eb88e7f41ae44c9019a973695576b093eea959",
+				"DiscoKey":   "discokey:c9bf4e9b9020bc9b79aa3c5efd0ae8466513c69ea2d52b86bcf1a843ddea4322",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:37:12.879412093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         736461048989189,
+				"StableID":   "n4rP1paYk611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c0b5194821bef8dea2bb3fe5823c2df4e2effb43c283852003d3d9b195ee156",
+				"DiscoKey":   "discokey:894945b756d14352c21ded55d19ca9d2bdfffd6ac7d04c3b8072573d2af03e19",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50776", "10.65.0.27:50776", "172.17.0.1:50776"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:37:13.36837485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2284538893417771,
+				"StableID":   "nEJayqxfqJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea10bbbd8b5a1b7516a0504210cf8f425e65ab38d147aa51a8f2b6530dfb3433",
+				"DiscoKey":   "discokey:1e18bb3ce1cd7bc3edbb8719a4f277670578ce6f377b71bfcdce3d22a9b3012c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:54687", "10.65.0.27:54687", "172.17.0.1:54687"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:37:13.898365139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7803420051703008,
+				"StableID":   "nDMvQXcBw321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd849edeb8074e4b10e317a66771ac3667e9db59f3b587a604d9e2aa7509ea04",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:0cd91dc17c8ed1d0a79b887dce785e84a05c4515d811b72fded4d7282c370e41",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59292", "10.65.0.27:59292", "172.17.0.1:59292"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:37:14.994061648Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4947965436736474,
+				"StableID":   "nZeh8Pfwdf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ad8a1d9a17eccfe183cc852d00c2ed5bd0119fc90a661ec52465af89e9e7984f",
+				"KeyExpiry":  "2026-10-26T10:37:15Z",
+				"DiscoKey":   "discokey:9dda5a367574c2ff8f6e1ca34a446b5bbc9faaacff27dd81769def363886335d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59342", "10.65.0.27:59342", "172.17.0.1:59342"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:37:15.529441336Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         736461048989189,
+				"StableID":   "n4rP1paYk611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       736461048989189,
+				"Key":        "nodekey:0c0b5194821bef8dea2bb3fe5823c2df4e2effb43c283852003d3d9b195ee156",
+				"DiscoKey":   "discokey:894945b756d14352c21ded55d19ca9d2bdfffd6ac7d04c3b8072573d2af03e19",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50776", "10.65.0.27:50776", "172.17.0.1:50776"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:37:13.36837485Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0c0b5194821bef8dea2bb3fe5823c2df4e2effb43c283852003d3d9b195ee156",
+			"MachineKey": "mkey:85c65d70444c0fce488c85df833eedb2479bd643d7f58a5080dbfe1a6e247b37",
+			"Peers": [{
+				"ID":         5929189856736284,
+				"StableID":   "nPAp5HmLJo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3bf658ed4080adc6fe4dc9b7c37a8e69d4b0c63ae9b394244cd9ac80c8171671",
+				"DiscoKey":   "discokey:57421e94d25e0bcd2816149272418869d5bb17e73fd63c15e976ec2aeb4c670e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56453", "10.65.0.27:56453", "172.17.0.1:56453"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-04-29T10:37:07.975665979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8348306496752619,
+				"StableID":   "nvvkgcrxB821CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f19a42efb93765bb12f0835af513179e374740e70e6da961d85d5ad0179f652",
+				"DiscoKey":   "discokey:a34fc7e0a237ac96888f00d22312f91de3f8710a8b51b99d826e1a109bd3a527",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48392", "10.65.0.27:48392", "172.17.0.1:48392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-04-29T10:37:08.600288499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3815936141756581,
+				"StableID":   "nzVgnxAFoW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1077a122e095de6dbd6fcdd256cc59cae2cb865fb39808f2b7fdf894002f597e",
+				"DiscoKey":   "discokey:7fb808aeb38f320cf08a74df37451f8567de5a34679856ac987ff0a50a65f530",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:37:09.082860078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8723586042244426,
+				"StableID":   "nyc639pv7B21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fce7ddc34fa31ab8d4a14d2208bf512f2873f5f80a7dd606612223eab242a804",
+				"DiscoKey":   "discokey:eda3fff8e661d72db3f6601ba7e58dc039b6b6ef3e2954fac1a44f10d638c504",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37990", "10.65.0.27:37990", "172.17.0.1:37990"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-04-29T10:37:09.591475371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2355217814779799,
+				"StableID":   "nzaCEYagPK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03681e64541003cc91c3fa0320d1b279259a801c7408307ca9f3c3646618f621",
+				"DiscoKey":   "discokey:8f78666b0546b1edbfa4058bac8296c5e13fff1f0580affbfa2fd73fca1ef40c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:47345", "10.65.0.27:47345", "172.17.0.1:47345"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-04-29T10:37:10.206713507Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1237546863892983,
+				"StableID":   "nc7mawFVfA11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:099ec6871bace965661a73025385b5c72a7997436196b5bc1b97db77b945625e",
+				"DiscoKey":   "discokey:552d917d18f3216ad42671758af9b130d38c15cee69278a264cc99d43533aa11",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:48096", "10.65.0.27:48096", "172.17.0.1:48096"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-04-29T10:37:10.729355923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5252274305086416,
+				"StableID":   "nhKnmhLm1i11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:768788310560e7083962a2a7af6f63f7aa6013317b83428c2ec0ce27fdbb1b65",
+				"DiscoKey":   "discokey:814f92740a9942bf59da5e59243c7f732e5a276399caee6ff44e0e11606f7a29",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52846", "10.65.0.27:52846", "172.17.0.1:52846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-04-29T10:37:11.221902163Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1955550606113046,
+				"StableID":   "nmQSbuzfGG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b92842410a14465a0e71bb9acd64596c1541d3b3a7ffd1a659b9e4614386308",
+				"DiscoKey":   "discokey:c032b6b6888b71df493b18a277a0d2f20f280717c59af7c1f1c72bdb769c7b4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:40575", "10.65.0.27:40575", "172.17.0.1:40575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-04-29T10:37:11.740883692Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8667026658105573,
+				"StableID":   "nWVRwR6KgA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2445a32fdd2290631fb4c48fc8e14893aabc558a84cb192e1d13ec9868fa9136",
+				"DiscoKey":   "discokey:f2ddcb0abce8b8dd7d75fb599878776367200641e75e17314fbd068920a9123f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46720", "10.65.0.27:46720", "172.17.0.1:46720"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:37:12.336513932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6311013070122196,
+				"StableID":   "ndoYxUcGHr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eb18226b58bb79dc4c3c526f8eb88e7f41ae44c9019a973695576b093eea959",
+				"DiscoKey":   "discokey:c9bf4e9b9020bc9b79aa3c5efd0ae8466513c69ea2d52b86bcf1a843ddea4322",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:37:12.879412093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2284538893417771,
+				"StableID":   "nEJayqxfqJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea10bbbd8b5a1b7516a0504210cf8f425e65ab38d147aa51a8f2b6530dfb3433",
+				"DiscoKey":   "discokey:1e18bb3ce1cd7bc3edbb8719a4f277670578ce6f377b71bfcdce3d22a9b3012c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:54687", "10.65.0.27:54687", "172.17.0.1:54687"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:37:13.898365139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1392263296418239,
+				"StableID":   "nvJXvxPZsB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bc4120981bc4c4e53b47df956708d08cfc2705e38937d775cd9a85009b65c20",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:e4f0a75739178486bb1f4d6de939224eb514645fc39c9fd876c74495c3069407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45519", "10.65.0.27:45519", "172.17.0.1:45519"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:37:14.478923535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7803420051703008,
+				"StableID":   "nDMvQXcBw321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd849edeb8074e4b10e317a66771ac3667e9db59f3b587a604d9e2aa7509ea04",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:0cd91dc17c8ed1d0a79b887dce785e84a05c4515d811b72fded4d7282c370e41",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59292", "10.65.0.27:59292", "172.17.0.1:59292"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:37:14.994061648Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4947965436736474,
+				"StableID":   "nZeh8Pfwdf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ad8a1d9a17eccfe183cc852d00c2ed5bd0119fc90a661ec52465af89e9e7984f",
+				"KeyExpiry":  "2026-10-26T10:37:15Z",
+				"DiscoKey":   "discokey:9dda5a367574c2ff8f6e1ca34a446b5bbc9faaacff27dd81769def363886335d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59342", "10.65.0.27:59342", "172.17.0.1:59342"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:37:15.529441336Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "736461048989189": {
+				"ID":          736461048989189,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8348306496752619,
+				"StableID":   "nvvkgcrxB821CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       8348306496752619,
+				"Key":        "nodekey:8f19a42efb93765bb12f0835af513179e374740e70e6da961d85d5ad0179f652",
+				"DiscoKey":   "discokey:a34fc7e0a237ac96888f00d22312f91de3f8710a8b51b99d826e1a109bd3a527",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48392", "10.65.0.27:48392", "172.17.0.1:48392"],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:37:08.600288499Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8f19a42efb93765bb12f0835af513179e374740e70e6da961d85d5ad0179f652",
+			"MachineKey": "mkey:5db0409f95c5af6cb38cbdac474cd57f24bf684653a2e107e53b34c51103371c",
+			"Peers": [{
+				"ID":         5929189856736284,
+				"StableID":   "nPAp5HmLJo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3bf658ed4080adc6fe4dc9b7c37a8e69d4b0c63ae9b394244cd9ac80c8171671",
+				"DiscoKey":   "discokey:57421e94d25e0bcd2816149272418869d5bb17e73fd63c15e976ec2aeb4c670e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56453", "10.65.0.27:56453", "172.17.0.1:56453"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-04-29T10:37:07.975665979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3815936141756581,
+				"StableID":   "nzVgnxAFoW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1077a122e095de6dbd6fcdd256cc59cae2cb865fb39808f2b7fdf894002f597e",
+				"DiscoKey":   "discokey:7fb808aeb38f320cf08a74df37451f8567de5a34679856ac987ff0a50a65f530",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:37:09.082860078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8723586042244426,
+				"StableID":   "nyc639pv7B21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fce7ddc34fa31ab8d4a14d2208bf512f2873f5f80a7dd606612223eab242a804",
+				"DiscoKey":   "discokey:eda3fff8e661d72db3f6601ba7e58dc039b6b6ef3e2954fac1a44f10d638c504",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37990", "10.65.0.27:37990", "172.17.0.1:37990"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-04-29T10:37:09.591475371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2355217814779799,
+				"StableID":   "nzaCEYagPK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03681e64541003cc91c3fa0320d1b279259a801c7408307ca9f3c3646618f621",
+				"DiscoKey":   "discokey:8f78666b0546b1edbfa4058bac8296c5e13fff1f0580affbfa2fd73fca1ef40c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:47345", "10.65.0.27:47345", "172.17.0.1:47345"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-04-29T10:37:10.206713507Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1237546863892983,
+				"StableID":   "nc7mawFVfA11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:099ec6871bace965661a73025385b5c72a7997436196b5bc1b97db77b945625e",
+				"DiscoKey":   "discokey:552d917d18f3216ad42671758af9b130d38c15cee69278a264cc99d43533aa11",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:48096", "10.65.0.27:48096", "172.17.0.1:48096"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-04-29T10:37:10.729355923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5252274305086416,
+				"StableID":   "nhKnmhLm1i11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:768788310560e7083962a2a7af6f63f7aa6013317b83428c2ec0ce27fdbb1b65",
+				"DiscoKey":   "discokey:814f92740a9942bf59da5e59243c7f732e5a276399caee6ff44e0e11606f7a29",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52846", "10.65.0.27:52846", "172.17.0.1:52846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-04-29T10:37:11.221902163Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1955550606113046,
+				"StableID":   "nmQSbuzfGG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b92842410a14465a0e71bb9acd64596c1541d3b3a7ffd1a659b9e4614386308",
+				"DiscoKey":   "discokey:c032b6b6888b71df493b18a277a0d2f20f280717c59af7c1f1c72bdb769c7b4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:40575", "10.65.0.27:40575", "172.17.0.1:40575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-04-29T10:37:11.740883692Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8667026658105573,
+				"StableID":   "nWVRwR6KgA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2445a32fdd2290631fb4c48fc8e14893aabc558a84cb192e1d13ec9868fa9136",
+				"DiscoKey":   "discokey:f2ddcb0abce8b8dd7d75fb599878776367200641e75e17314fbd068920a9123f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46720", "10.65.0.27:46720", "172.17.0.1:46720"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:37:12.336513932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6311013070122196,
+				"StableID":   "ndoYxUcGHr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eb18226b58bb79dc4c3c526f8eb88e7f41ae44c9019a973695576b093eea959",
+				"DiscoKey":   "discokey:c9bf4e9b9020bc9b79aa3c5efd0ae8466513c69ea2d52b86bcf1a843ddea4322",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:37:12.879412093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         736461048989189,
+				"StableID":   "n4rP1paYk611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c0b5194821bef8dea2bb3fe5823c2df4e2effb43c283852003d3d9b195ee156",
+				"DiscoKey":   "discokey:894945b756d14352c21ded55d19ca9d2bdfffd6ac7d04c3b8072573d2af03e19",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50776", "10.65.0.27:50776", "172.17.0.1:50776"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:37:13.36837485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2284538893417771,
+				"StableID":   "nEJayqxfqJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea10bbbd8b5a1b7516a0504210cf8f425e65ab38d147aa51a8f2b6530dfb3433",
+				"DiscoKey":   "discokey:1e18bb3ce1cd7bc3edbb8719a4f277670578ce6f377b71bfcdce3d22a9b3012c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:54687", "10.65.0.27:54687", "172.17.0.1:54687"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:37:13.898365139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1392263296418239,
+				"StableID":   "nvJXvxPZsB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bc4120981bc4c4e53b47df956708d08cfc2705e38937d775cd9a85009b65c20",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:e4f0a75739178486bb1f4d6de939224eb514645fc39c9fd876c74495c3069407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45519", "10.65.0.27:45519", "172.17.0.1:45519"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:37:14.478923535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7803420051703008,
+				"StableID":   "nDMvQXcBw321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd849edeb8074e4b10e317a66771ac3667e9db59f3b587a604d9e2aa7509ea04",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:0cd91dc17c8ed1d0a79b887dce785e84a05c4515d811b72fded4d7282c370e41",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59292", "10.65.0.27:59292", "172.17.0.1:59292"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:37:14.994061648Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4947965436736474,
+				"StableID":   "nZeh8Pfwdf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ad8a1d9a17eccfe183cc852d00c2ed5bd0119fc90a661ec52465af89e9e7984f",
+				"KeyExpiry":  "2026-10-26T10:37:15Z",
+				"DiscoKey":   "discokey:9dda5a367574c2ff8f6e1ca34a446b5bbc9faaacff27dd81769def363886335d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59342", "10.65.0.27:59342", "172.17.0.1:59342"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:37:15.529441336Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8348306496752619": {
+				"ID":          8348306496752619,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5929189856736284,
+				"StableID":   "nPAp5HmLJo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       5929189856736284,
+				"Key":        "nodekey:3bf658ed4080adc6fe4dc9b7c37a8e69d4b0c63ae9b394244cd9ac80c8171671",
+				"DiscoKey":   "discokey:57421e94d25e0bcd2816149272418869d5bb17e73fd63c15e976ec2aeb4c670e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56453", "10.65.0.27:56453", "172.17.0.1:56453"],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:37:07.975665979Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3bf658ed4080adc6fe4dc9b7c37a8e69d4b0c63ae9b394244cd9ac80c8171671",
+			"MachineKey": "mkey:167d9ded61deb5ab3a6c287e3647ba35ebaf57877590f7dd7fad66f4fc221145",
+			"Peers": [{
+				"ID":         8348306496752619,
+				"StableID":   "nvvkgcrxB821CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f19a42efb93765bb12f0835af513179e374740e70e6da961d85d5ad0179f652",
+				"DiscoKey":   "discokey:a34fc7e0a237ac96888f00d22312f91de3f8710a8b51b99d826e1a109bd3a527",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48392", "10.65.0.27:48392", "172.17.0.1:48392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-04-29T10:37:08.600288499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3815936141756581,
+				"StableID":   "nzVgnxAFoW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1077a122e095de6dbd6fcdd256cc59cae2cb865fb39808f2b7fdf894002f597e",
+				"DiscoKey":   "discokey:7fb808aeb38f320cf08a74df37451f8567de5a34679856ac987ff0a50a65f530",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:37:09.082860078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8723586042244426,
+				"StableID":   "nyc639pv7B21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fce7ddc34fa31ab8d4a14d2208bf512f2873f5f80a7dd606612223eab242a804",
+				"DiscoKey":   "discokey:eda3fff8e661d72db3f6601ba7e58dc039b6b6ef3e2954fac1a44f10d638c504",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37990", "10.65.0.27:37990", "172.17.0.1:37990"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-04-29T10:37:09.591475371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2355217814779799,
+				"StableID":   "nzaCEYagPK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03681e64541003cc91c3fa0320d1b279259a801c7408307ca9f3c3646618f621",
+				"DiscoKey":   "discokey:8f78666b0546b1edbfa4058bac8296c5e13fff1f0580affbfa2fd73fca1ef40c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:47345", "10.65.0.27:47345", "172.17.0.1:47345"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-04-29T10:37:10.206713507Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1237546863892983,
+				"StableID":   "nc7mawFVfA11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:099ec6871bace965661a73025385b5c72a7997436196b5bc1b97db77b945625e",
+				"DiscoKey":   "discokey:552d917d18f3216ad42671758af9b130d38c15cee69278a264cc99d43533aa11",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:48096", "10.65.0.27:48096", "172.17.0.1:48096"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-04-29T10:37:10.729355923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5252274305086416,
+				"StableID":   "nhKnmhLm1i11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:768788310560e7083962a2a7af6f63f7aa6013317b83428c2ec0ce27fdbb1b65",
+				"DiscoKey":   "discokey:814f92740a9942bf59da5e59243c7f732e5a276399caee6ff44e0e11606f7a29",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52846", "10.65.0.27:52846", "172.17.0.1:52846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-04-29T10:37:11.221902163Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1955550606113046,
+				"StableID":   "nmQSbuzfGG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b92842410a14465a0e71bb9acd64596c1541d3b3a7ffd1a659b9e4614386308",
+				"DiscoKey":   "discokey:c032b6b6888b71df493b18a277a0d2f20f280717c59af7c1f1c72bdb769c7b4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:40575", "10.65.0.27:40575", "172.17.0.1:40575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-04-29T10:37:11.740883692Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8667026658105573,
+				"StableID":   "nWVRwR6KgA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2445a32fdd2290631fb4c48fc8e14893aabc558a84cb192e1d13ec9868fa9136",
+				"DiscoKey":   "discokey:f2ddcb0abce8b8dd7d75fb599878776367200641e75e17314fbd068920a9123f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46720", "10.65.0.27:46720", "172.17.0.1:46720"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:37:12.336513932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6311013070122196,
+				"StableID":   "ndoYxUcGHr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eb18226b58bb79dc4c3c526f8eb88e7f41ae44c9019a973695576b093eea959",
+				"DiscoKey":   "discokey:c9bf4e9b9020bc9b79aa3c5efd0ae8466513c69ea2d52b86bcf1a843ddea4322",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:37:12.879412093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         736461048989189,
+				"StableID":   "n4rP1paYk611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c0b5194821bef8dea2bb3fe5823c2df4e2effb43c283852003d3d9b195ee156",
+				"DiscoKey":   "discokey:894945b756d14352c21ded55d19ca9d2bdfffd6ac7d04c3b8072573d2af03e19",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50776", "10.65.0.27:50776", "172.17.0.1:50776"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:37:13.36837485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2284538893417771,
+				"StableID":   "nEJayqxfqJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea10bbbd8b5a1b7516a0504210cf8f425e65ab38d147aa51a8f2b6530dfb3433",
+				"DiscoKey":   "discokey:1e18bb3ce1cd7bc3edbb8719a4f277670578ce6f377b71bfcdce3d22a9b3012c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:54687", "10.65.0.27:54687", "172.17.0.1:54687"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:37:13.898365139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1392263296418239,
+				"StableID":   "nvJXvxPZsB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bc4120981bc4c4e53b47df956708d08cfc2705e38937d775cd9a85009b65c20",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:e4f0a75739178486bb1f4d6de939224eb514645fc39c9fd876c74495c3069407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45519", "10.65.0.27:45519", "172.17.0.1:45519"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:37:14.478923535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7803420051703008,
+				"StableID":   "nDMvQXcBw321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd849edeb8074e4b10e317a66771ac3667e9db59f3b587a604d9e2aa7509ea04",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:0cd91dc17c8ed1d0a79b887dce785e84a05c4515d811b72fded4d7282c370e41",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59292", "10.65.0.27:59292", "172.17.0.1:59292"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:37:14.994061648Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4947965436736474,
+				"StableID":   "nZeh8Pfwdf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ad8a1d9a17eccfe183cc852d00c2ed5bd0119fc90a661ec52465af89e9e7984f",
+				"KeyExpiry":  "2026-10-26T10:37:15Z",
+				"DiscoKey":   "discokey:9dda5a367574c2ff8f6e1ca34a446b5bbc9faaacff27dd81769def363886335d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59342", "10.65.0.27:59342", "172.17.0.1:59342"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:37:15.529441336Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5929189856736284": {
+				"ID":          5929189856736284,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2355217814779799,
+				"StableID":   "nzaCEYagPK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       2355217814779799,
+				"Key":        "nodekey:03681e64541003cc91c3fa0320d1b279259a801c7408307ca9f3c3646618f621",
+				"DiscoKey":   "discokey:8f78666b0546b1edbfa4058bac8296c5e13fff1f0580affbfa2fd73fca1ef40c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:47345", "10.65.0.27:47345", "172.17.0.1:47345"],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:37:10.206713507Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:03681e64541003cc91c3fa0320d1b279259a801c7408307ca9f3c3646618f621",
+			"MachineKey": "mkey:9e10a049bff4f25990bebdddea44b94d86e1cdff222facf40f6ded197acd0a7c",
+			"Peers": [{
+				"ID":         5929189856736284,
+				"StableID":   "nPAp5HmLJo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3bf658ed4080adc6fe4dc9b7c37a8e69d4b0c63ae9b394244cd9ac80c8171671",
+				"DiscoKey":   "discokey:57421e94d25e0bcd2816149272418869d5bb17e73fd63c15e976ec2aeb4c670e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56453", "10.65.0.27:56453", "172.17.0.1:56453"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-04-29T10:37:07.975665979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8348306496752619,
+				"StableID":   "nvvkgcrxB821CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f19a42efb93765bb12f0835af513179e374740e70e6da961d85d5ad0179f652",
+				"DiscoKey":   "discokey:a34fc7e0a237ac96888f00d22312f91de3f8710a8b51b99d826e1a109bd3a527",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48392", "10.65.0.27:48392", "172.17.0.1:48392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-04-29T10:37:08.600288499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3815936141756581,
+				"StableID":   "nzVgnxAFoW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1077a122e095de6dbd6fcdd256cc59cae2cb865fb39808f2b7fdf894002f597e",
+				"DiscoKey":   "discokey:7fb808aeb38f320cf08a74df37451f8567de5a34679856ac987ff0a50a65f530",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:37:09.082860078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8723586042244426,
+				"StableID":   "nyc639pv7B21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fce7ddc34fa31ab8d4a14d2208bf512f2873f5f80a7dd606612223eab242a804",
+				"DiscoKey":   "discokey:eda3fff8e661d72db3f6601ba7e58dc039b6b6ef3e2954fac1a44f10d638c504",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37990", "10.65.0.27:37990", "172.17.0.1:37990"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-04-29T10:37:09.591475371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1237546863892983,
+				"StableID":   "nc7mawFVfA11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:099ec6871bace965661a73025385b5c72a7997436196b5bc1b97db77b945625e",
+				"DiscoKey":   "discokey:552d917d18f3216ad42671758af9b130d38c15cee69278a264cc99d43533aa11",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:48096", "10.65.0.27:48096", "172.17.0.1:48096"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-04-29T10:37:10.729355923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5252274305086416,
+				"StableID":   "nhKnmhLm1i11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:768788310560e7083962a2a7af6f63f7aa6013317b83428c2ec0ce27fdbb1b65",
+				"DiscoKey":   "discokey:814f92740a9942bf59da5e59243c7f732e5a276399caee6ff44e0e11606f7a29",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52846", "10.65.0.27:52846", "172.17.0.1:52846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-04-29T10:37:11.221902163Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1955550606113046,
+				"StableID":   "nmQSbuzfGG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b92842410a14465a0e71bb9acd64596c1541d3b3a7ffd1a659b9e4614386308",
+				"DiscoKey":   "discokey:c032b6b6888b71df493b18a277a0d2f20f280717c59af7c1f1c72bdb769c7b4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:40575", "10.65.0.27:40575", "172.17.0.1:40575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-04-29T10:37:11.740883692Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8667026658105573,
+				"StableID":   "nWVRwR6KgA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2445a32fdd2290631fb4c48fc8e14893aabc558a84cb192e1d13ec9868fa9136",
+				"DiscoKey":   "discokey:f2ddcb0abce8b8dd7d75fb599878776367200641e75e17314fbd068920a9123f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46720", "10.65.0.27:46720", "172.17.0.1:46720"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:37:12.336513932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6311013070122196,
+				"StableID":   "ndoYxUcGHr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eb18226b58bb79dc4c3c526f8eb88e7f41ae44c9019a973695576b093eea959",
+				"DiscoKey":   "discokey:c9bf4e9b9020bc9b79aa3c5efd0ae8466513c69ea2d52b86bcf1a843ddea4322",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:37:12.879412093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         736461048989189,
+				"StableID":   "n4rP1paYk611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c0b5194821bef8dea2bb3fe5823c2df4e2effb43c283852003d3d9b195ee156",
+				"DiscoKey":   "discokey:894945b756d14352c21ded55d19ca9d2bdfffd6ac7d04c3b8072573d2af03e19",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50776", "10.65.0.27:50776", "172.17.0.1:50776"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:37:13.36837485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2284538893417771,
+				"StableID":   "nEJayqxfqJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea10bbbd8b5a1b7516a0504210cf8f425e65ab38d147aa51a8f2b6530dfb3433",
+				"DiscoKey":   "discokey:1e18bb3ce1cd7bc3edbb8719a4f277670578ce6f377b71bfcdce3d22a9b3012c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:54687", "10.65.0.27:54687", "172.17.0.1:54687"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:37:13.898365139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1392263296418239,
+				"StableID":   "nvJXvxPZsB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bc4120981bc4c4e53b47df956708d08cfc2705e38937d775cd9a85009b65c20",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:e4f0a75739178486bb1f4d6de939224eb514645fc39c9fd876c74495c3069407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45519", "10.65.0.27:45519", "172.17.0.1:45519"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:37:14.478923535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7803420051703008,
+				"StableID":   "nDMvQXcBw321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd849edeb8074e4b10e317a66771ac3667e9db59f3b587a604d9e2aa7509ea04",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:0cd91dc17c8ed1d0a79b887dce785e84a05c4515d811b72fded4d7282c370e41",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59292", "10.65.0.27:59292", "172.17.0.1:59292"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:37:14.994061648Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4947965436736474,
+				"StableID":   "nZeh8Pfwdf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ad8a1d9a17eccfe183cc852d00c2ed5bd0119fc90a661ec52465af89e9e7984f",
+				"KeyExpiry":  "2026-10-26T10:37:15Z",
+				"DiscoKey":   "discokey:9dda5a367574c2ff8f6e1ca34a446b5bbc9faaacff27dd81769def363886335d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59342", "10.65.0.27:59342", "172.17.0.1:59342"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:37:15.529441336Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2355217814779799": {
+				"ID":          2355217814779799,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8723586042244426,
+				"StableID":   "nyc639pv7B21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       8723586042244426,
+				"Key":        "nodekey:fce7ddc34fa31ab8d4a14d2208bf512f2873f5f80a7dd606612223eab242a804",
+				"DiscoKey":   "discokey:eda3fff8e661d72db3f6601ba7e58dc039b6b6ef3e2954fac1a44f10d638c504",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37990", "10.65.0.27:37990", "172.17.0.1:37990"],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:37:09.591475371Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fce7ddc34fa31ab8d4a14d2208bf512f2873f5f80a7dd606612223eab242a804",
+			"MachineKey": "mkey:6e1c64f626fd8a0cd81d4450e3d00895c74abb1b6b365d1da1381fecf04cd363",
+			"Peers": [{
+				"ID":         5929189856736284,
+				"StableID":   "nPAp5HmLJo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3bf658ed4080adc6fe4dc9b7c37a8e69d4b0c63ae9b394244cd9ac80c8171671",
+				"DiscoKey":   "discokey:57421e94d25e0bcd2816149272418869d5bb17e73fd63c15e976ec2aeb4c670e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56453", "10.65.0.27:56453", "172.17.0.1:56453"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-04-29T10:37:07.975665979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8348306496752619,
+				"StableID":   "nvvkgcrxB821CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f19a42efb93765bb12f0835af513179e374740e70e6da961d85d5ad0179f652",
+				"DiscoKey":   "discokey:a34fc7e0a237ac96888f00d22312f91de3f8710a8b51b99d826e1a109bd3a527",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48392", "10.65.0.27:48392", "172.17.0.1:48392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-04-29T10:37:08.600288499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3815936141756581,
+				"StableID":   "nzVgnxAFoW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1077a122e095de6dbd6fcdd256cc59cae2cb865fb39808f2b7fdf894002f597e",
+				"DiscoKey":   "discokey:7fb808aeb38f320cf08a74df37451f8567de5a34679856ac987ff0a50a65f530",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:37:09.082860078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2355217814779799,
+				"StableID":   "nzaCEYagPK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03681e64541003cc91c3fa0320d1b279259a801c7408307ca9f3c3646618f621",
+				"DiscoKey":   "discokey:8f78666b0546b1edbfa4058bac8296c5e13fff1f0580affbfa2fd73fca1ef40c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:47345", "10.65.0.27:47345", "172.17.0.1:47345"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-04-29T10:37:10.206713507Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1237546863892983,
+				"StableID":   "nc7mawFVfA11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:099ec6871bace965661a73025385b5c72a7997436196b5bc1b97db77b945625e",
+				"DiscoKey":   "discokey:552d917d18f3216ad42671758af9b130d38c15cee69278a264cc99d43533aa11",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:48096", "10.65.0.27:48096", "172.17.0.1:48096"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-04-29T10:37:10.729355923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5252274305086416,
+				"StableID":   "nhKnmhLm1i11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:768788310560e7083962a2a7af6f63f7aa6013317b83428c2ec0ce27fdbb1b65",
+				"DiscoKey":   "discokey:814f92740a9942bf59da5e59243c7f732e5a276399caee6ff44e0e11606f7a29",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52846", "10.65.0.27:52846", "172.17.0.1:52846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-04-29T10:37:11.221902163Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1955550606113046,
+				"StableID":   "nmQSbuzfGG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b92842410a14465a0e71bb9acd64596c1541d3b3a7ffd1a659b9e4614386308",
+				"DiscoKey":   "discokey:c032b6b6888b71df493b18a277a0d2f20f280717c59af7c1f1c72bdb769c7b4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:40575", "10.65.0.27:40575", "172.17.0.1:40575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-04-29T10:37:11.740883692Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8667026658105573,
+				"StableID":   "nWVRwR6KgA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2445a32fdd2290631fb4c48fc8e14893aabc558a84cb192e1d13ec9868fa9136",
+				"DiscoKey":   "discokey:f2ddcb0abce8b8dd7d75fb599878776367200641e75e17314fbd068920a9123f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46720", "10.65.0.27:46720", "172.17.0.1:46720"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:37:12.336513932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6311013070122196,
+				"StableID":   "ndoYxUcGHr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eb18226b58bb79dc4c3c526f8eb88e7f41ae44c9019a973695576b093eea959",
+				"DiscoKey":   "discokey:c9bf4e9b9020bc9b79aa3c5efd0ae8466513c69ea2d52b86bcf1a843ddea4322",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:37:12.879412093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         736461048989189,
+				"StableID":   "n4rP1paYk611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c0b5194821bef8dea2bb3fe5823c2df4e2effb43c283852003d3d9b195ee156",
+				"DiscoKey":   "discokey:894945b756d14352c21ded55d19ca9d2bdfffd6ac7d04c3b8072573d2af03e19",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50776", "10.65.0.27:50776", "172.17.0.1:50776"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:37:13.36837485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2284538893417771,
+				"StableID":   "nEJayqxfqJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea10bbbd8b5a1b7516a0504210cf8f425e65ab38d147aa51a8f2b6530dfb3433",
+				"DiscoKey":   "discokey:1e18bb3ce1cd7bc3edbb8719a4f277670578ce6f377b71bfcdce3d22a9b3012c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:54687", "10.65.0.27:54687", "172.17.0.1:54687"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:37:13.898365139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1392263296418239,
+				"StableID":   "nvJXvxPZsB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bc4120981bc4c4e53b47df956708d08cfc2705e38937d775cd9a85009b65c20",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:e4f0a75739178486bb1f4d6de939224eb514645fc39c9fd876c74495c3069407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45519", "10.65.0.27:45519", "172.17.0.1:45519"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:37:14.478923535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7803420051703008,
+				"StableID":   "nDMvQXcBw321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd849edeb8074e4b10e317a66771ac3667e9db59f3b587a604d9e2aa7509ea04",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:0cd91dc17c8ed1d0a79b887dce785e84a05c4515d811b72fded4d7282c370e41",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59292", "10.65.0.27:59292", "172.17.0.1:59292"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:37:14.994061648Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4947965436736474,
+				"StableID":   "nZeh8Pfwdf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ad8a1d9a17eccfe183cc852d00c2ed5bd0119fc90a661ec52465af89e9e7984f",
+				"KeyExpiry":  "2026-10-26T10:37:15Z",
+				"DiscoKey":   "discokey:9dda5a367574c2ff8f6e1ca34a446b5bbc9faaacff27dd81769def363886335d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59342", "10.65.0.27:59342", "172.17.0.1:59342"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:37:15.529441336Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8723586042244426": {
+				"ID":          8723586042244426,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5252274305086416,
+				"StableID":   "nhKnmhLm1i11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       5252274305086416,
+				"Key":        "nodekey:768788310560e7083962a2a7af6f63f7aa6013317b83428c2ec0ce27fdbb1b65",
+				"DiscoKey":   "discokey:814f92740a9942bf59da5e59243c7f732e5a276399caee6ff44e0e11606f7a29",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52846", "10.65.0.27:52846", "172.17.0.1:52846"],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:37:11.221902163Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:768788310560e7083962a2a7af6f63f7aa6013317b83428c2ec0ce27fdbb1b65",
+			"MachineKey": "mkey:669e40f3816c851ea16408c479eb6f27a1263595392acf2fc8d44dd029ea0a2d",
+			"Peers": [{
+				"ID":         5929189856736284,
+				"StableID":   "nPAp5HmLJo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3bf658ed4080adc6fe4dc9b7c37a8e69d4b0c63ae9b394244cd9ac80c8171671",
+				"DiscoKey":   "discokey:57421e94d25e0bcd2816149272418869d5bb17e73fd63c15e976ec2aeb4c670e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56453", "10.65.0.27:56453", "172.17.0.1:56453"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-04-29T10:37:07.975665979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8348306496752619,
+				"StableID":   "nvvkgcrxB821CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f19a42efb93765bb12f0835af513179e374740e70e6da961d85d5ad0179f652",
+				"DiscoKey":   "discokey:a34fc7e0a237ac96888f00d22312f91de3f8710a8b51b99d826e1a109bd3a527",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48392", "10.65.0.27:48392", "172.17.0.1:48392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-04-29T10:37:08.600288499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3815936141756581,
+				"StableID":   "nzVgnxAFoW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1077a122e095de6dbd6fcdd256cc59cae2cb865fb39808f2b7fdf894002f597e",
+				"DiscoKey":   "discokey:7fb808aeb38f320cf08a74df37451f8567de5a34679856ac987ff0a50a65f530",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:37:09.082860078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8723586042244426,
+				"StableID":   "nyc639pv7B21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fce7ddc34fa31ab8d4a14d2208bf512f2873f5f80a7dd606612223eab242a804",
+				"DiscoKey":   "discokey:eda3fff8e661d72db3f6601ba7e58dc039b6b6ef3e2954fac1a44f10d638c504",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37990", "10.65.0.27:37990", "172.17.0.1:37990"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-04-29T10:37:09.591475371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2355217814779799,
+				"StableID":   "nzaCEYagPK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03681e64541003cc91c3fa0320d1b279259a801c7408307ca9f3c3646618f621",
+				"DiscoKey":   "discokey:8f78666b0546b1edbfa4058bac8296c5e13fff1f0580affbfa2fd73fca1ef40c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:47345", "10.65.0.27:47345", "172.17.0.1:47345"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-04-29T10:37:10.206713507Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1237546863892983,
+				"StableID":   "nc7mawFVfA11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:099ec6871bace965661a73025385b5c72a7997436196b5bc1b97db77b945625e",
+				"DiscoKey":   "discokey:552d917d18f3216ad42671758af9b130d38c15cee69278a264cc99d43533aa11",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:48096", "10.65.0.27:48096", "172.17.0.1:48096"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-04-29T10:37:10.729355923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1955550606113046,
+				"StableID":   "nmQSbuzfGG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b92842410a14465a0e71bb9acd64596c1541d3b3a7ffd1a659b9e4614386308",
+				"DiscoKey":   "discokey:c032b6b6888b71df493b18a277a0d2f20f280717c59af7c1f1c72bdb769c7b4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:40575", "10.65.0.27:40575", "172.17.0.1:40575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-04-29T10:37:11.740883692Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8667026658105573,
+				"StableID":   "nWVRwR6KgA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2445a32fdd2290631fb4c48fc8e14893aabc558a84cb192e1d13ec9868fa9136",
+				"DiscoKey":   "discokey:f2ddcb0abce8b8dd7d75fb599878776367200641e75e17314fbd068920a9123f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46720", "10.65.0.27:46720", "172.17.0.1:46720"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:37:12.336513932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6311013070122196,
+				"StableID":   "ndoYxUcGHr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eb18226b58bb79dc4c3c526f8eb88e7f41ae44c9019a973695576b093eea959",
+				"DiscoKey":   "discokey:c9bf4e9b9020bc9b79aa3c5efd0ae8466513c69ea2d52b86bcf1a843ddea4322",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:37:12.879412093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         736461048989189,
+				"StableID":   "n4rP1paYk611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c0b5194821bef8dea2bb3fe5823c2df4e2effb43c283852003d3d9b195ee156",
+				"DiscoKey":   "discokey:894945b756d14352c21ded55d19ca9d2bdfffd6ac7d04c3b8072573d2af03e19",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50776", "10.65.0.27:50776", "172.17.0.1:50776"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:37:13.36837485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2284538893417771,
+				"StableID":   "nEJayqxfqJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea10bbbd8b5a1b7516a0504210cf8f425e65ab38d147aa51a8f2b6530dfb3433",
+				"DiscoKey":   "discokey:1e18bb3ce1cd7bc3edbb8719a4f277670578ce6f377b71bfcdce3d22a9b3012c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:54687", "10.65.0.27:54687", "172.17.0.1:54687"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:37:13.898365139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1392263296418239,
+				"StableID":   "nvJXvxPZsB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bc4120981bc4c4e53b47df956708d08cfc2705e38937d775cd9a85009b65c20",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:e4f0a75739178486bb1f4d6de939224eb514645fc39c9fd876c74495c3069407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45519", "10.65.0.27:45519", "172.17.0.1:45519"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:37:14.478923535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7803420051703008,
+				"StableID":   "nDMvQXcBw321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd849edeb8074e4b10e317a66771ac3667e9db59f3b587a604d9e2aa7509ea04",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:0cd91dc17c8ed1d0a79b887dce785e84a05c4515d811b72fded4d7282c370e41",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59292", "10.65.0.27:59292", "172.17.0.1:59292"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:37:14.994061648Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4947965436736474,
+				"StableID":   "nZeh8Pfwdf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ad8a1d9a17eccfe183cc852d00c2ed5bd0119fc90a661ec52465af89e9e7984f",
+				"KeyExpiry":  "2026-10-26T10:37:15Z",
+				"DiscoKey":   "discokey:9dda5a367574c2ff8f6e1ca34a446b5bbc9faaacff27dd81769def363886335d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59342", "10.65.0.27:59342", "172.17.0.1:59342"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:37:15.529441336Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5252274305086416": {
+				"ID":          5252274305086416,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8667026658105573,
+				"StableID":   "nWVRwR6KgA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       8667026658105573,
+				"Key":        "nodekey:2445a32fdd2290631fb4c48fc8e14893aabc558a84cb192e1d13ec9868fa9136",
+				"DiscoKey":   "discokey:f2ddcb0abce8b8dd7d75fb599878776367200641e75e17314fbd068920a9123f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46720", "10.65.0.27:46720", "172.17.0.1:46720"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:37:12.336513932Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2445a32fdd2290631fb4c48fc8e14893aabc558a84cb192e1d13ec9868fa9136",
+			"MachineKey": "mkey:b7f7c1fd89a4d9aee3c858eb52eeed3031996996e420bdd8a64f9cddde085161",
+			"Peers": [{
+				"ID":         5929189856736284,
+				"StableID":   "nPAp5HmLJo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3bf658ed4080adc6fe4dc9b7c37a8e69d4b0c63ae9b394244cd9ac80c8171671",
+				"DiscoKey":   "discokey:57421e94d25e0bcd2816149272418869d5bb17e73fd63c15e976ec2aeb4c670e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56453", "10.65.0.27:56453", "172.17.0.1:56453"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-04-29T10:37:07.975665979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8348306496752619,
+				"StableID":   "nvvkgcrxB821CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f19a42efb93765bb12f0835af513179e374740e70e6da961d85d5ad0179f652",
+				"DiscoKey":   "discokey:a34fc7e0a237ac96888f00d22312f91de3f8710a8b51b99d826e1a109bd3a527",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48392", "10.65.0.27:48392", "172.17.0.1:48392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-04-29T10:37:08.600288499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3815936141756581,
+				"StableID":   "nzVgnxAFoW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1077a122e095de6dbd6fcdd256cc59cae2cb865fb39808f2b7fdf894002f597e",
+				"DiscoKey":   "discokey:7fb808aeb38f320cf08a74df37451f8567de5a34679856ac987ff0a50a65f530",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:37:09.082860078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8723586042244426,
+				"StableID":   "nyc639pv7B21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fce7ddc34fa31ab8d4a14d2208bf512f2873f5f80a7dd606612223eab242a804",
+				"DiscoKey":   "discokey:eda3fff8e661d72db3f6601ba7e58dc039b6b6ef3e2954fac1a44f10d638c504",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37990", "10.65.0.27:37990", "172.17.0.1:37990"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-04-29T10:37:09.591475371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2355217814779799,
+				"StableID":   "nzaCEYagPK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03681e64541003cc91c3fa0320d1b279259a801c7408307ca9f3c3646618f621",
+				"DiscoKey":   "discokey:8f78666b0546b1edbfa4058bac8296c5e13fff1f0580affbfa2fd73fca1ef40c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:47345", "10.65.0.27:47345", "172.17.0.1:47345"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-04-29T10:37:10.206713507Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1237546863892983,
+				"StableID":   "nc7mawFVfA11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:099ec6871bace965661a73025385b5c72a7997436196b5bc1b97db77b945625e",
+				"DiscoKey":   "discokey:552d917d18f3216ad42671758af9b130d38c15cee69278a264cc99d43533aa11",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:48096", "10.65.0.27:48096", "172.17.0.1:48096"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-04-29T10:37:10.729355923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5252274305086416,
+				"StableID":   "nhKnmhLm1i11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:768788310560e7083962a2a7af6f63f7aa6013317b83428c2ec0ce27fdbb1b65",
+				"DiscoKey":   "discokey:814f92740a9942bf59da5e59243c7f732e5a276399caee6ff44e0e11606f7a29",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52846", "10.65.0.27:52846", "172.17.0.1:52846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-04-29T10:37:11.221902163Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1955550606113046,
+				"StableID":   "nmQSbuzfGG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b92842410a14465a0e71bb9acd64596c1541d3b3a7ffd1a659b9e4614386308",
+				"DiscoKey":   "discokey:c032b6b6888b71df493b18a277a0d2f20f280717c59af7c1f1c72bdb769c7b4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:40575", "10.65.0.27:40575", "172.17.0.1:40575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-04-29T10:37:11.740883692Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6311013070122196,
+				"StableID":   "ndoYxUcGHr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eb18226b58bb79dc4c3c526f8eb88e7f41ae44c9019a973695576b093eea959",
+				"DiscoKey":   "discokey:c9bf4e9b9020bc9b79aa3c5efd0ae8466513c69ea2d52b86bcf1a843ddea4322",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:37:12.879412093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         736461048989189,
+				"StableID":   "n4rP1paYk611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c0b5194821bef8dea2bb3fe5823c2df4e2effb43c283852003d3d9b195ee156",
+				"DiscoKey":   "discokey:894945b756d14352c21ded55d19ca9d2bdfffd6ac7d04c3b8072573d2af03e19",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50776", "10.65.0.27:50776", "172.17.0.1:50776"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:37:13.36837485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2284538893417771,
+				"StableID":   "nEJayqxfqJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea10bbbd8b5a1b7516a0504210cf8f425e65ab38d147aa51a8f2b6530dfb3433",
+				"DiscoKey":   "discokey:1e18bb3ce1cd7bc3edbb8719a4f277670578ce6f377b71bfcdce3d22a9b3012c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:54687", "10.65.0.27:54687", "172.17.0.1:54687"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:37:13.898365139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1392263296418239,
+				"StableID":   "nvJXvxPZsB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bc4120981bc4c4e53b47df956708d08cfc2705e38937d775cd9a85009b65c20",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:e4f0a75739178486bb1f4d6de939224eb514645fc39c9fd876c74495c3069407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45519", "10.65.0.27:45519", "172.17.0.1:45519"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:37:14.478923535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7803420051703008,
+				"StableID":   "nDMvQXcBw321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd849edeb8074e4b10e317a66771ac3667e9db59f3b587a604d9e2aa7509ea04",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:0cd91dc17c8ed1d0a79b887dce785e84a05c4515d811b72fded4d7282c370e41",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59292", "10.65.0.27:59292", "172.17.0.1:59292"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:37:14.994061648Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4947965436736474,
+				"StableID":   "nZeh8Pfwdf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ad8a1d9a17eccfe183cc852d00c2ed5bd0119fc90a661ec52465af89e9e7984f",
+				"KeyExpiry":  "2026-10-26T10:37:15Z",
+				"DiscoKey":   "discokey:9dda5a367574c2ff8f6e1ca34a446b5bbc9faaacff27dd81769def363886335d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59342", "10.65.0.27:59342", "172.17.0.1:59342"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:37:15.529441336Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8667026658105573": {
+				"ID":          8667026658105573,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7803420051703008,
+				"StableID":   "nDMvQXcBw321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd849edeb8074e4b10e317a66771ac3667e9db59f3b587a604d9e2aa7509ea04",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:0cd91dc17c8ed1d0a79b887dce785e84a05c4515d811b72fded4d7282c370e41",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59292", "10.65.0.27:59292", "172.17.0.1:59292"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:37:14.994061648Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fd849edeb8074e4b10e317a66771ac3667e9db59f3b587a604d9e2aa7509ea04",
+			"MachineKey": "mkey:162de2de297393f8ef9f64463ab7159be34de8d2f417616e80c5ee982ff8873b",
+			"Peers": [{
+				"ID":         5929189856736284,
+				"StableID":   "nPAp5HmLJo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3bf658ed4080adc6fe4dc9b7c37a8e69d4b0c63ae9b394244cd9ac80c8171671",
+				"DiscoKey":   "discokey:57421e94d25e0bcd2816149272418869d5bb17e73fd63c15e976ec2aeb4c670e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56453", "10.65.0.27:56453", "172.17.0.1:56453"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-04-29T10:37:07.975665979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8348306496752619,
+				"StableID":   "nvvkgcrxB821CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f19a42efb93765bb12f0835af513179e374740e70e6da961d85d5ad0179f652",
+				"DiscoKey":   "discokey:a34fc7e0a237ac96888f00d22312f91de3f8710a8b51b99d826e1a109bd3a527",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48392", "10.65.0.27:48392", "172.17.0.1:48392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-04-29T10:37:08.600288499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3815936141756581,
+				"StableID":   "nzVgnxAFoW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1077a122e095de6dbd6fcdd256cc59cae2cb865fb39808f2b7fdf894002f597e",
+				"DiscoKey":   "discokey:7fb808aeb38f320cf08a74df37451f8567de5a34679856ac987ff0a50a65f530",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:37:09.082860078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8723586042244426,
+				"StableID":   "nyc639pv7B21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fce7ddc34fa31ab8d4a14d2208bf512f2873f5f80a7dd606612223eab242a804",
+				"DiscoKey":   "discokey:eda3fff8e661d72db3f6601ba7e58dc039b6b6ef3e2954fac1a44f10d638c504",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37990", "10.65.0.27:37990", "172.17.0.1:37990"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-04-29T10:37:09.591475371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2355217814779799,
+				"StableID":   "nzaCEYagPK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03681e64541003cc91c3fa0320d1b279259a801c7408307ca9f3c3646618f621",
+				"DiscoKey":   "discokey:8f78666b0546b1edbfa4058bac8296c5e13fff1f0580affbfa2fd73fca1ef40c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:47345", "10.65.0.27:47345", "172.17.0.1:47345"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-04-29T10:37:10.206713507Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1237546863892983,
+				"StableID":   "nc7mawFVfA11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:099ec6871bace965661a73025385b5c72a7997436196b5bc1b97db77b945625e",
+				"DiscoKey":   "discokey:552d917d18f3216ad42671758af9b130d38c15cee69278a264cc99d43533aa11",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:48096", "10.65.0.27:48096", "172.17.0.1:48096"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-04-29T10:37:10.729355923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5252274305086416,
+				"StableID":   "nhKnmhLm1i11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:768788310560e7083962a2a7af6f63f7aa6013317b83428c2ec0ce27fdbb1b65",
+				"DiscoKey":   "discokey:814f92740a9942bf59da5e59243c7f732e5a276399caee6ff44e0e11606f7a29",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52846", "10.65.0.27:52846", "172.17.0.1:52846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-04-29T10:37:11.221902163Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1955550606113046,
+				"StableID":   "nmQSbuzfGG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b92842410a14465a0e71bb9acd64596c1541d3b3a7ffd1a659b9e4614386308",
+				"DiscoKey":   "discokey:c032b6b6888b71df493b18a277a0d2f20f280717c59af7c1f1c72bdb769c7b4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:40575", "10.65.0.27:40575", "172.17.0.1:40575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-04-29T10:37:11.740883692Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8667026658105573,
+				"StableID":   "nWVRwR6KgA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2445a32fdd2290631fb4c48fc8e14893aabc558a84cb192e1d13ec9868fa9136",
+				"DiscoKey":   "discokey:f2ddcb0abce8b8dd7d75fb599878776367200641e75e17314fbd068920a9123f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46720", "10.65.0.27:46720", "172.17.0.1:46720"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:37:12.336513932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6311013070122196,
+				"StableID":   "ndoYxUcGHr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eb18226b58bb79dc4c3c526f8eb88e7f41ae44c9019a973695576b093eea959",
+				"DiscoKey":   "discokey:c9bf4e9b9020bc9b79aa3c5efd0ae8466513c69ea2d52b86bcf1a843ddea4322",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:37:12.879412093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         736461048989189,
+				"StableID":   "n4rP1paYk611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c0b5194821bef8dea2bb3fe5823c2df4e2effb43c283852003d3d9b195ee156",
+				"DiscoKey":   "discokey:894945b756d14352c21ded55d19ca9d2bdfffd6ac7d04c3b8072573d2af03e19",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50776", "10.65.0.27:50776", "172.17.0.1:50776"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:37:13.36837485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2284538893417771,
+				"StableID":   "nEJayqxfqJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea10bbbd8b5a1b7516a0504210cf8f425e65ab38d147aa51a8f2b6530dfb3433",
+				"DiscoKey":   "discokey:1e18bb3ce1cd7bc3edbb8719a4f277670578ce6f377b71bfcdce3d22a9b3012c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:54687", "10.65.0.27:54687", "172.17.0.1:54687"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:37:13.898365139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1392263296418239,
+				"StableID":   "nvJXvxPZsB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bc4120981bc4c4e53b47df956708d08cfc2705e38937d775cd9a85009b65c20",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:e4f0a75739178486bb1f4d6de939224eb514645fc39c9fd876c74495c3069407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45519", "10.65.0.27:45519", "172.17.0.1:45519"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:37:14.478923535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4947965436736474,
+				"StableID":   "nZeh8Pfwdf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ad8a1d9a17eccfe183cc852d00c2ed5bd0119fc90a661ec52465af89e9e7984f",
+				"KeyExpiry":  "2026-10-26T10:37:15Z",
+				"DiscoKey":   "discokey:9dda5a367574c2ff8f6e1ca34a446b5bbc9faaacff27dd81769def363886335d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59342", "10.65.0.27:59342", "172.17.0.1:59342"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:37:15.529441336Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6311013070122196,
+				"StableID":   "ndoYxUcGHr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       6311013070122196,
+				"Key":        "nodekey:4eb18226b58bb79dc4c3c526f8eb88e7f41ae44c9019a973695576b093eea959",
+				"DiscoKey":   "discokey:c9bf4e9b9020bc9b79aa3c5efd0ae8466513c69ea2d52b86bcf1a843ddea4322",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:37:12.879412093Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4eb18226b58bb79dc4c3c526f8eb88e7f41ae44c9019a973695576b093eea959",
+			"MachineKey": "mkey:033f1f0024dfb6daa24ab9f171231cd4190e4ab54bd63e0e04eb9c5f8366c812",
+			"Peers": [{
+				"ID":         5929189856736284,
+				"StableID":   "nPAp5HmLJo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3bf658ed4080adc6fe4dc9b7c37a8e69d4b0c63ae9b394244cd9ac80c8171671",
+				"DiscoKey":   "discokey:57421e94d25e0bcd2816149272418869d5bb17e73fd63c15e976ec2aeb4c670e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56453", "10.65.0.27:56453", "172.17.0.1:56453"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-04-29T10:37:07.975665979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8348306496752619,
+				"StableID":   "nvvkgcrxB821CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f19a42efb93765bb12f0835af513179e374740e70e6da961d85d5ad0179f652",
+				"DiscoKey":   "discokey:a34fc7e0a237ac96888f00d22312f91de3f8710a8b51b99d826e1a109bd3a527",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48392", "10.65.0.27:48392", "172.17.0.1:48392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-04-29T10:37:08.600288499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3815936141756581,
+				"StableID":   "nzVgnxAFoW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1077a122e095de6dbd6fcdd256cc59cae2cb865fb39808f2b7fdf894002f597e",
+				"DiscoKey":   "discokey:7fb808aeb38f320cf08a74df37451f8567de5a34679856ac987ff0a50a65f530",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:37:09.082860078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8723586042244426,
+				"StableID":   "nyc639pv7B21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fce7ddc34fa31ab8d4a14d2208bf512f2873f5f80a7dd606612223eab242a804",
+				"DiscoKey":   "discokey:eda3fff8e661d72db3f6601ba7e58dc039b6b6ef3e2954fac1a44f10d638c504",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37990", "10.65.0.27:37990", "172.17.0.1:37990"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-04-29T10:37:09.591475371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2355217814779799,
+				"StableID":   "nzaCEYagPK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03681e64541003cc91c3fa0320d1b279259a801c7408307ca9f3c3646618f621",
+				"DiscoKey":   "discokey:8f78666b0546b1edbfa4058bac8296c5e13fff1f0580affbfa2fd73fca1ef40c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:47345", "10.65.0.27:47345", "172.17.0.1:47345"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-04-29T10:37:10.206713507Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1237546863892983,
+				"StableID":   "nc7mawFVfA11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:099ec6871bace965661a73025385b5c72a7997436196b5bc1b97db77b945625e",
+				"DiscoKey":   "discokey:552d917d18f3216ad42671758af9b130d38c15cee69278a264cc99d43533aa11",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:48096", "10.65.0.27:48096", "172.17.0.1:48096"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-04-29T10:37:10.729355923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5252274305086416,
+				"StableID":   "nhKnmhLm1i11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:768788310560e7083962a2a7af6f63f7aa6013317b83428c2ec0ce27fdbb1b65",
+				"DiscoKey":   "discokey:814f92740a9942bf59da5e59243c7f732e5a276399caee6ff44e0e11606f7a29",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52846", "10.65.0.27:52846", "172.17.0.1:52846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-04-29T10:37:11.221902163Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1955550606113046,
+				"StableID":   "nmQSbuzfGG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b92842410a14465a0e71bb9acd64596c1541d3b3a7ffd1a659b9e4614386308",
+				"DiscoKey":   "discokey:c032b6b6888b71df493b18a277a0d2f20f280717c59af7c1f1c72bdb769c7b4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:40575", "10.65.0.27:40575", "172.17.0.1:40575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-04-29T10:37:11.740883692Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8667026658105573,
+				"StableID":   "nWVRwR6KgA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2445a32fdd2290631fb4c48fc8e14893aabc558a84cb192e1d13ec9868fa9136",
+				"DiscoKey":   "discokey:f2ddcb0abce8b8dd7d75fb599878776367200641e75e17314fbd068920a9123f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46720", "10.65.0.27:46720", "172.17.0.1:46720"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:37:12.336513932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         736461048989189,
+				"StableID":   "n4rP1paYk611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c0b5194821bef8dea2bb3fe5823c2df4e2effb43c283852003d3d9b195ee156",
+				"DiscoKey":   "discokey:894945b756d14352c21ded55d19ca9d2bdfffd6ac7d04c3b8072573d2af03e19",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50776", "10.65.0.27:50776", "172.17.0.1:50776"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:37:13.36837485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2284538893417771,
+				"StableID":   "nEJayqxfqJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea10bbbd8b5a1b7516a0504210cf8f425e65ab38d147aa51a8f2b6530dfb3433",
+				"DiscoKey":   "discokey:1e18bb3ce1cd7bc3edbb8719a4f277670578ce6f377b71bfcdce3d22a9b3012c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:54687", "10.65.0.27:54687", "172.17.0.1:54687"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:37:13.898365139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1392263296418239,
+				"StableID":   "nvJXvxPZsB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bc4120981bc4c4e53b47df956708d08cfc2705e38937d775cd9a85009b65c20",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:e4f0a75739178486bb1f4d6de939224eb514645fc39c9fd876c74495c3069407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45519", "10.65.0.27:45519", "172.17.0.1:45519"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:37:14.478923535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7803420051703008,
+				"StableID":   "nDMvQXcBw321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd849edeb8074e4b10e317a66771ac3667e9db59f3b587a604d9e2aa7509ea04",
+				"KeyExpiry":  "2026-10-26T10:37:14Z",
+				"DiscoKey":   "discokey:0cd91dc17c8ed1d0a79b887dce785e84a05c4515d811b72fded4d7282c370e41",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59292", "10.65.0.27:59292", "172.17.0.1:59292"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:37:14.994061648Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4947965436736474,
+				"StableID":   "nZeh8Pfwdf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ad8a1d9a17eccfe183cc852d00c2ed5bd0119fc90a661ec52465af89e9e7984f",
+				"KeyExpiry":  "2026-10-26T10:37:15Z",
+				"DiscoKey":   "discokey:9dda5a367574c2ff8f6e1ca34a446b5bbc9faaacff27dd81769def363886335d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59342", "10.65.0.27:59342", "172.17.0.1:59342"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:37:15.529441336Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6311013070122196": {
+				"ID":          6311013070122196,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-accept-fail-group-src-tag-dst.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-accept-fail-group-src-tag-dst.hujson
@@ -1,0 +1,8841 @@
+// policytest-accept-fail-group-src-tag-dst
+//
+// tests block accept-fail: group src to tag dst, ACL allows different tag
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:37:51Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-accept-fail-group-src-tag-dst",
+	"description":    "tests block accept-fail: group src to tag dst, ACL allows different tag",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:37:51.487360287Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                           \n  \n                                                                   \n                                                            \n{\n\t\"id\":          \"policytest-accept-fail-group-src-tag-dst\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block accept-fail: group src to tag dst, ACL allows different tag\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"group:developers\"], \"dst\": [\"tag:client:22\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"group:developers\", \"accept\": [\"tag:server:22\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-accept-fail-group-src-tag-dst.hujson",
+		"full_policy": {"acls": [{
+			"action": "accept",
+			"dst":    ["tag:client:22"],
+			"src":    ["group:developers"]
+		}], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [{"accept": ["tag:server:22"], "src": "group:developers"}]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1342224679299359,
+				"StableID":   "nC7Hg3ytUB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1342224679299359,
+				"Key":        "nodekey:baaeee4d6ecba955826d38c0a65d04204bb5e46972ef293efa0068a90c052002",
+				"DiscoKey":   "discokey:3b3d2310587bf8a09eb1ab33f63f03c2a1bf885f039bd739821f2296c9fd356d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:43038", "10.65.0.27:43038", "172.17.0.1:43038"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:37:55.328374361Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:baaeee4d6ecba955826d38c0a65d04204bb5e46972ef293efa0068a90c052002",
+			"MachineKey": "mkey:e265fd5131c9cfe437a45ad02269e0ab062aa835db42f89ac0804e81f83e8832",
+			"Peers": [{
+				"ID":         5703417686615105,
+				"StableID":   "nSRjXT76Ym11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60fdeb9757f2dfb1e7fb9478cc37953c05aca5c3c981be087f909708770e742d",
+				"DiscoKey":   "discokey:4111f11def6b05e817c7b4e58458c15b7b70db022d652ce9382add34bf81f158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43850", "10.65.0.27:43850", "172.17.0.1:43850"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:37:53.198249654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1419611232259861,
+				"StableID":   "nJF9NEnw5C11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e1bec001054b6aee774c085a3de6620c73ce75f62e94a610bf540bdf5450165",
+				"DiscoKey":   "discokey:ff03a92308f8ffabd0d79d37289e18029111caecb1ec1ac7d1651e6ad69c2561",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47734", "10.65.0.27:47734", "172.17.0.1:47734"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:37:53.695723138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1854289521133802,
+				"StableID":   "nZJTGQ3pUF11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4641702e299ef7135708ad261c36fdd5db5cecc3b65c11134eca856a38a8a779",
+				"DiscoKey":   "discokey:de304548cd24dc351f090090b9d8ba152227e34e356bee5e741e853d19aafc46",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47851", "10.65.0.27:47851", "172.17.0.1:47851"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:37:54.264514104Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7895695545010549,
+				"StableID":   "nimrmvXye421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22f777f88a9691ece37ae2195818ebf1882cee7fc33bc722a70fbea320eaba3f",
+				"DiscoKey":   "discokey:5a14b3a18105db8f65f7497ed8698cd755a3139213bc0b591e948ae8e7a5e603",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36056", "10.65.0.27:36056", "172.17.0.1:36056"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:37:54.787035209Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4006893575424745,
+				"StableID":   "npxGJPJjHY11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2c3caf9f9094473ea186dc6240ab2d47fe57abfd969584df82961bf957bdd48",
+				"KeyExpiry":  "2026-10-26T10:37:55Z",
+				"DiscoKey":   "discokey:81325f4a8a82fc8ab661200de4caf32feb2942ab1d7dc828f8b637fc5160b019",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51649", "10.65.0.27:51649", "172.17.0.1:51649"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:37:55.8710616Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6579530214399294,
+				"StableID":   "nfZDWu6tNt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f7f67a9c5686cceeba5772a649618b968dcf663015d04617cd4dccd526152305",
+				"KeyExpiry":  "2026-10-26T10:37:56Z",
+				"DiscoKey":   "discokey:f6d85f93c3d97a79b614654cf18e3b820f07b3973bc08bc168bd9c9d575ea337",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60229", "10.65.0.27:60229", "172.17.0.1:60229"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:37:56.428202117Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1017746610960472,
+				"StableID":   "nT6GuhUww811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:048516c446ae8b1ef83a3283adfbb1c5ff7f8dd429f786778db997846979740b",
+				"KeyExpiry":  "2026-10-26T10:37:57Z",
+				"DiscoKey":   "discokey:49f9ea182a0e04c9d8fd0929c5c8e4f8137460d5ac623d79d226dabaadc9ef31",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52228", "10.65.0.27:52228", "172.17.0.1:52228"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:37:57.040858364Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1342224679299359": {
+				"ID":          1342224679299359,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1017746610960472,
+				"StableID":   "nT6GuhUww811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:048516c446ae8b1ef83a3283adfbb1c5ff7f8dd429f786778db997846979740b",
+				"KeyExpiry":  "2026-10-26T10:37:57Z",
+				"DiscoKey":   "discokey:49f9ea182a0e04c9d8fd0929c5c8e4f8137460d5ac623d79d226dabaadc9ef31",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52228", "10.65.0.27:52228", "172.17.0.1:52228"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:37:57.040858364Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:048516c446ae8b1ef83a3283adfbb1c5ff7f8dd429f786778db997846979740b",
+			"MachineKey": "mkey:694f7b0fdfe9237af86d7f911f9fd22a8d6c26d118aacfe22c0484161854ad7a",
+			"Peers": [{
+				"ID":         5703417686615105,
+				"StableID":   "nSRjXT76Ym11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60fdeb9757f2dfb1e7fb9478cc37953c05aca5c3c981be087f909708770e742d",
+				"DiscoKey":   "discokey:4111f11def6b05e817c7b4e58458c15b7b70db022d652ce9382add34bf81f158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43850", "10.65.0.27:43850", "172.17.0.1:43850"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:37:53.198249654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1419611232259861,
+				"StableID":   "nJF9NEnw5C11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e1bec001054b6aee774c085a3de6620c73ce75f62e94a610bf540bdf5450165",
+				"DiscoKey":   "discokey:ff03a92308f8ffabd0d79d37289e18029111caecb1ec1ac7d1651e6ad69c2561",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47734", "10.65.0.27:47734", "172.17.0.1:47734"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:37:53.695723138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1854289521133802,
+				"StableID":   "nZJTGQ3pUF11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4641702e299ef7135708ad261c36fdd5db5cecc3b65c11134eca856a38a8a779",
+				"DiscoKey":   "discokey:de304548cd24dc351f090090b9d8ba152227e34e356bee5e741e853d19aafc46",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47851", "10.65.0.27:47851", "172.17.0.1:47851"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:37:54.264514104Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7895695545010549,
+				"StableID":   "nimrmvXye421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22f777f88a9691ece37ae2195818ebf1882cee7fc33bc722a70fbea320eaba3f",
+				"DiscoKey":   "discokey:5a14b3a18105db8f65f7497ed8698cd755a3139213bc0b591e948ae8e7a5e603",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36056", "10.65.0.27:36056", "172.17.0.1:36056"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:37:54.787035209Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1342224679299359,
+				"StableID":   "nC7Hg3ytUB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:baaeee4d6ecba955826d38c0a65d04204bb5e46972ef293efa0068a90c052002",
+				"DiscoKey":   "discokey:3b3d2310587bf8a09eb1ab33f63f03c2a1bf885f039bd739821f2296c9fd356d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:43038", "10.65.0.27:43038", "172.17.0.1:43038"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:37:55.328374361Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4006893575424745,
+				"StableID":   "npxGJPJjHY11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2c3caf9f9094473ea186dc6240ab2d47fe57abfd969584df82961bf957bdd48",
+				"KeyExpiry":  "2026-10-26T10:37:55Z",
+				"DiscoKey":   "discokey:81325f4a8a82fc8ab661200de4caf32feb2942ab1d7dc828f8b637fc5160b019",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51649", "10.65.0.27:51649", "172.17.0.1:51649"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:37:55.8710616Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6579530214399294,
+				"StableID":   "nfZDWu6tNt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f7f67a9c5686cceeba5772a649618b968dcf663015d04617cd4dccd526152305",
+				"KeyExpiry":  "2026-10-26T10:37:56Z",
+				"DiscoKey":   "discokey:f6d85f93c3d97a79b614654cf18e3b820f07b3973bc08bc168bd9c9d575ea337",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60229", "10.65.0.27:60229", "172.17.0.1:60229"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:37:56.428202117Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5703417686615105,
+				"StableID":   "nSRjXT76Ym11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       5703417686615105,
+				"Key":        "nodekey:60fdeb9757f2dfb1e7fb9478cc37953c05aca5c3c981be087f909708770e742d",
+				"DiscoKey":   "discokey:4111f11def6b05e817c7b4e58458c15b7b70db022d652ce9382add34bf81f158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43850", "10.65.0.27:43850", "172.17.0.1:43850"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:37:53.198249654Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:60fdeb9757f2dfb1e7fb9478cc37953c05aca5c3c981be087f909708770e742d",
+			"MachineKey": "mkey:52c8871650fb824c28f9e72fc03db1cbe1bce5d7dd49fbe1856f56fb76878470",
+			"Peers": [{
+				"ID":         1419611232259861,
+				"StableID":   "nJF9NEnw5C11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e1bec001054b6aee774c085a3de6620c73ce75f62e94a610bf540bdf5450165",
+				"DiscoKey":   "discokey:ff03a92308f8ffabd0d79d37289e18029111caecb1ec1ac7d1651e6ad69c2561",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47734", "10.65.0.27:47734", "172.17.0.1:47734"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:37:53.695723138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1854289521133802,
+				"StableID":   "nZJTGQ3pUF11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4641702e299ef7135708ad261c36fdd5db5cecc3b65c11134eca856a38a8a779",
+				"DiscoKey":   "discokey:de304548cd24dc351f090090b9d8ba152227e34e356bee5e741e853d19aafc46",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47851", "10.65.0.27:47851", "172.17.0.1:47851"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:37:54.264514104Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7895695545010549,
+				"StableID":   "nimrmvXye421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22f777f88a9691ece37ae2195818ebf1882cee7fc33bc722a70fbea320eaba3f",
+				"DiscoKey":   "discokey:5a14b3a18105db8f65f7497ed8698cd755a3139213bc0b591e948ae8e7a5e603",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36056", "10.65.0.27:36056", "172.17.0.1:36056"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:37:54.787035209Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1342224679299359,
+				"StableID":   "nC7Hg3ytUB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:baaeee4d6ecba955826d38c0a65d04204bb5e46972ef293efa0068a90c052002",
+				"DiscoKey":   "discokey:3b3d2310587bf8a09eb1ab33f63f03c2a1bf885f039bd739821f2296c9fd356d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:43038", "10.65.0.27:43038", "172.17.0.1:43038"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:37:55.328374361Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4006893575424745,
+				"StableID":   "npxGJPJjHY11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2c3caf9f9094473ea186dc6240ab2d47fe57abfd969584df82961bf957bdd48",
+				"KeyExpiry":  "2026-10-26T10:37:55Z",
+				"DiscoKey":   "discokey:81325f4a8a82fc8ab661200de4caf32feb2942ab1d7dc828f8b637fc5160b019",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51649", "10.65.0.27:51649", "172.17.0.1:51649"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:37:55.8710616Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6579530214399294,
+				"StableID":   "nfZDWu6tNt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f7f67a9c5686cceeba5772a649618b968dcf663015d04617cd4dccd526152305",
+				"KeyExpiry":  "2026-10-26T10:37:56Z",
+				"DiscoKey":   "discokey:f6d85f93c3d97a79b614654cf18e3b820f07b3973bc08bc168bd9c9d575ea337",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60229", "10.65.0.27:60229", "172.17.0.1:60229"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:37:56.428202117Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1017746610960472,
+				"StableID":   "nT6GuhUww811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:048516c446ae8b1ef83a3283adfbb1c5ff7f8dd429f786778db997846979740b",
+				"KeyExpiry":  "2026-10-26T10:37:57Z",
+				"DiscoKey":   "discokey:49f9ea182a0e04c9d8fd0929c5c8e4f8137460d5ac623d79d226dabaadc9ef31",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52228", "10.65.0.27:52228", "172.17.0.1:52228"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:37:57.040858364Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5703417686615105": {
+				"ID":          5703417686615105,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4006893575424745,
+				"StableID":   "npxGJPJjHY11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2c3caf9f9094473ea186dc6240ab2d47fe57abfd969584df82961bf957bdd48",
+				"KeyExpiry":  "2026-10-26T10:37:55Z",
+				"DiscoKey":   "discokey:81325f4a8a82fc8ab661200de4caf32feb2942ab1d7dc828f8b637fc5160b019",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51649", "10.65.0.27:51649", "172.17.0.1:51649"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:37:55.8710616Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a2c3caf9f9094473ea186dc6240ab2d47fe57abfd969584df82961bf957bdd48",
+			"MachineKey": "mkey:24fb41188fe70bb09d9f000b7db1d2dc34c5aa78090d20e2963e4ab427a80454",
+			"Peers": [{
+				"ID":         5703417686615105,
+				"StableID":   "nSRjXT76Ym11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60fdeb9757f2dfb1e7fb9478cc37953c05aca5c3c981be087f909708770e742d",
+				"DiscoKey":   "discokey:4111f11def6b05e817c7b4e58458c15b7b70db022d652ce9382add34bf81f158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43850", "10.65.0.27:43850", "172.17.0.1:43850"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:37:53.198249654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1419611232259861,
+				"StableID":   "nJF9NEnw5C11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e1bec001054b6aee774c085a3de6620c73ce75f62e94a610bf540bdf5450165",
+				"DiscoKey":   "discokey:ff03a92308f8ffabd0d79d37289e18029111caecb1ec1ac7d1651e6ad69c2561",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47734", "10.65.0.27:47734", "172.17.0.1:47734"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:37:53.695723138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1854289521133802,
+				"StableID":   "nZJTGQ3pUF11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4641702e299ef7135708ad261c36fdd5db5cecc3b65c11134eca856a38a8a779",
+				"DiscoKey":   "discokey:de304548cd24dc351f090090b9d8ba152227e34e356bee5e741e853d19aafc46",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47851", "10.65.0.27:47851", "172.17.0.1:47851"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:37:54.264514104Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7895695545010549,
+				"StableID":   "nimrmvXye421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22f777f88a9691ece37ae2195818ebf1882cee7fc33bc722a70fbea320eaba3f",
+				"DiscoKey":   "discokey:5a14b3a18105db8f65f7497ed8698cd755a3139213bc0b591e948ae8e7a5e603",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36056", "10.65.0.27:36056", "172.17.0.1:36056"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:37:54.787035209Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1342224679299359,
+				"StableID":   "nC7Hg3ytUB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:baaeee4d6ecba955826d38c0a65d04204bb5e46972ef293efa0068a90c052002",
+				"DiscoKey":   "discokey:3b3d2310587bf8a09eb1ab33f63f03c2a1bf885f039bd739821f2296c9fd356d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:43038", "10.65.0.27:43038", "172.17.0.1:43038"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:37:55.328374361Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6579530214399294,
+				"StableID":   "nfZDWu6tNt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f7f67a9c5686cceeba5772a649618b968dcf663015d04617cd4dccd526152305",
+				"KeyExpiry":  "2026-10-26T10:37:56Z",
+				"DiscoKey":   "discokey:f6d85f93c3d97a79b614654cf18e3b820f07b3973bc08bc168bd9c9d575ea337",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60229", "10.65.0.27:60229", "172.17.0.1:60229"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:37:56.428202117Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1017746610960472,
+				"StableID":   "nT6GuhUww811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:048516c446ae8b1ef83a3283adfbb1c5ff7f8dd429f786778db997846979740b",
+				"KeyExpiry":  "2026-10-26T10:37:57Z",
+				"DiscoKey":   "discokey:49f9ea182a0e04c9d8fd0929c5c8e4f8137460d5ac623d79d226dabaadc9ef31",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52228", "10.65.0.27:52228", "172.17.0.1:52228"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:37:57.040858364Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7895695545010549,
+				"StableID":   "nimrmvXye421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       7895695545010549,
+				"Key":        "nodekey:22f777f88a9691ece37ae2195818ebf1882cee7fc33bc722a70fbea320eaba3f",
+				"DiscoKey":   "discokey:5a14b3a18105db8f65f7497ed8698cd755a3139213bc0b591e948ae8e7a5e603",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36056", "10.65.0.27:36056", "172.17.0.1:36056"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:37:54.787035209Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:22f777f88a9691ece37ae2195818ebf1882cee7fc33bc722a70fbea320eaba3f",
+			"MachineKey": "mkey:dacf83a9f2c77040fbadda125c187e6df3de8cb2ae4f5bcf56222a1178a1f550",
+			"Peers": [{
+				"ID":         5703417686615105,
+				"StableID":   "nSRjXT76Ym11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60fdeb9757f2dfb1e7fb9478cc37953c05aca5c3c981be087f909708770e742d",
+				"DiscoKey":   "discokey:4111f11def6b05e817c7b4e58458c15b7b70db022d652ce9382add34bf81f158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43850", "10.65.0.27:43850", "172.17.0.1:43850"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:37:53.198249654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1419611232259861,
+				"StableID":   "nJF9NEnw5C11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e1bec001054b6aee774c085a3de6620c73ce75f62e94a610bf540bdf5450165",
+				"DiscoKey":   "discokey:ff03a92308f8ffabd0d79d37289e18029111caecb1ec1ac7d1651e6ad69c2561",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47734", "10.65.0.27:47734", "172.17.0.1:47734"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:37:53.695723138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1854289521133802,
+				"StableID":   "nZJTGQ3pUF11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4641702e299ef7135708ad261c36fdd5db5cecc3b65c11134eca856a38a8a779",
+				"DiscoKey":   "discokey:de304548cd24dc351f090090b9d8ba152227e34e356bee5e741e853d19aafc46",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47851", "10.65.0.27:47851", "172.17.0.1:47851"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:37:54.264514104Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1342224679299359,
+				"StableID":   "nC7Hg3ytUB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:baaeee4d6ecba955826d38c0a65d04204bb5e46972ef293efa0068a90c052002",
+				"DiscoKey":   "discokey:3b3d2310587bf8a09eb1ab33f63f03c2a1bf885f039bd739821f2296c9fd356d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:43038", "10.65.0.27:43038", "172.17.0.1:43038"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:37:55.328374361Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4006893575424745,
+				"StableID":   "npxGJPJjHY11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2c3caf9f9094473ea186dc6240ab2d47fe57abfd969584df82961bf957bdd48",
+				"KeyExpiry":  "2026-10-26T10:37:55Z",
+				"DiscoKey":   "discokey:81325f4a8a82fc8ab661200de4caf32feb2942ab1d7dc828f8b637fc5160b019",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51649", "10.65.0.27:51649", "172.17.0.1:51649"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:37:55.8710616Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6579530214399294,
+				"StableID":   "nfZDWu6tNt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f7f67a9c5686cceeba5772a649618b968dcf663015d04617cd4dccd526152305",
+				"KeyExpiry":  "2026-10-26T10:37:56Z",
+				"DiscoKey":   "discokey:f6d85f93c3d97a79b614654cf18e3b820f07b3973bc08bc168bd9c9d575ea337",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60229", "10.65.0.27:60229", "172.17.0.1:60229"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:37:56.428202117Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1017746610960472,
+				"StableID":   "nT6GuhUww811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:048516c446ae8b1ef83a3283adfbb1c5ff7f8dd429f786778db997846979740b",
+				"KeyExpiry":  "2026-10-26T10:37:57Z",
+				"DiscoKey":   "discokey:49f9ea182a0e04c9d8fd0929c5c8e4f8137460d5ac623d79d226dabaadc9ef31",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52228", "10.65.0.27:52228", "172.17.0.1:52228"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:37:57.040858364Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7895695545010549": {
+				"ID":          7895695545010549,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1419611232259861,
+				"StableID":   "nJF9NEnw5C11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1419611232259861,
+				"Key":        "nodekey:6e1bec001054b6aee774c085a3de6620c73ce75f62e94a610bf540bdf5450165",
+				"DiscoKey":   "discokey:ff03a92308f8ffabd0d79d37289e18029111caecb1ec1ac7d1651e6ad69c2561",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47734", "10.65.0.27:47734", "172.17.0.1:47734"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:37:53.695723138Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6e1bec001054b6aee774c085a3de6620c73ce75f62e94a610bf540bdf5450165",
+			"MachineKey": "mkey:e3ced7c6c90a430167d4f50d05a85ec33d2b712bc026128313370ae561e24542",
+			"Peers": [{
+				"ID":         5703417686615105,
+				"StableID":   "nSRjXT76Ym11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60fdeb9757f2dfb1e7fb9478cc37953c05aca5c3c981be087f909708770e742d",
+				"DiscoKey":   "discokey:4111f11def6b05e817c7b4e58458c15b7b70db022d652ce9382add34bf81f158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43850", "10.65.0.27:43850", "172.17.0.1:43850"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:37:53.198249654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1854289521133802,
+				"StableID":   "nZJTGQ3pUF11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4641702e299ef7135708ad261c36fdd5db5cecc3b65c11134eca856a38a8a779",
+				"DiscoKey":   "discokey:de304548cd24dc351f090090b9d8ba152227e34e356bee5e741e853d19aafc46",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47851", "10.65.0.27:47851", "172.17.0.1:47851"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:37:54.264514104Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7895695545010549,
+				"StableID":   "nimrmvXye421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22f777f88a9691ece37ae2195818ebf1882cee7fc33bc722a70fbea320eaba3f",
+				"DiscoKey":   "discokey:5a14b3a18105db8f65f7497ed8698cd755a3139213bc0b591e948ae8e7a5e603",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36056", "10.65.0.27:36056", "172.17.0.1:36056"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:37:54.787035209Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1342224679299359,
+				"StableID":   "nC7Hg3ytUB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:baaeee4d6ecba955826d38c0a65d04204bb5e46972ef293efa0068a90c052002",
+				"DiscoKey":   "discokey:3b3d2310587bf8a09eb1ab33f63f03c2a1bf885f039bd739821f2296c9fd356d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:43038", "10.65.0.27:43038", "172.17.0.1:43038"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:37:55.328374361Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4006893575424745,
+				"StableID":   "npxGJPJjHY11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2c3caf9f9094473ea186dc6240ab2d47fe57abfd969584df82961bf957bdd48",
+				"KeyExpiry":  "2026-10-26T10:37:55Z",
+				"DiscoKey":   "discokey:81325f4a8a82fc8ab661200de4caf32feb2942ab1d7dc828f8b637fc5160b019",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51649", "10.65.0.27:51649", "172.17.0.1:51649"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:37:55.8710616Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6579530214399294,
+				"StableID":   "nfZDWu6tNt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f7f67a9c5686cceeba5772a649618b968dcf663015d04617cd4dccd526152305",
+				"KeyExpiry":  "2026-10-26T10:37:56Z",
+				"DiscoKey":   "discokey:f6d85f93c3d97a79b614654cf18e3b820f07b3973bc08bc168bd9c9d575ea337",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60229", "10.65.0.27:60229", "172.17.0.1:60229"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:37:56.428202117Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1017746610960472,
+				"StableID":   "nT6GuhUww811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:048516c446ae8b1ef83a3283adfbb1c5ff7f8dd429f786778db997846979740b",
+				"KeyExpiry":  "2026-10-26T10:37:57Z",
+				"DiscoKey":   "discokey:49f9ea182a0e04c9d8fd0929c5c8e4f8137460d5ac623d79d226dabaadc9ef31",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52228", "10.65.0.27:52228", "172.17.0.1:52228"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:37:57.040858364Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1419611232259861": {
+				"ID":          1419611232259861,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6579530214399294,
+				"StableID":   "nfZDWu6tNt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f7f67a9c5686cceeba5772a649618b968dcf663015d04617cd4dccd526152305",
+				"KeyExpiry":  "2026-10-26T10:37:56Z",
+				"DiscoKey":   "discokey:f6d85f93c3d97a79b614654cf18e3b820f07b3973bc08bc168bd9c9d575ea337",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60229", "10.65.0.27:60229", "172.17.0.1:60229"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:37:56.428202117Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f7f67a9c5686cceeba5772a649618b968dcf663015d04617cd4dccd526152305",
+			"MachineKey": "mkey:24b1e1ae7593ec7c5921ffd495b961cf9de43274fc747c08fbf07c8f464cfe58",
+			"Peers": [{
+				"ID":         5703417686615105,
+				"StableID":   "nSRjXT76Ym11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60fdeb9757f2dfb1e7fb9478cc37953c05aca5c3c981be087f909708770e742d",
+				"DiscoKey":   "discokey:4111f11def6b05e817c7b4e58458c15b7b70db022d652ce9382add34bf81f158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43850", "10.65.0.27:43850", "172.17.0.1:43850"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:37:53.198249654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1419611232259861,
+				"StableID":   "nJF9NEnw5C11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e1bec001054b6aee774c085a3de6620c73ce75f62e94a610bf540bdf5450165",
+				"DiscoKey":   "discokey:ff03a92308f8ffabd0d79d37289e18029111caecb1ec1ac7d1651e6ad69c2561",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47734", "10.65.0.27:47734", "172.17.0.1:47734"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:37:53.695723138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1854289521133802,
+				"StableID":   "nZJTGQ3pUF11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4641702e299ef7135708ad261c36fdd5db5cecc3b65c11134eca856a38a8a779",
+				"DiscoKey":   "discokey:de304548cd24dc351f090090b9d8ba152227e34e356bee5e741e853d19aafc46",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47851", "10.65.0.27:47851", "172.17.0.1:47851"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:37:54.264514104Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7895695545010549,
+				"StableID":   "nimrmvXye421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22f777f88a9691ece37ae2195818ebf1882cee7fc33bc722a70fbea320eaba3f",
+				"DiscoKey":   "discokey:5a14b3a18105db8f65f7497ed8698cd755a3139213bc0b591e948ae8e7a5e603",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36056", "10.65.0.27:36056", "172.17.0.1:36056"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:37:54.787035209Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1342224679299359,
+				"StableID":   "nC7Hg3ytUB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:baaeee4d6ecba955826d38c0a65d04204bb5e46972ef293efa0068a90c052002",
+				"DiscoKey":   "discokey:3b3d2310587bf8a09eb1ab33f63f03c2a1bf885f039bd739821f2296c9fd356d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:43038", "10.65.0.27:43038", "172.17.0.1:43038"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:37:55.328374361Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4006893575424745,
+				"StableID":   "npxGJPJjHY11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2c3caf9f9094473ea186dc6240ab2d47fe57abfd969584df82961bf957bdd48",
+				"KeyExpiry":  "2026-10-26T10:37:55Z",
+				"DiscoKey":   "discokey:81325f4a8a82fc8ab661200de4caf32feb2942ab1d7dc828f8b637fc5160b019",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51649", "10.65.0.27:51649", "172.17.0.1:51649"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:37:55.8710616Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1017746610960472,
+				"StableID":   "nT6GuhUww811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:048516c446ae8b1ef83a3283adfbb1c5ff7f8dd429f786778db997846979740b",
+				"KeyExpiry":  "2026-10-26T10:37:57Z",
+				"DiscoKey":   "discokey:49f9ea182a0e04c9d8fd0929c5c8e4f8137460d5ac623d79d226dabaadc9ef31",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52228", "10.65.0.27:52228", "172.17.0.1:52228"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:37:57.040858364Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1854289521133802,
+				"StableID":   "nZJTGQ3pUF11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1854289521133802,
+				"Key":        "nodekey:4641702e299ef7135708ad261c36fdd5db5cecc3b65c11134eca856a38a8a779",
+				"DiscoKey":   "discokey:de304548cd24dc351f090090b9d8ba152227e34e356bee5e741e853d19aafc46",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47851", "10.65.0.27:47851", "172.17.0.1:47851"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:37:54.264514104Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4641702e299ef7135708ad261c36fdd5db5cecc3b65c11134eca856a38a8a779",
+			"MachineKey": "mkey:68281e08b83bab7d5ea3e2a06c5d5076c07f564f5ab72df93111d02494a2b964",
+			"Peers": [{
+				"ID":         5703417686615105,
+				"StableID":   "nSRjXT76Ym11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60fdeb9757f2dfb1e7fb9478cc37953c05aca5c3c981be087f909708770e742d",
+				"DiscoKey":   "discokey:4111f11def6b05e817c7b4e58458c15b7b70db022d652ce9382add34bf81f158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43850", "10.65.0.27:43850", "172.17.0.1:43850"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:37:53.198249654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1419611232259861,
+				"StableID":   "nJF9NEnw5C11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e1bec001054b6aee774c085a3de6620c73ce75f62e94a610bf540bdf5450165",
+				"DiscoKey":   "discokey:ff03a92308f8ffabd0d79d37289e18029111caecb1ec1ac7d1651e6ad69c2561",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47734", "10.65.0.27:47734", "172.17.0.1:47734"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:37:53.695723138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7895695545010549,
+				"StableID":   "nimrmvXye421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22f777f88a9691ece37ae2195818ebf1882cee7fc33bc722a70fbea320eaba3f",
+				"DiscoKey":   "discokey:5a14b3a18105db8f65f7497ed8698cd755a3139213bc0b591e948ae8e7a5e603",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36056", "10.65.0.27:36056", "172.17.0.1:36056"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:37:54.787035209Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1342224679299359,
+				"StableID":   "nC7Hg3ytUB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:baaeee4d6ecba955826d38c0a65d04204bb5e46972ef293efa0068a90c052002",
+				"DiscoKey":   "discokey:3b3d2310587bf8a09eb1ab33f63f03c2a1bf885f039bd739821f2296c9fd356d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:43038", "10.65.0.27:43038", "172.17.0.1:43038"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:37:55.328374361Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4006893575424745,
+				"StableID":   "npxGJPJjHY11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2c3caf9f9094473ea186dc6240ab2d47fe57abfd969584df82961bf957bdd48",
+				"KeyExpiry":  "2026-10-26T10:37:55Z",
+				"DiscoKey":   "discokey:81325f4a8a82fc8ab661200de4caf32feb2942ab1d7dc828f8b637fc5160b019",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51649", "10.65.0.27:51649", "172.17.0.1:51649"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:37:55.8710616Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6579530214399294,
+				"StableID":   "nfZDWu6tNt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f7f67a9c5686cceeba5772a649618b968dcf663015d04617cd4dccd526152305",
+				"KeyExpiry":  "2026-10-26T10:37:56Z",
+				"DiscoKey":   "discokey:f6d85f93c3d97a79b614654cf18e3b820f07b3973bc08bc168bd9c9d575ea337",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60229", "10.65.0.27:60229", "172.17.0.1:60229"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:37:56.428202117Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1017746610960472,
+				"StableID":   "nT6GuhUww811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:048516c446ae8b1ef83a3283adfbb1c5ff7f8dd429f786778db997846979740b",
+				"KeyExpiry":  "2026-10-26T10:37:57Z",
+				"DiscoKey":   "discokey:49f9ea182a0e04c9d8fd0929c5c8e4f8137460d5ac623d79d226dabaadc9ef31",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52228", "10.65.0.27:52228", "172.17.0.1:52228"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:37:57.040858364Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1854289521133802": {
+				"ID":          1854289521133802,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-accept-fail-ip-literal-src-host-dst.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-accept-fail-ip-literal-src-host-dst.hujson
@@ -1,0 +1,8843 @@
+// policytest-accept-fail-ip-literal-src-host-dst
+//
+// tests block accept-fail: ip literal src to host dst, no covering rule
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:38:18Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-accept-fail-ip-literal-src-host-dst",
+	"description":    "tests block accept-fail: ip literal src to host dst, no covering rule",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:38:18.772598568Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                 \n  \n                                                                     \n          \n{\n\t\"id\":          \"policytest-accept-fail-ip-literal-src-host-dst\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block accept-fail: ip literal src to host dst, no covering rule\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"tag:client\"], \"dst\": [\"webserver:80\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"100.64.0.19\", \"accept\": [\"webserver:80\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-accept-fail-ip-literal-src-host-dst.hujson",
+		"full_policy": {
+			"acls": [{"action": "accept", "dst": ["webserver:80"], "src": ["tag:client"]}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["webserver:80"], "src": "100.64.0.19"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8699044213249234,
+				"StableID":   "nFqYe99pvA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       8699044213249234,
+				"Key":        "nodekey:01f0e75c7e15984ff84f3548a583b11d5d0767933219c5c86a83e6a435045144",
+				"DiscoKey":   "discokey:c02f7b529eea59a55aabee3f800e24094addf73ee371dde868f35019b29f5e78",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34188", "10.65.0.27:34188", "172.17.0.1:34188"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:38:22.593455803Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:01f0e75c7e15984ff84f3548a583b11d5d0767933219c5c86a83e6a435045144",
+			"MachineKey": "mkey:d4557728a71ef29987a7e0e7fe59d1fd6a10795dcb0908dc4b65af57ec237770",
+			"Peers": [{
+				"ID":         3137023329684076,
+				"StableID":   "n5XvQSHmVR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bd104a635f5d12e2a789648ae22460f7aa7fc5b6bc40585dbf2ebcb4459e0747",
+				"DiscoKey":   "discokey:41cc13e2b8341d6847ae36a361afca460b866303ee6d171fc868cb9fed2c4d18",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:54648", "10.65.0.27:54648", "172.17.0.1:54648"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:38:20.369156703Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7288294861132164,
+				"StableID":   "ndmXHY9tuy11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:124e450b2d8c98cd66f4021e58156b08ee1ca261e53b59f520c7cbddf50d694b",
+				"DiscoKey":   "discokey:eadcedf14cba5846e362f443feaeb24b7c934a69010924a7d6d75cc6da310f03",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60231", "10.65.0.27:60231", "172.17.0.1:60231"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:38:20.879296989Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2962093807975772,
+				"StableID":   "n1fdbXBY8Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33eb2f350f2fe8cd63cd2d0065dd286e48e10301512c4e2ad911da49d3bc7e16",
+				"DiscoKey":   "discokey:ff060c2e11e125a69d713c4f37a8002dfa84ae4537d4a82190934123c10f1d01",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59515", "10.65.0.27:59515", "172.17.0.1:59515"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:38:21.425373037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3971276804133734,
+				"StableID":   "nhpbB3ib1Y11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bcd002d4bdb06af74decde14fc1105ff72370c6017a7c6b34d21ee808438454a",
+				"DiscoKey":   "discokey:80f37d7b8610283475e3b32c8f832d5dec2aa65b98ee96ef7ad6e14f247ae807",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38697", "10.65.0.27:38697", "172.17.0.1:38697"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:38:21.980913833Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8238520975478923,
+				"StableID":   "nCPa7cyEL721CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f1c84edb7495b0445e548598c8a13605c3a845ba434ff44c03619df91403955d",
+				"KeyExpiry":  "2026-10-26T10:38:23Z",
+				"DiscoKey":   "discokey:0c655178a0697f9f6c65fdc8ee913dbaf578c0d023c6e9e6549216daf959f826",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54289", "10.65.0.27:54289", "172.17.0.1:54289"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:38:23.113024696Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3316941455849157,
+				"StableID":   "ni128oRFuS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:34c0fa1a92797ea1d95bb5ede8dfc9802e3ede8533d41b3b393e598ff1325862",
+				"KeyExpiry":  "2026-10-26T10:38:23Z",
+				"DiscoKey":   "discokey:b95bf106ecaf8cab0f0fba8da5c966b8843f00de14ec703a63489ae58955ae4f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:40471", "10.65.0.27:40471", "172.17.0.1:40471"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:38:23.662258727Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4918020572410626,
+				"StableID":   "noyn1Y4PQf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:71e01c1f68fee5c55315712a11965ca4d375c9784e6af242b532bdf4d294b56c",
+				"KeyExpiry":  "2026-10-26T10:38:24Z",
+				"DiscoKey":   "discokey:464a72887bd55dea60c5f09b515c283d9980ab8011febd6adfb6e41945fe1b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34405", "10.65.0.27:34405", "172.17.0.1:34405"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:38:24.175766736Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8699044213249234": {
+				"ID":          8699044213249234,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4918020572410626,
+				"StableID":   "noyn1Y4PQf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:71e01c1f68fee5c55315712a11965ca4d375c9784e6af242b532bdf4d294b56c",
+				"KeyExpiry":  "2026-10-26T10:38:24Z",
+				"DiscoKey":   "discokey:464a72887bd55dea60c5f09b515c283d9980ab8011febd6adfb6e41945fe1b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34405", "10.65.0.27:34405", "172.17.0.1:34405"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:38:24.175766736Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:71e01c1f68fee5c55315712a11965ca4d375c9784e6af242b532bdf4d294b56c",
+			"MachineKey": "mkey:552e8b3765eb99e8a37c63c735f0294152522c9868acb5c02c456aeafb2f3f72",
+			"Peers": [{
+				"ID":         3137023329684076,
+				"StableID":   "n5XvQSHmVR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bd104a635f5d12e2a789648ae22460f7aa7fc5b6bc40585dbf2ebcb4459e0747",
+				"DiscoKey":   "discokey:41cc13e2b8341d6847ae36a361afca460b866303ee6d171fc868cb9fed2c4d18",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:54648", "10.65.0.27:54648", "172.17.0.1:54648"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:38:20.369156703Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7288294861132164,
+				"StableID":   "ndmXHY9tuy11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:124e450b2d8c98cd66f4021e58156b08ee1ca261e53b59f520c7cbddf50d694b",
+				"DiscoKey":   "discokey:eadcedf14cba5846e362f443feaeb24b7c934a69010924a7d6d75cc6da310f03",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60231", "10.65.0.27:60231", "172.17.0.1:60231"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:38:20.879296989Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2962093807975772,
+				"StableID":   "n1fdbXBY8Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33eb2f350f2fe8cd63cd2d0065dd286e48e10301512c4e2ad911da49d3bc7e16",
+				"DiscoKey":   "discokey:ff060c2e11e125a69d713c4f37a8002dfa84ae4537d4a82190934123c10f1d01",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59515", "10.65.0.27:59515", "172.17.0.1:59515"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:38:21.425373037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3971276804133734,
+				"StableID":   "nhpbB3ib1Y11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bcd002d4bdb06af74decde14fc1105ff72370c6017a7c6b34d21ee808438454a",
+				"DiscoKey":   "discokey:80f37d7b8610283475e3b32c8f832d5dec2aa65b98ee96ef7ad6e14f247ae807",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38697", "10.65.0.27:38697", "172.17.0.1:38697"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:38:21.980913833Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8699044213249234,
+				"StableID":   "nFqYe99pvA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01f0e75c7e15984ff84f3548a583b11d5d0767933219c5c86a83e6a435045144",
+				"DiscoKey":   "discokey:c02f7b529eea59a55aabee3f800e24094addf73ee371dde868f35019b29f5e78",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34188", "10.65.0.27:34188", "172.17.0.1:34188"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:38:22.593455803Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8238520975478923,
+				"StableID":   "nCPa7cyEL721CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f1c84edb7495b0445e548598c8a13605c3a845ba434ff44c03619df91403955d",
+				"KeyExpiry":  "2026-10-26T10:38:23Z",
+				"DiscoKey":   "discokey:0c655178a0697f9f6c65fdc8ee913dbaf578c0d023c6e9e6549216daf959f826",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54289", "10.65.0.27:54289", "172.17.0.1:54289"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:38:23.113024696Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3316941455849157,
+				"StableID":   "ni128oRFuS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:34c0fa1a92797ea1d95bb5ede8dfc9802e3ede8533d41b3b393e598ff1325862",
+				"KeyExpiry":  "2026-10-26T10:38:23Z",
+				"DiscoKey":   "discokey:b95bf106ecaf8cab0f0fba8da5c966b8843f00de14ec703a63489ae58955ae4f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:40471", "10.65.0.27:40471", "172.17.0.1:40471"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:38:23.662258727Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3137023329684076,
+				"StableID":   "n5XvQSHmVR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       3137023329684076,
+				"Key":        "nodekey:bd104a635f5d12e2a789648ae22460f7aa7fc5b6bc40585dbf2ebcb4459e0747",
+				"DiscoKey":   "discokey:41cc13e2b8341d6847ae36a361afca460b866303ee6d171fc868cb9fed2c4d18",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:54648", "10.65.0.27:54648", "172.17.0.1:54648"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:38:20.369156703Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bd104a635f5d12e2a789648ae22460f7aa7fc5b6bc40585dbf2ebcb4459e0747",
+			"MachineKey": "mkey:54315cce95b7fcc4bda5801f0860e87fe400f63a91cfbb96708ccab782b2811b",
+			"Peers": [{
+				"ID":         7288294861132164,
+				"StableID":   "ndmXHY9tuy11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:124e450b2d8c98cd66f4021e58156b08ee1ca261e53b59f520c7cbddf50d694b",
+				"DiscoKey":   "discokey:eadcedf14cba5846e362f443feaeb24b7c934a69010924a7d6d75cc6da310f03",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60231", "10.65.0.27:60231", "172.17.0.1:60231"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:38:20.879296989Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2962093807975772,
+				"StableID":   "n1fdbXBY8Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33eb2f350f2fe8cd63cd2d0065dd286e48e10301512c4e2ad911da49d3bc7e16",
+				"DiscoKey":   "discokey:ff060c2e11e125a69d713c4f37a8002dfa84ae4537d4a82190934123c10f1d01",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59515", "10.65.0.27:59515", "172.17.0.1:59515"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:38:21.425373037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3971276804133734,
+				"StableID":   "nhpbB3ib1Y11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bcd002d4bdb06af74decde14fc1105ff72370c6017a7c6b34d21ee808438454a",
+				"DiscoKey":   "discokey:80f37d7b8610283475e3b32c8f832d5dec2aa65b98ee96ef7ad6e14f247ae807",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38697", "10.65.0.27:38697", "172.17.0.1:38697"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:38:21.980913833Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8699044213249234,
+				"StableID":   "nFqYe99pvA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01f0e75c7e15984ff84f3548a583b11d5d0767933219c5c86a83e6a435045144",
+				"DiscoKey":   "discokey:c02f7b529eea59a55aabee3f800e24094addf73ee371dde868f35019b29f5e78",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34188", "10.65.0.27:34188", "172.17.0.1:34188"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:38:22.593455803Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8238520975478923,
+				"StableID":   "nCPa7cyEL721CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f1c84edb7495b0445e548598c8a13605c3a845ba434ff44c03619df91403955d",
+				"KeyExpiry":  "2026-10-26T10:38:23Z",
+				"DiscoKey":   "discokey:0c655178a0697f9f6c65fdc8ee913dbaf578c0d023c6e9e6549216daf959f826",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54289", "10.65.0.27:54289", "172.17.0.1:54289"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:38:23.113024696Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3316941455849157,
+				"StableID":   "ni128oRFuS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:34c0fa1a92797ea1d95bb5ede8dfc9802e3ede8533d41b3b393e598ff1325862",
+				"KeyExpiry":  "2026-10-26T10:38:23Z",
+				"DiscoKey":   "discokey:b95bf106ecaf8cab0f0fba8da5c966b8843f00de14ec703a63489ae58955ae4f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:40471", "10.65.0.27:40471", "172.17.0.1:40471"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:38:23.662258727Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4918020572410626,
+				"StableID":   "noyn1Y4PQf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:71e01c1f68fee5c55315712a11965ca4d375c9784e6af242b532bdf4d294b56c",
+				"KeyExpiry":  "2026-10-26T10:38:24Z",
+				"DiscoKey":   "discokey:464a72887bd55dea60c5f09b515c283d9980ab8011febd6adfb6e41945fe1b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34405", "10.65.0.27:34405", "172.17.0.1:34405"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:38:24.175766736Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3137023329684076": {
+				"ID":          3137023329684076,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8238520975478923,
+				"StableID":   "nCPa7cyEL721CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f1c84edb7495b0445e548598c8a13605c3a845ba434ff44c03619df91403955d",
+				"KeyExpiry":  "2026-10-26T10:38:23Z",
+				"DiscoKey":   "discokey:0c655178a0697f9f6c65fdc8ee913dbaf578c0d023c6e9e6549216daf959f826",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54289", "10.65.0.27:54289", "172.17.0.1:54289"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:38:23.113024696Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f1c84edb7495b0445e548598c8a13605c3a845ba434ff44c03619df91403955d",
+			"MachineKey": "mkey:eae78fa39a6a5e6d0632a7ac4344bc4a442666c59a6dee7d4e424c9f3111761a",
+			"Peers": [{
+				"ID":         3137023329684076,
+				"StableID":   "n5XvQSHmVR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bd104a635f5d12e2a789648ae22460f7aa7fc5b6bc40585dbf2ebcb4459e0747",
+				"DiscoKey":   "discokey:41cc13e2b8341d6847ae36a361afca460b866303ee6d171fc868cb9fed2c4d18",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:54648", "10.65.0.27:54648", "172.17.0.1:54648"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:38:20.369156703Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7288294861132164,
+				"StableID":   "ndmXHY9tuy11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:124e450b2d8c98cd66f4021e58156b08ee1ca261e53b59f520c7cbddf50d694b",
+				"DiscoKey":   "discokey:eadcedf14cba5846e362f443feaeb24b7c934a69010924a7d6d75cc6da310f03",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60231", "10.65.0.27:60231", "172.17.0.1:60231"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:38:20.879296989Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2962093807975772,
+				"StableID":   "n1fdbXBY8Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33eb2f350f2fe8cd63cd2d0065dd286e48e10301512c4e2ad911da49d3bc7e16",
+				"DiscoKey":   "discokey:ff060c2e11e125a69d713c4f37a8002dfa84ae4537d4a82190934123c10f1d01",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59515", "10.65.0.27:59515", "172.17.0.1:59515"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:38:21.425373037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3971276804133734,
+				"StableID":   "nhpbB3ib1Y11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bcd002d4bdb06af74decde14fc1105ff72370c6017a7c6b34d21ee808438454a",
+				"DiscoKey":   "discokey:80f37d7b8610283475e3b32c8f832d5dec2aa65b98ee96ef7ad6e14f247ae807",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38697", "10.65.0.27:38697", "172.17.0.1:38697"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:38:21.980913833Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8699044213249234,
+				"StableID":   "nFqYe99pvA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01f0e75c7e15984ff84f3548a583b11d5d0767933219c5c86a83e6a435045144",
+				"DiscoKey":   "discokey:c02f7b529eea59a55aabee3f800e24094addf73ee371dde868f35019b29f5e78",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34188", "10.65.0.27:34188", "172.17.0.1:34188"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:38:22.593455803Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3316941455849157,
+				"StableID":   "ni128oRFuS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:34c0fa1a92797ea1d95bb5ede8dfc9802e3ede8533d41b3b393e598ff1325862",
+				"KeyExpiry":  "2026-10-26T10:38:23Z",
+				"DiscoKey":   "discokey:b95bf106ecaf8cab0f0fba8da5c966b8843f00de14ec703a63489ae58955ae4f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:40471", "10.65.0.27:40471", "172.17.0.1:40471"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:38:23.662258727Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4918020572410626,
+				"StableID":   "noyn1Y4PQf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:71e01c1f68fee5c55315712a11965ca4d375c9784e6af242b532bdf4d294b56c",
+				"KeyExpiry":  "2026-10-26T10:38:24Z",
+				"DiscoKey":   "discokey:464a72887bd55dea60c5f09b515c283d9980ab8011febd6adfb6e41945fe1b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34405", "10.65.0.27:34405", "172.17.0.1:34405"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:38:24.175766736Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3971276804133734,
+				"StableID":   "nhpbB3ib1Y11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       3971276804133734,
+				"Key":        "nodekey:bcd002d4bdb06af74decde14fc1105ff72370c6017a7c6b34d21ee808438454a",
+				"DiscoKey":   "discokey:80f37d7b8610283475e3b32c8f832d5dec2aa65b98ee96ef7ad6e14f247ae807",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38697", "10.65.0.27:38697", "172.17.0.1:38697"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:38:21.980913833Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bcd002d4bdb06af74decde14fc1105ff72370c6017a7c6b34d21ee808438454a",
+			"MachineKey": "mkey:89e59f854b906326e77258bac990239ba65b15275ac4b4016c3d5ada3fe0f21d",
+			"Peers": [{
+				"ID":         3137023329684076,
+				"StableID":   "n5XvQSHmVR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bd104a635f5d12e2a789648ae22460f7aa7fc5b6bc40585dbf2ebcb4459e0747",
+				"DiscoKey":   "discokey:41cc13e2b8341d6847ae36a361afca460b866303ee6d171fc868cb9fed2c4d18",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:54648", "10.65.0.27:54648", "172.17.0.1:54648"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:38:20.369156703Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7288294861132164,
+				"StableID":   "ndmXHY9tuy11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:124e450b2d8c98cd66f4021e58156b08ee1ca261e53b59f520c7cbddf50d694b",
+				"DiscoKey":   "discokey:eadcedf14cba5846e362f443feaeb24b7c934a69010924a7d6d75cc6da310f03",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60231", "10.65.0.27:60231", "172.17.0.1:60231"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:38:20.879296989Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2962093807975772,
+				"StableID":   "n1fdbXBY8Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33eb2f350f2fe8cd63cd2d0065dd286e48e10301512c4e2ad911da49d3bc7e16",
+				"DiscoKey":   "discokey:ff060c2e11e125a69d713c4f37a8002dfa84ae4537d4a82190934123c10f1d01",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59515", "10.65.0.27:59515", "172.17.0.1:59515"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:38:21.425373037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8699044213249234,
+				"StableID":   "nFqYe99pvA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01f0e75c7e15984ff84f3548a583b11d5d0767933219c5c86a83e6a435045144",
+				"DiscoKey":   "discokey:c02f7b529eea59a55aabee3f800e24094addf73ee371dde868f35019b29f5e78",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34188", "10.65.0.27:34188", "172.17.0.1:34188"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:38:22.593455803Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8238520975478923,
+				"StableID":   "nCPa7cyEL721CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f1c84edb7495b0445e548598c8a13605c3a845ba434ff44c03619df91403955d",
+				"KeyExpiry":  "2026-10-26T10:38:23Z",
+				"DiscoKey":   "discokey:0c655178a0697f9f6c65fdc8ee913dbaf578c0d023c6e9e6549216daf959f826",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54289", "10.65.0.27:54289", "172.17.0.1:54289"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:38:23.113024696Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3316941455849157,
+				"StableID":   "ni128oRFuS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:34c0fa1a92797ea1d95bb5ede8dfc9802e3ede8533d41b3b393e598ff1325862",
+				"KeyExpiry":  "2026-10-26T10:38:23Z",
+				"DiscoKey":   "discokey:b95bf106ecaf8cab0f0fba8da5c966b8843f00de14ec703a63489ae58955ae4f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:40471", "10.65.0.27:40471", "172.17.0.1:40471"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:38:23.662258727Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4918020572410626,
+				"StableID":   "noyn1Y4PQf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:71e01c1f68fee5c55315712a11965ca4d375c9784e6af242b532bdf4d294b56c",
+				"KeyExpiry":  "2026-10-26T10:38:24Z",
+				"DiscoKey":   "discokey:464a72887bd55dea60c5f09b515c283d9980ab8011febd6adfb6e41945fe1b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34405", "10.65.0.27:34405", "172.17.0.1:34405"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:38:24.175766736Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3971276804133734": {
+				"ID":          3971276804133734,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7288294861132164,
+				"StableID":   "ndmXHY9tuy11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       7288294861132164,
+				"Key":        "nodekey:124e450b2d8c98cd66f4021e58156b08ee1ca261e53b59f520c7cbddf50d694b",
+				"DiscoKey":   "discokey:eadcedf14cba5846e362f443feaeb24b7c934a69010924a7d6d75cc6da310f03",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60231", "10.65.0.27:60231", "172.17.0.1:60231"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:38:20.879296989Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:124e450b2d8c98cd66f4021e58156b08ee1ca261e53b59f520c7cbddf50d694b",
+			"MachineKey": "mkey:10dd3159112019265315f484d513fb4f8941dba7cf6072aff3782ada106f0562",
+			"Peers": [{
+				"ID":         3137023329684076,
+				"StableID":   "n5XvQSHmVR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bd104a635f5d12e2a789648ae22460f7aa7fc5b6bc40585dbf2ebcb4459e0747",
+				"DiscoKey":   "discokey:41cc13e2b8341d6847ae36a361afca460b866303ee6d171fc868cb9fed2c4d18",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:54648", "10.65.0.27:54648", "172.17.0.1:54648"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:38:20.369156703Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2962093807975772,
+				"StableID":   "n1fdbXBY8Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33eb2f350f2fe8cd63cd2d0065dd286e48e10301512c4e2ad911da49d3bc7e16",
+				"DiscoKey":   "discokey:ff060c2e11e125a69d713c4f37a8002dfa84ae4537d4a82190934123c10f1d01",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59515", "10.65.0.27:59515", "172.17.0.1:59515"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:38:21.425373037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3971276804133734,
+				"StableID":   "nhpbB3ib1Y11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bcd002d4bdb06af74decde14fc1105ff72370c6017a7c6b34d21ee808438454a",
+				"DiscoKey":   "discokey:80f37d7b8610283475e3b32c8f832d5dec2aa65b98ee96ef7ad6e14f247ae807",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38697", "10.65.0.27:38697", "172.17.0.1:38697"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:38:21.980913833Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8699044213249234,
+				"StableID":   "nFqYe99pvA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01f0e75c7e15984ff84f3548a583b11d5d0767933219c5c86a83e6a435045144",
+				"DiscoKey":   "discokey:c02f7b529eea59a55aabee3f800e24094addf73ee371dde868f35019b29f5e78",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34188", "10.65.0.27:34188", "172.17.0.1:34188"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:38:22.593455803Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8238520975478923,
+				"StableID":   "nCPa7cyEL721CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f1c84edb7495b0445e548598c8a13605c3a845ba434ff44c03619df91403955d",
+				"KeyExpiry":  "2026-10-26T10:38:23Z",
+				"DiscoKey":   "discokey:0c655178a0697f9f6c65fdc8ee913dbaf578c0d023c6e9e6549216daf959f826",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54289", "10.65.0.27:54289", "172.17.0.1:54289"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:38:23.113024696Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3316941455849157,
+				"StableID":   "ni128oRFuS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:34c0fa1a92797ea1d95bb5ede8dfc9802e3ede8533d41b3b393e598ff1325862",
+				"KeyExpiry":  "2026-10-26T10:38:23Z",
+				"DiscoKey":   "discokey:b95bf106ecaf8cab0f0fba8da5c966b8843f00de14ec703a63489ae58955ae4f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:40471", "10.65.0.27:40471", "172.17.0.1:40471"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:38:23.662258727Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4918020572410626,
+				"StableID":   "noyn1Y4PQf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:71e01c1f68fee5c55315712a11965ca4d375c9784e6af242b532bdf4d294b56c",
+				"KeyExpiry":  "2026-10-26T10:38:24Z",
+				"DiscoKey":   "discokey:464a72887bd55dea60c5f09b515c283d9980ab8011febd6adfb6e41945fe1b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34405", "10.65.0.27:34405", "172.17.0.1:34405"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:38:24.175766736Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7288294861132164": {
+				"ID":          7288294861132164,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3316941455849157,
+				"StableID":   "ni128oRFuS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:34c0fa1a92797ea1d95bb5ede8dfc9802e3ede8533d41b3b393e598ff1325862",
+				"KeyExpiry":  "2026-10-26T10:38:23Z",
+				"DiscoKey":   "discokey:b95bf106ecaf8cab0f0fba8da5c966b8843f00de14ec703a63489ae58955ae4f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:40471", "10.65.0.27:40471", "172.17.0.1:40471"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:38:23.662258727Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:34c0fa1a92797ea1d95bb5ede8dfc9802e3ede8533d41b3b393e598ff1325862",
+			"MachineKey": "mkey:4df6fdd83391297d54423333d232deb5d1b79d0c282a705d343446aa51db9a1e",
+			"Peers": [{
+				"ID":         3137023329684076,
+				"StableID":   "n5XvQSHmVR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bd104a635f5d12e2a789648ae22460f7aa7fc5b6bc40585dbf2ebcb4459e0747",
+				"DiscoKey":   "discokey:41cc13e2b8341d6847ae36a361afca460b866303ee6d171fc868cb9fed2c4d18",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:54648", "10.65.0.27:54648", "172.17.0.1:54648"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:38:20.369156703Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7288294861132164,
+				"StableID":   "ndmXHY9tuy11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:124e450b2d8c98cd66f4021e58156b08ee1ca261e53b59f520c7cbddf50d694b",
+				"DiscoKey":   "discokey:eadcedf14cba5846e362f443feaeb24b7c934a69010924a7d6d75cc6da310f03",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60231", "10.65.0.27:60231", "172.17.0.1:60231"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:38:20.879296989Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2962093807975772,
+				"StableID":   "n1fdbXBY8Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33eb2f350f2fe8cd63cd2d0065dd286e48e10301512c4e2ad911da49d3bc7e16",
+				"DiscoKey":   "discokey:ff060c2e11e125a69d713c4f37a8002dfa84ae4537d4a82190934123c10f1d01",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59515", "10.65.0.27:59515", "172.17.0.1:59515"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:38:21.425373037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3971276804133734,
+				"StableID":   "nhpbB3ib1Y11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bcd002d4bdb06af74decde14fc1105ff72370c6017a7c6b34d21ee808438454a",
+				"DiscoKey":   "discokey:80f37d7b8610283475e3b32c8f832d5dec2aa65b98ee96ef7ad6e14f247ae807",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38697", "10.65.0.27:38697", "172.17.0.1:38697"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:38:21.980913833Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8699044213249234,
+				"StableID":   "nFqYe99pvA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01f0e75c7e15984ff84f3548a583b11d5d0767933219c5c86a83e6a435045144",
+				"DiscoKey":   "discokey:c02f7b529eea59a55aabee3f800e24094addf73ee371dde868f35019b29f5e78",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34188", "10.65.0.27:34188", "172.17.0.1:34188"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:38:22.593455803Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8238520975478923,
+				"StableID":   "nCPa7cyEL721CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f1c84edb7495b0445e548598c8a13605c3a845ba434ff44c03619df91403955d",
+				"KeyExpiry":  "2026-10-26T10:38:23Z",
+				"DiscoKey":   "discokey:0c655178a0697f9f6c65fdc8ee913dbaf578c0d023c6e9e6549216daf959f826",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54289", "10.65.0.27:54289", "172.17.0.1:54289"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:38:23.113024696Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4918020572410626,
+				"StableID":   "noyn1Y4PQf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:71e01c1f68fee5c55315712a11965ca4d375c9784e6af242b532bdf4d294b56c",
+				"KeyExpiry":  "2026-10-26T10:38:24Z",
+				"DiscoKey":   "discokey:464a72887bd55dea60c5f09b515c283d9980ab8011febd6adfb6e41945fe1b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34405", "10.65.0.27:34405", "172.17.0.1:34405"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:38:24.175766736Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2962093807975772,
+				"StableID":   "n1fdbXBY8Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       2962093807975772,
+				"Key":        "nodekey:33eb2f350f2fe8cd63cd2d0065dd286e48e10301512c4e2ad911da49d3bc7e16",
+				"DiscoKey":   "discokey:ff060c2e11e125a69d713c4f37a8002dfa84ae4537d4a82190934123c10f1d01",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59515", "10.65.0.27:59515", "172.17.0.1:59515"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:38:21.425373037Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:33eb2f350f2fe8cd63cd2d0065dd286e48e10301512c4e2ad911da49d3bc7e16",
+			"MachineKey": "mkey:418542255e4124d69d40bfdefc3602a899dec3c69adecf37ade603808568ec0f",
+			"Peers": [{
+				"ID":         3137023329684076,
+				"StableID":   "n5XvQSHmVR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bd104a635f5d12e2a789648ae22460f7aa7fc5b6bc40585dbf2ebcb4459e0747",
+				"DiscoKey":   "discokey:41cc13e2b8341d6847ae36a361afca460b866303ee6d171fc868cb9fed2c4d18",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:54648", "10.65.0.27:54648", "172.17.0.1:54648"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:38:20.369156703Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7288294861132164,
+				"StableID":   "ndmXHY9tuy11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:124e450b2d8c98cd66f4021e58156b08ee1ca261e53b59f520c7cbddf50d694b",
+				"DiscoKey":   "discokey:eadcedf14cba5846e362f443feaeb24b7c934a69010924a7d6d75cc6da310f03",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60231", "10.65.0.27:60231", "172.17.0.1:60231"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:38:20.879296989Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3971276804133734,
+				"StableID":   "nhpbB3ib1Y11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bcd002d4bdb06af74decde14fc1105ff72370c6017a7c6b34d21ee808438454a",
+				"DiscoKey":   "discokey:80f37d7b8610283475e3b32c8f832d5dec2aa65b98ee96ef7ad6e14f247ae807",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38697", "10.65.0.27:38697", "172.17.0.1:38697"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:38:21.980913833Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8699044213249234,
+				"StableID":   "nFqYe99pvA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01f0e75c7e15984ff84f3548a583b11d5d0767933219c5c86a83e6a435045144",
+				"DiscoKey":   "discokey:c02f7b529eea59a55aabee3f800e24094addf73ee371dde868f35019b29f5e78",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34188", "10.65.0.27:34188", "172.17.0.1:34188"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:38:22.593455803Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8238520975478923,
+				"StableID":   "nCPa7cyEL721CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f1c84edb7495b0445e548598c8a13605c3a845ba434ff44c03619df91403955d",
+				"KeyExpiry":  "2026-10-26T10:38:23Z",
+				"DiscoKey":   "discokey:0c655178a0697f9f6c65fdc8ee913dbaf578c0d023c6e9e6549216daf959f826",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54289", "10.65.0.27:54289", "172.17.0.1:54289"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:38:23.113024696Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3316941455849157,
+				"StableID":   "ni128oRFuS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:34c0fa1a92797ea1d95bb5ede8dfc9802e3ede8533d41b3b393e598ff1325862",
+				"KeyExpiry":  "2026-10-26T10:38:23Z",
+				"DiscoKey":   "discokey:b95bf106ecaf8cab0f0fba8da5c966b8843f00de14ec703a63489ae58955ae4f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:40471", "10.65.0.27:40471", "172.17.0.1:40471"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:38:23.662258727Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4918020572410626,
+				"StableID":   "noyn1Y4PQf11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:71e01c1f68fee5c55315712a11965ca4d375c9784e6af242b532bdf4d294b56c",
+				"KeyExpiry":  "2026-10-26T10:38:24Z",
+				"DiscoKey":   "discokey:464a72887bd55dea60c5f09b515c283d9980ab8011febd6adfb6e41945fe1b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34405", "10.65.0.27:34405", "172.17.0.1:34405"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:38:24.175766736Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2962093807975772": {
+				"ID":          2962093807975772,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-accept-fail-port-list-mismatch.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-accept-fail-port-list-mismatch.hujson
@@ -1,0 +1,8847 @@
+// policytest-accept-fail-port-list-mismatch
+//
+// tests block accept-fail: dst port list disjoint from rule
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:38:45Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-accept-fail-port-list-mismatch",
+	"description":    "tests block accept-fail: dst port list disjoint from rule",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:38:45.917578927Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                            \n  \n                                                                   \n                                                                \n{\n\t\"id\":          \"policytest-accept-fail-port-list-mismatch\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block accept-fail: dst port list disjoint from rule\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"group:developers\"], \"dst\": [\"webserver:80,443\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"accept\": [\"webserver:22,3306\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-accept-fail-port-list-mismatch.hujson",
+		"full_policy": {
+			"acls": [{
+				"action": "accept",
+				"dst":    ["webserver:80,443"],
+				"src":    ["group:developers"]
+			}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["webserver:22,3306"], "src": "thor@example.org"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6390330479321103,
+				"StableID":   "npbLoS9Cur11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6390330479321103,
+				"Key":        "nodekey:c69ea3490bfabd5c368b304dea71318d3d424d0295f9f146847b778a6d76a61a",
+				"DiscoKey":   "discokey:7b3687f5acce448deef29cc24f5e4190979af491681d1dcf1f7b6215f14c334d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:37796", "10.65.0.27:37796", "172.17.0.1:37796"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:38:49.607288677Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c69ea3490bfabd5c368b304dea71318d3d424d0295f9f146847b778a6d76a61a",
+			"MachineKey": "mkey:ff595592e0da5892a4167d34608e816ac7fe4d80c1135d973de8c285144ca86f",
+			"Peers": [{
+				"ID":         3885986622150508,
+				"StableID":   "nZX5sBHyLX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d9624f8291fb52906a8b613cecde32ffc10a3ba6de31bd303c9a838c68ee0362",
+				"DiscoKey":   "discokey:6d5f38d8a01f95160635bec7571a9a7660c945d2f1086f93e1cb5144c71cd05f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59947", "10.65.0.27:59947", "172.17.0.1:59947"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:38:47.47376633Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         147870895795182,
+				"StableID":   "nDGghRKy9211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67abf6db618d5398cc8cf9f67bb83b831c469c37d2ad190d906bd45969f8f469",
+				"DiscoKey":   "discokey:a984c6a56f3e902cb62bc635b37b705e8292944bc1b15b4593ddabc8979fb73c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56606", "10.65.0.27:56606", "172.17.0.1:56606"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:38:48.023308645Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         581155887201593,
+				"StableID":   "neyGgpyCY511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f743c9eb1956aa366f28bb845722bccb1a3b1e4e37fc9e7993d836189bda830c",
+				"DiscoKey":   "discokey:2105620164358678a69d86fd0dfc83ee743f846cc1b4ccd33eb6ee008b070e2a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:38104", "10.65.0.27:38104", "172.17.0.1:38104"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:38:48.563201307Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8032249215135038,
+				"StableID":   "njMnzrZpi521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:292394fb5da2b8880249107ece66f5f192671f27b6a6a5d8dcf0cdfc085a1f2e",
+				"DiscoKey":   "discokey:50bda4231b96aefef979eedbbaa35278427056e0ed8135bf193c98323a235850",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59953", "10.65.0.27:59953", "172.17.0.1:59953"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:38:49.105240955Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8987788355030454,
+				"StableID":   "nFZXhexaBD21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2ed257f2b9a7fe9d61dcb04c182190798063fa49d60669a01e941187011d85b",
+				"KeyExpiry":  "2026-10-26T10:38:50Z",
+				"DiscoKey":   "discokey:16e6aa659c705a3e88ac2175e092ba9f9487d78eac5ef6300a6321928e12926b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33611", "10.65.0.27:33611", "172.17.0.1:33611"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:38:50.15914721Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6549857845594458,
+				"StableID":   "n3h5tDfS9t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:685dbe165d8887d2ffea674a2175daa26eb187ad2bed81b1b36890b0d7122d6a",
+				"KeyExpiry":  "2026-10-26T10:38:50Z",
+				"DiscoKey":   "discokey:b3a65a7942514570fed24103a83aa90d3e21b563f8faeab4fe7f9ce38cb8bb18",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48324", "10.65.0.27:48324", "172.17.0.1:48324"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:38:50.694078484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4532056775705055,
+				"StableID":   "nEAFytSaPc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2bf630560d8af25297da574207c192043037c05904d9bd6b4e647286400f6722",
+				"KeyExpiry":  "2026-10-26T10:38:51Z",
+				"DiscoKey":   "discokey:7deac42dbc328da380d47c0290602589073a9ba2d8250f1293cfa41d48099b4e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:49839", "10.65.0.27:49839", "172.17.0.1:49839"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:38:51.268058669Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6390330479321103": {
+				"ID":          6390330479321103,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4532056775705055,
+				"StableID":   "nEAFytSaPc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2bf630560d8af25297da574207c192043037c05904d9bd6b4e647286400f6722",
+				"KeyExpiry":  "2026-10-26T10:38:51Z",
+				"DiscoKey":   "discokey:7deac42dbc328da380d47c0290602589073a9ba2d8250f1293cfa41d48099b4e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:49839", "10.65.0.27:49839", "172.17.0.1:49839"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:38:51.268058669Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2bf630560d8af25297da574207c192043037c05904d9bd6b4e647286400f6722",
+			"MachineKey": "mkey:c7729da52f6116aff7f267e366cf5e0fcce0a575ce5a245442a18041bf6f9d31",
+			"Peers": [{
+				"ID":         3885986622150508,
+				"StableID":   "nZX5sBHyLX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d9624f8291fb52906a8b613cecde32ffc10a3ba6de31bd303c9a838c68ee0362",
+				"DiscoKey":   "discokey:6d5f38d8a01f95160635bec7571a9a7660c945d2f1086f93e1cb5144c71cd05f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59947", "10.65.0.27:59947", "172.17.0.1:59947"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:38:47.47376633Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         147870895795182,
+				"StableID":   "nDGghRKy9211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67abf6db618d5398cc8cf9f67bb83b831c469c37d2ad190d906bd45969f8f469",
+				"DiscoKey":   "discokey:a984c6a56f3e902cb62bc635b37b705e8292944bc1b15b4593ddabc8979fb73c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56606", "10.65.0.27:56606", "172.17.0.1:56606"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:38:48.023308645Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         581155887201593,
+				"StableID":   "neyGgpyCY511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f743c9eb1956aa366f28bb845722bccb1a3b1e4e37fc9e7993d836189bda830c",
+				"DiscoKey":   "discokey:2105620164358678a69d86fd0dfc83ee743f846cc1b4ccd33eb6ee008b070e2a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:38104", "10.65.0.27:38104", "172.17.0.1:38104"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:38:48.563201307Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8032249215135038,
+				"StableID":   "njMnzrZpi521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:292394fb5da2b8880249107ece66f5f192671f27b6a6a5d8dcf0cdfc085a1f2e",
+				"DiscoKey":   "discokey:50bda4231b96aefef979eedbbaa35278427056e0ed8135bf193c98323a235850",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59953", "10.65.0.27:59953", "172.17.0.1:59953"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:38:49.105240955Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6390330479321103,
+				"StableID":   "npbLoS9Cur11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c69ea3490bfabd5c368b304dea71318d3d424d0295f9f146847b778a6d76a61a",
+				"DiscoKey":   "discokey:7b3687f5acce448deef29cc24f5e4190979af491681d1dcf1f7b6215f14c334d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:37796", "10.65.0.27:37796", "172.17.0.1:37796"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:38:49.607288677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8987788355030454,
+				"StableID":   "nFZXhexaBD21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2ed257f2b9a7fe9d61dcb04c182190798063fa49d60669a01e941187011d85b",
+				"KeyExpiry":  "2026-10-26T10:38:50Z",
+				"DiscoKey":   "discokey:16e6aa659c705a3e88ac2175e092ba9f9487d78eac5ef6300a6321928e12926b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33611", "10.65.0.27:33611", "172.17.0.1:33611"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:38:50.15914721Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6549857845594458,
+				"StableID":   "n3h5tDfS9t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:685dbe165d8887d2ffea674a2175daa26eb187ad2bed81b1b36890b0d7122d6a",
+				"KeyExpiry":  "2026-10-26T10:38:50Z",
+				"DiscoKey":   "discokey:b3a65a7942514570fed24103a83aa90d3e21b563f8faeab4fe7f9ce38cb8bb18",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48324", "10.65.0.27:48324", "172.17.0.1:48324"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:38:50.694078484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3885986622150508,
+				"StableID":   "nZX5sBHyLX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       3885986622150508,
+				"Key":        "nodekey:d9624f8291fb52906a8b613cecde32ffc10a3ba6de31bd303c9a838c68ee0362",
+				"DiscoKey":   "discokey:6d5f38d8a01f95160635bec7571a9a7660c945d2f1086f93e1cb5144c71cd05f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59947", "10.65.0.27:59947", "172.17.0.1:59947"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:38:47.47376633Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d9624f8291fb52906a8b613cecde32ffc10a3ba6de31bd303c9a838c68ee0362",
+			"MachineKey": "mkey:042adced42d4770d77980130bc5df3ffd9c3c9db38ee59003c9a510f3f83a378",
+			"Peers": [{
+				"ID":         147870895795182,
+				"StableID":   "nDGghRKy9211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67abf6db618d5398cc8cf9f67bb83b831c469c37d2ad190d906bd45969f8f469",
+				"DiscoKey":   "discokey:a984c6a56f3e902cb62bc635b37b705e8292944bc1b15b4593ddabc8979fb73c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56606", "10.65.0.27:56606", "172.17.0.1:56606"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:38:48.023308645Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         581155887201593,
+				"StableID":   "neyGgpyCY511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f743c9eb1956aa366f28bb845722bccb1a3b1e4e37fc9e7993d836189bda830c",
+				"DiscoKey":   "discokey:2105620164358678a69d86fd0dfc83ee743f846cc1b4ccd33eb6ee008b070e2a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:38104", "10.65.0.27:38104", "172.17.0.1:38104"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:38:48.563201307Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8032249215135038,
+				"StableID":   "njMnzrZpi521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:292394fb5da2b8880249107ece66f5f192671f27b6a6a5d8dcf0cdfc085a1f2e",
+				"DiscoKey":   "discokey:50bda4231b96aefef979eedbbaa35278427056e0ed8135bf193c98323a235850",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59953", "10.65.0.27:59953", "172.17.0.1:59953"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:38:49.105240955Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6390330479321103,
+				"StableID":   "npbLoS9Cur11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c69ea3490bfabd5c368b304dea71318d3d424d0295f9f146847b778a6d76a61a",
+				"DiscoKey":   "discokey:7b3687f5acce448deef29cc24f5e4190979af491681d1dcf1f7b6215f14c334d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:37796", "10.65.0.27:37796", "172.17.0.1:37796"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:38:49.607288677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8987788355030454,
+				"StableID":   "nFZXhexaBD21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2ed257f2b9a7fe9d61dcb04c182190798063fa49d60669a01e941187011d85b",
+				"KeyExpiry":  "2026-10-26T10:38:50Z",
+				"DiscoKey":   "discokey:16e6aa659c705a3e88ac2175e092ba9f9487d78eac5ef6300a6321928e12926b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33611", "10.65.0.27:33611", "172.17.0.1:33611"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:38:50.15914721Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6549857845594458,
+				"StableID":   "n3h5tDfS9t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:685dbe165d8887d2ffea674a2175daa26eb187ad2bed81b1b36890b0d7122d6a",
+				"KeyExpiry":  "2026-10-26T10:38:50Z",
+				"DiscoKey":   "discokey:b3a65a7942514570fed24103a83aa90d3e21b563f8faeab4fe7f9ce38cb8bb18",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48324", "10.65.0.27:48324", "172.17.0.1:48324"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:38:50.694078484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4532056775705055,
+				"StableID":   "nEAFytSaPc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2bf630560d8af25297da574207c192043037c05904d9bd6b4e647286400f6722",
+				"KeyExpiry":  "2026-10-26T10:38:51Z",
+				"DiscoKey":   "discokey:7deac42dbc328da380d47c0290602589073a9ba2d8250f1293cfa41d48099b4e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:49839", "10.65.0.27:49839", "172.17.0.1:49839"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:38:51.268058669Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3885986622150508": {
+				"ID":          3885986622150508,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8987788355030454,
+				"StableID":   "nFZXhexaBD21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2ed257f2b9a7fe9d61dcb04c182190798063fa49d60669a01e941187011d85b",
+				"KeyExpiry":  "2026-10-26T10:38:50Z",
+				"DiscoKey":   "discokey:16e6aa659c705a3e88ac2175e092ba9f9487d78eac5ef6300a6321928e12926b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33611", "10.65.0.27:33611", "172.17.0.1:33611"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:38:50.15914721Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f2ed257f2b9a7fe9d61dcb04c182190798063fa49d60669a01e941187011d85b",
+			"MachineKey": "mkey:810ee99859187eae9e3c6197bfa1940611e019173b664bf0b51aa62133e2f651",
+			"Peers": [{
+				"ID":         3885986622150508,
+				"StableID":   "nZX5sBHyLX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d9624f8291fb52906a8b613cecde32ffc10a3ba6de31bd303c9a838c68ee0362",
+				"DiscoKey":   "discokey:6d5f38d8a01f95160635bec7571a9a7660c945d2f1086f93e1cb5144c71cd05f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59947", "10.65.0.27:59947", "172.17.0.1:59947"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:38:47.47376633Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         147870895795182,
+				"StableID":   "nDGghRKy9211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67abf6db618d5398cc8cf9f67bb83b831c469c37d2ad190d906bd45969f8f469",
+				"DiscoKey":   "discokey:a984c6a56f3e902cb62bc635b37b705e8292944bc1b15b4593ddabc8979fb73c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56606", "10.65.0.27:56606", "172.17.0.1:56606"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:38:48.023308645Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         581155887201593,
+				"StableID":   "neyGgpyCY511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f743c9eb1956aa366f28bb845722bccb1a3b1e4e37fc9e7993d836189bda830c",
+				"DiscoKey":   "discokey:2105620164358678a69d86fd0dfc83ee743f846cc1b4ccd33eb6ee008b070e2a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:38104", "10.65.0.27:38104", "172.17.0.1:38104"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:38:48.563201307Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8032249215135038,
+				"StableID":   "njMnzrZpi521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:292394fb5da2b8880249107ece66f5f192671f27b6a6a5d8dcf0cdfc085a1f2e",
+				"DiscoKey":   "discokey:50bda4231b96aefef979eedbbaa35278427056e0ed8135bf193c98323a235850",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59953", "10.65.0.27:59953", "172.17.0.1:59953"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:38:49.105240955Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6390330479321103,
+				"StableID":   "npbLoS9Cur11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c69ea3490bfabd5c368b304dea71318d3d424d0295f9f146847b778a6d76a61a",
+				"DiscoKey":   "discokey:7b3687f5acce448deef29cc24f5e4190979af491681d1dcf1f7b6215f14c334d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:37796", "10.65.0.27:37796", "172.17.0.1:37796"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:38:49.607288677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6549857845594458,
+				"StableID":   "n3h5tDfS9t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:685dbe165d8887d2ffea674a2175daa26eb187ad2bed81b1b36890b0d7122d6a",
+				"KeyExpiry":  "2026-10-26T10:38:50Z",
+				"DiscoKey":   "discokey:b3a65a7942514570fed24103a83aa90d3e21b563f8faeab4fe7f9ce38cb8bb18",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48324", "10.65.0.27:48324", "172.17.0.1:48324"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:38:50.694078484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4532056775705055,
+				"StableID":   "nEAFytSaPc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2bf630560d8af25297da574207c192043037c05904d9bd6b4e647286400f6722",
+				"KeyExpiry":  "2026-10-26T10:38:51Z",
+				"DiscoKey":   "discokey:7deac42dbc328da380d47c0290602589073a9ba2d8250f1293cfa41d48099b4e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:49839", "10.65.0.27:49839", "172.17.0.1:49839"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:38:51.268058669Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8032249215135038,
+				"StableID":   "njMnzrZpi521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       8032249215135038,
+				"Key":        "nodekey:292394fb5da2b8880249107ece66f5f192671f27b6a6a5d8dcf0cdfc085a1f2e",
+				"DiscoKey":   "discokey:50bda4231b96aefef979eedbbaa35278427056e0ed8135bf193c98323a235850",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59953", "10.65.0.27:59953", "172.17.0.1:59953"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:38:49.105240955Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:292394fb5da2b8880249107ece66f5f192671f27b6a6a5d8dcf0cdfc085a1f2e",
+			"MachineKey": "mkey:aff7094daeb6a14412c386653269d3121cb31e7794bb350043cc9585fd539668",
+			"Peers": [{
+				"ID":         3885986622150508,
+				"StableID":   "nZX5sBHyLX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d9624f8291fb52906a8b613cecde32ffc10a3ba6de31bd303c9a838c68ee0362",
+				"DiscoKey":   "discokey:6d5f38d8a01f95160635bec7571a9a7660c945d2f1086f93e1cb5144c71cd05f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59947", "10.65.0.27:59947", "172.17.0.1:59947"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:38:47.47376633Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         147870895795182,
+				"StableID":   "nDGghRKy9211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67abf6db618d5398cc8cf9f67bb83b831c469c37d2ad190d906bd45969f8f469",
+				"DiscoKey":   "discokey:a984c6a56f3e902cb62bc635b37b705e8292944bc1b15b4593ddabc8979fb73c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56606", "10.65.0.27:56606", "172.17.0.1:56606"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:38:48.023308645Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         581155887201593,
+				"StableID":   "neyGgpyCY511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f743c9eb1956aa366f28bb845722bccb1a3b1e4e37fc9e7993d836189bda830c",
+				"DiscoKey":   "discokey:2105620164358678a69d86fd0dfc83ee743f846cc1b4ccd33eb6ee008b070e2a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:38104", "10.65.0.27:38104", "172.17.0.1:38104"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:38:48.563201307Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6390330479321103,
+				"StableID":   "npbLoS9Cur11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c69ea3490bfabd5c368b304dea71318d3d424d0295f9f146847b778a6d76a61a",
+				"DiscoKey":   "discokey:7b3687f5acce448deef29cc24f5e4190979af491681d1dcf1f7b6215f14c334d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:37796", "10.65.0.27:37796", "172.17.0.1:37796"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:38:49.607288677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8987788355030454,
+				"StableID":   "nFZXhexaBD21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2ed257f2b9a7fe9d61dcb04c182190798063fa49d60669a01e941187011d85b",
+				"KeyExpiry":  "2026-10-26T10:38:50Z",
+				"DiscoKey":   "discokey:16e6aa659c705a3e88ac2175e092ba9f9487d78eac5ef6300a6321928e12926b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33611", "10.65.0.27:33611", "172.17.0.1:33611"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:38:50.15914721Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6549857845594458,
+				"StableID":   "n3h5tDfS9t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:685dbe165d8887d2ffea674a2175daa26eb187ad2bed81b1b36890b0d7122d6a",
+				"KeyExpiry":  "2026-10-26T10:38:50Z",
+				"DiscoKey":   "discokey:b3a65a7942514570fed24103a83aa90d3e21b563f8faeab4fe7f9ce38cb8bb18",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48324", "10.65.0.27:48324", "172.17.0.1:48324"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:38:50.694078484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4532056775705055,
+				"StableID":   "nEAFytSaPc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2bf630560d8af25297da574207c192043037c05904d9bd6b4e647286400f6722",
+				"KeyExpiry":  "2026-10-26T10:38:51Z",
+				"DiscoKey":   "discokey:7deac42dbc328da380d47c0290602589073a9ba2d8250f1293cfa41d48099b4e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:49839", "10.65.0.27:49839", "172.17.0.1:49839"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:38:51.268058669Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8032249215135038": {
+				"ID":          8032249215135038,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         147870895795182,
+				"StableID":   "nDGghRKy9211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       147870895795182,
+				"Key":        "nodekey:67abf6db618d5398cc8cf9f67bb83b831c469c37d2ad190d906bd45969f8f469",
+				"DiscoKey":   "discokey:a984c6a56f3e902cb62bc635b37b705e8292944bc1b15b4593ddabc8979fb73c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56606", "10.65.0.27:56606", "172.17.0.1:56606"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:38:48.023308645Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:67abf6db618d5398cc8cf9f67bb83b831c469c37d2ad190d906bd45969f8f469",
+			"MachineKey": "mkey:ab5dcbbfdbbf679dedec0150cade554becd001613bd59315d282c0d83532e64a",
+			"Peers": [{
+				"ID":         3885986622150508,
+				"StableID":   "nZX5sBHyLX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d9624f8291fb52906a8b613cecde32ffc10a3ba6de31bd303c9a838c68ee0362",
+				"DiscoKey":   "discokey:6d5f38d8a01f95160635bec7571a9a7660c945d2f1086f93e1cb5144c71cd05f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59947", "10.65.0.27:59947", "172.17.0.1:59947"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:38:47.47376633Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         581155887201593,
+				"StableID":   "neyGgpyCY511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f743c9eb1956aa366f28bb845722bccb1a3b1e4e37fc9e7993d836189bda830c",
+				"DiscoKey":   "discokey:2105620164358678a69d86fd0dfc83ee743f846cc1b4ccd33eb6ee008b070e2a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:38104", "10.65.0.27:38104", "172.17.0.1:38104"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:38:48.563201307Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8032249215135038,
+				"StableID":   "njMnzrZpi521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:292394fb5da2b8880249107ece66f5f192671f27b6a6a5d8dcf0cdfc085a1f2e",
+				"DiscoKey":   "discokey:50bda4231b96aefef979eedbbaa35278427056e0ed8135bf193c98323a235850",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59953", "10.65.0.27:59953", "172.17.0.1:59953"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:38:49.105240955Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6390330479321103,
+				"StableID":   "npbLoS9Cur11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c69ea3490bfabd5c368b304dea71318d3d424d0295f9f146847b778a6d76a61a",
+				"DiscoKey":   "discokey:7b3687f5acce448deef29cc24f5e4190979af491681d1dcf1f7b6215f14c334d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:37796", "10.65.0.27:37796", "172.17.0.1:37796"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:38:49.607288677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8987788355030454,
+				"StableID":   "nFZXhexaBD21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2ed257f2b9a7fe9d61dcb04c182190798063fa49d60669a01e941187011d85b",
+				"KeyExpiry":  "2026-10-26T10:38:50Z",
+				"DiscoKey":   "discokey:16e6aa659c705a3e88ac2175e092ba9f9487d78eac5ef6300a6321928e12926b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33611", "10.65.0.27:33611", "172.17.0.1:33611"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:38:50.15914721Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6549857845594458,
+				"StableID":   "n3h5tDfS9t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:685dbe165d8887d2ffea674a2175daa26eb187ad2bed81b1b36890b0d7122d6a",
+				"KeyExpiry":  "2026-10-26T10:38:50Z",
+				"DiscoKey":   "discokey:b3a65a7942514570fed24103a83aa90d3e21b563f8faeab4fe7f9ce38cb8bb18",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48324", "10.65.0.27:48324", "172.17.0.1:48324"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:38:50.694078484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4532056775705055,
+				"StableID":   "nEAFytSaPc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2bf630560d8af25297da574207c192043037c05904d9bd6b4e647286400f6722",
+				"KeyExpiry":  "2026-10-26T10:38:51Z",
+				"DiscoKey":   "discokey:7deac42dbc328da380d47c0290602589073a9ba2d8250f1293cfa41d48099b4e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:49839", "10.65.0.27:49839", "172.17.0.1:49839"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:38:51.268058669Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "147870895795182": {
+				"ID":          147870895795182,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6549857845594458,
+				"StableID":   "n3h5tDfS9t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:685dbe165d8887d2ffea674a2175daa26eb187ad2bed81b1b36890b0d7122d6a",
+				"KeyExpiry":  "2026-10-26T10:38:50Z",
+				"DiscoKey":   "discokey:b3a65a7942514570fed24103a83aa90d3e21b563f8faeab4fe7f9ce38cb8bb18",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48324", "10.65.0.27:48324", "172.17.0.1:48324"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:38:50.694078484Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:685dbe165d8887d2ffea674a2175daa26eb187ad2bed81b1b36890b0d7122d6a",
+			"MachineKey": "mkey:dd9262f1c6c12525c7623366d012cac59fb8e46ce6f292f40a9475014ff0516f",
+			"Peers": [{
+				"ID":         3885986622150508,
+				"StableID":   "nZX5sBHyLX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d9624f8291fb52906a8b613cecde32ffc10a3ba6de31bd303c9a838c68ee0362",
+				"DiscoKey":   "discokey:6d5f38d8a01f95160635bec7571a9a7660c945d2f1086f93e1cb5144c71cd05f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59947", "10.65.0.27:59947", "172.17.0.1:59947"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:38:47.47376633Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         147870895795182,
+				"StableID":   "nDGghRKy9211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67abf6db618d5398cc8cf9f67bb83b831c469c37d2ad190d906bd45969f8f469",
+				"DiscoKey":   "discokey:a984c6a56f3e902cb62bc635b37b705e8292944bc1b15b4593ddabc8979fb73c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56606", "10.65.0.27:56606", "172.17.0.1:56606"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:38:48.023308645Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         581155887201593,
+				"StableID":   "neyGgpyCY511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f743c9eb1956aa366f28bb845722bccb1a3b1e4e37fc9e7993d836189bda830c",
+				"DiscoKey":   "discokey:2105620164358678a69d86fd0dfc83ee743f846cc1b4ccd33eb6ee008b070e2a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:38104", "10.65.0.27:38104", "172.17.0.1:38104"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:38:48.563201307Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8032249215135038,
+				"StableID":   "njMnzrZpi521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:292394fb5da2b8880249107ece66f5f192671f27b6a6a5d8dcf0cdfc085a1f2e",
+				"DiscoKey":   "discokey:50bda4231b96aefef979eedbbaa35278427056e0ed8135bf193c98323a235850",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59953", "10.65.0.27:59953", "172.17.0.1:59953"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:38:49.105240955Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6390330479321103,
+				"StableID":   "npbLoS9Cur11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c69ea3490bfabd5c368b304dea71318d3d424d0295f9f146847b778a6d76a61a",
+				"DiscoKey":   "discokey:7b3687f5acce448deef29cc24f5e4190979af491681d1dcf1f7b6215f14c334d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:37796", "10.65.0.27:37796", "172.17.0.1:37796"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:38:49.607288677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8987788355030454,
+				"StableID":   "nFZXhexaBD21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2ed257f2b9a7fe9d61dcb04c182190798063fa49d60669a01e941187011d85b",
+				"KeyExpiry":  "2026-10-26T10:38:50Z",
+				"DiscoKey":   "discokey:16e6aa659c705a3e88ac2175e092ba9f9487d78eac5ef6300a6321928e12926b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33611", "10.65.0.27:33611", "172.17.0.1:33611"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:38:50.15914721Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4532056775705055,
+				"StableID":   "nEAFytSaPc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2bf630560d8af25297da574207c192043037c05904d9bd6b4e647286400f6722",
+				"KeyExpiry":  "2026-10-26T10:38:51Z",
+				"DiscoKey":   "discokey:7deac42dbc328da380d47c0290602589073a9ba2d8250f1293cfa41d48099b4e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:49839", "10.65.0.27:49839", "172.17.0.1:49839"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:38:51.268058669Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         581155887201593,
+				"StableID":   "neyGgpyCY511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       581155887201593,
+				"Key":        "nodekey:f743c9eb1956aa366f28bb845722bccb1a3b1e4e37fc9e7993d836189bda830c",
+				"DiscoKey":   "discokey:2105620164358678a69d86fd0dfc83ee743f846cc1b4ccd33eb6ee008b070e2a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:38104", "10.65.0.27:38104", "172.17.0.1:38104"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:38:48.563201307Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f743c9eb1956aa366f28bb845722bccb1a3b1e4e37fc9e7993d836189bda830c",
+			"MachineKey": "mkey:e8d9b328936199adf1c6398bf4599e36aa976b09e498311609f46b67d377de00",
+			"Peers": [{
+				"ID":         3885986622150508,
+				"StableID":   "nZX5sBHyLX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d9624f8291fb52906a8b613cecde32ffc10a3ba6de31bd303c9a838c68ee0362",
+				"DiscoKey":   "discokey:6d5f38d8a01f95160635bec7571a9a7660c945d2f1086f93e1cb5144c71cd05f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59947", "10.65.0.27:59947", "172.17.0.1:59947"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:38:47.47376633Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         147870895795182,
+				"StableID":   "nDGghRKy9211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67abf6db618d5398cc8cf9f67bb83b831c469c37d2ad190d906bd45969f8f469",
+				"DiscoKey":   "discokey:a984c6a56f3e902cb62bc635b37b705e8292944bc1b15b4593ddabc8979fb73c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56606", "10.65.0.27:56606", "172.17.0.1:56606"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:38:48.023308645Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8032249215135038,
+				"StableID":   "njMnzrZpi521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:292394fb5da2b8880249107ece66f5f192671f27b6a6a5d8dcf0cdfc085a1f2e",
+				"DiscoKey":   "discokey:50bda4231b96aefef979eedbbaa35278427056e0ed8135bf193c98323a235850",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59953", "10.65.0.27:59953", "172.17.0.1:59953"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:38:49.105240955Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6390330479321103,
+				"StableID":   "npbLoS9Cur11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c69ea3490bfabd5c368b304dea71318d3d424d0295f9f146847b778a6d76a61a",
+				"DiscoKey":   "discokey:7b3687f5acce448deef29cc24f5e4190979af491681d1dcf1f7b6215f14c334d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:37796", "10.65.0.27:37796", "172.17.0.1:37796"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:38:49.607288677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8987788355030454,
+				"StableID":   "nFZXhexaBD21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2ed257f2b9a7fe9d61dcb04c182190798063fa49d60669a01e941187011d85b",
+				"KeyExpiry":  "2026-10-26T10:38:50Z",
+				"DiscoKey":   "discokey:16e6aa659c705a3e88ac2175e092ba9f9487d78eac5ef6300a6321928e12926b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33611", "10.65.0.27:33611", "172.17.0.1:33611"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:38:50.15914721Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6549857845594458,
+				"StableID":   "n3h5tDfS9t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:685dbe165d8887d2ffea674a2175daa26eb187ad2bed81b1b36890b0d7122d6a",
+				"KeyExpiry":  "2026-10-26T10:38:50Z",
+				"DiscoKey":   "discokey:b3a65a7942514570fed24103a83aa90d3e21b563f8faeab4fe7f9ce38cb8bb18",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48324", "10.65.0.27:48324", "172.17.0.1:48324"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:38:50.694078484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4532056775705055,
+				"StableID":   "nEAFytSaPc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2bf630560d8af25297da574207c192043037c05904d9bd6b4e647286400f6722",
+				"KeyExpiry":  "2026-10-26T10:38:51Z",
+				"DiscoKey":   "discokey:7deac42dbc328da380d47c0290602589073a9ba2d8250f1293cfa41d48099b4e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:49839", "10.65.0.27:49839", "172.17.0.1:49839"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:38:51.268058669Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "581155887201593": {
+				"ID":          581155887201593,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-accept-fail-port-range-mismatch.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-accept-fail-port-range-mismatch.hujson
@@ -1,0 +1,8845 @@
+// policytest-accept-fail-port-range-mismatch
+//
+// tests block accept-fail: dst port range outside rule's allowed port
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:39:12Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-accept-fail-port-range-mismatch",
+	"description":    "tests block accept-fail: dst port range outside rule's allowed port",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:39:12.996541672Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                             \n  \n                                                                    \n                                                                       \n{\n\t\"id\":          \"policytest-accept-fail-port-range-mismatch\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block accept-fail: dst port range outside rule's allowed port\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"group:developers\"], \"dst\": [\"webserver:80\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"accept\": [\"webserver:8000-8100\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-accept-fail-port-range-mismatch.hujson",
+		"full_policy": {
+			"acls": [
+				{"action": "accept", "dst": ["webserver:80"], "src": ["group:developers"]}
+			],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["webserver:8000-8100"], "src": "thor@example.org"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6428733811929947,
+				"StableID":   "nEC9oHwaCs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6428733811929947,
+				"Key":        "nodekey:94b33de474979bfcd1dd06182db13a6be88723620dade46a256be495cd659510",
+				"DiscoKey":   "discokey:ce25a7fc5374aa1b58acebc8fb2f96ce85f52df6f41a53f9800d077c8886eb5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57271", "10.65.0.27:57271", "172.17.0.1:57271"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:39:16.711978643Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:94b33de474979bfcd1dd06182db13a6be88723620dade46a256be495cd659510",
+			"MachineKey": "mkey:8a2941c00c464bd712ded0abacc4278e186de8c2a012cb6cb4b2a5e4ec2a4c34",
+			"Peers": [{
+				"ID":         4643946780644944,
+				"StableID":   "nDZJZDcFGd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1fbe70b883e5054a9767a4361556608f8a2e0638daf9eb455baa4c88f672af1f",
+				"DiscoKey":   "discokey:336ee1c334ac5ea06a2150eb8a933440089e5468a732d6cb97216287dad0f747",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:51903", "10.65.0.27:51903", "172.17.0.1:51903"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:39:14.482920693Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6605059533556240,
+				"StableID":   "nRox1QiSat11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21c0d4e84af962dc6409df3dff17105f69929a82b55cd3a71f6b02b3dedcf37f",
+				"DiscoKey":   "discokey:2e4924cd5d98cbcf66b834159ff45a7068344938fad1b5b75421b51cf22ed31b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54508", "10.65.0.27:54508", "172.17.0.1:54508"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:39:15.044496951Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6781198105298853,
+				"StableID":   "nCCiSNaDxu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26bad139f355c177a2eaad2ef59f65a8e745d5b7e68349685e448909a7fff214",
+				"DiscoKey":   "discokey:97bd894d3f77932e1e7e87342f9db339ce8ffc4a7e2ae95c900133824ef0913e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47788", "10.65.0.27:47788", "172.17.0.1:47788"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:39:15.608543833Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8266086595639517,
+				"StableID":   "ntLEaX5jY721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb11c9420a8af35433b446e92746034c61412b607400dccceba1a5f54375c73",
+				"DiscoKey":   "discokey:9981efb3619dcabb52688602f28843251af6037b64215b03f67635085f38e120",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56292", "10.65.0.27:56292", "172.17.0.1:56292"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:39:16.142765235Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         772643950650921,
+				"StableID":   "ntWC8h3w2711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:27d5c5ffd86aeecb038a64611415fc5edd4dbac279739b59695aead4d3ebdd3f",
+				"KeyExpiry":  "2026-10-26T10:39:17Z",
+				"DiscoKey":   "discokey:a9ba90b0f7b55ea781f9a843710555436d205019d7890ab1e95320529c6ccf23",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33641", "10.65.0.27:33641", "172.17.0.1:33641"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:39:17.212580332Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5796044830383630,
+				"StableID":   "nRaC3dG3Gn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd34d3a1c6643648cb53f7e317eaea9cad77726f5ea632463bcad3336e9b5c01",
+				"KeyExpiry":  "2026-10-26T10:39:17Z",
+				"DiscoKey":   "discokey:1651f7a4fed3e75b02b6b3f7af48ecf598388b97cec91497f34da5a84452b237",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52149", "10.65.0.27:52149", "172.17.0.1:52149"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:39:17.792488063Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8780606967579194,
+				"StableID":   "nZS3x2fkZB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1ec87c8975e68992eae89c834b9e75aad838c8cd7d6dfb5dbda82d5441da6b66",
+				"KeyExpiry":  "2026-10-26T10:39:18Z",
+				"DiscoKey":   "discokey:def02699535980143cbb0da404d721dbce7a6366ae2f18f971dd5bddc5c5de3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:56061", "10.65.0.27:56061", "172.17.0.1:56061"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:39:18.317065956Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6428733811929947": {
+				"ID":          6428733811929947,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8780606967579194,
+				"StableID":   "nZS3x2fkZB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1ec87c8975e68992eae89c834b9e75aad838c8cd7d6dfb5dbda82d5441da6b66",
+				"KeyExpiry":  "2026-10-26T10:39:18Z",
+				"DiscoKey":   "discokey:def02699535980143cbb0da404d721dbce7a6366ae2f18f971dd5bddc5c5de3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:56061", "10.65.0.27:56061", "172.17.0.1:56061"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:39:18.317065956Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1ec87c8975e68992eae89c834b9e75aad838c8cd7d6dfb5dbda82d5441da6b66",
+			"MachineKey": "mkey:8822b7a0c80a1a89ee2146d75281b82f9cb40cdb56fe12ac9fe22d5e48757158",
+			"Peers": [{
+				"ID":         4643946780644944,
+				"StableID":   "nDZJZDcFGd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1fbe70b883e5054a9767a4361556608f8a2e0638daf9eb455baa4c88f672af1f",
+				"DiscoKey":   "discokey:336ee1c334ac5ea06a2150eb8a933440089e5468a732d6cb97216287dad0f747",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:51903", "10.65.0.27:51903", "172.17.0.1:51903"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:39:14.482920693Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6605059533556240,
+				"StableID":   "nRox1QiSat11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21c0d4e84af962dc6409df3dff17105f69929a82b55cd3a71f6b02b3dedcf37f",
+				"DiscoKey":   "discokey:2e4924cd5d98cbcf66b834159ff45a7068344938fad1b5b75421b51cf22ed31b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54508", "10.65.0.27:54508", "172.17.0.1:54508"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:39:15.044496951Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6781198105298853,
+				"StableID":   "nCCiSNaDxu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26bad139f355c177a2eaad2ef59f65a8e745d5b7e68349685e448909a7fff214",
+				"DiscoKey":   "discokey:97bd894d3f77932e1e7e87342f9db339ce8ffc4a7e2ae95c900133824ef0913e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47788", "10.65.0.27:47788", "172.17.0.1:47788"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:39:15.608543833Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8266086595639517,
+				"StableID":   "ntLEaX5jY721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb11c9420a8af35433b446e92746034c61412b607400dccceba1a5f54375c73",
+				"DiscoKey":   "discokey:9981efb3619dcabb52688602f28843251af6037b64215b03f67635085f38e120",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56292", "10.65.0.27:56292", "172.17.0.1:56292"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:39:16.142765235Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6428733811929947,
+				"StableID":   "nEC9oHwaCs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:94b33de474979bfcd1dd06182db13a6be88723620dade46a256be495cd659510",
+				"DiscoKey":   "discokey:ce25a7fc5374aa1b58acebc8fb2f96ce85f52df6f41a53f9800d077c8886eb5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57271", "10.65.0.27:57271", "172.17.0.1:57271"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:39:16.711978643Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         772643950650921,
+				"StableID":   "ntWC8h3w2711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:27d5c5ffd86aeecb038a64611415fc5edd4dbac279739b59695aead4d3ebdd3f",
+				"KeyExpiry":  "2026-10-26T10:39:17Z",
+				"DiscoKey":   "discokey:a9ba90b0f7b55ea781f9a843710555436d205019d7890ab1e95320529c6ccf23",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33641", "10.65.0.27:33641", "172.17.0.1:33641"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:39:17.212580332Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5796044830383630,
+				"StableID":   "nRaC3dG3Gn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd34d3a1c6643648cb53f7e317eaea9cad77726f5ea632463bcad3336e9b5c01",
+				"KeyExpiry":  "2026-10-26T10:39:17Z",
+				"DiscoKey":   "discokey:1651f7a4fed3e75b02b6b3f7af48ecf598388b97cec91497f34da5a84452b237",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52149", "10.65.0.27:52149", "172.17.0.1:52149"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:39:17.792488063Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4643946780644944,
+				"StableID":   "nDZJZDcFGd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       4643946780644944,
+				"Key":        "nodekey:1fbe70b883e5054a9767a4361556608f8a2e0638daf9eb455baa4c88f672af1f",
+				"DiscoKey":   "discokey:336ee1c334ac5ea06a2150eb8a933440089e5468a732d6cb97216287dad0f747",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:51903", "10.65.0.27:51903", "172.17.0.1:51903"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:39:14.482920693Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1fbe70b883e5054a9767a4361556608f8a2e0638daf9eb455baa4c88f672af1f",
+			"MachineKey": "mkey:c1ff4ff3e0d814f5f87e9d42ba0904cf7da4c8332e5acdd2de8b96ccc20e7502",
+			"Peers": [{
+				"ID":         6605059533556240,
+				"StableID":   "nRox1QiSat11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21c0d4e84af962dc6409df3dff17105f69929a82b55cd3a71f6b02b3dedcf37f",
+				"DiscoKey":   "discokey:2e4924cd5d98cbcf66b834159ff45a7068344938fad1b5b75421b51cf22ed31b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54508", "10.65.0.27:54508", "172.17.0.1:54508"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:39:15.044496951Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6781198105298853,
+				"StableID":   "nCCiSNaDxu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26bad139f355c177a2eaad2ef59f65a8e745d5b7e68349685e448909a7fff214",
+				"DiscoKey":   "discokey:97bd894d3f77932e1e7e87342f9db339ce8ffc4a7e2ae95c900133824ef0913e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47788", "10.65.0.27:47788", "172.17.0.1:47788"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:39:15.608543833Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8266086595639517,
+				"StableID":   "ntLEaX5jY721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb11c9420a8af35433b446e92746034c61412b607400dccceba1a5f54375c73",
+				"DiscoKey":   "discokey:9981efb3619dcabb52688602f28843251af6037b64215b03f67635085f38e120",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56292", "10.65.0.27:56292", "172.17.0.1:56292"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:39:16.142765235Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6428733811929947,
+				"StableID":   "nEC9oHwaCs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:94b33de474979bfcd1dd06182db13a6be88723620dade46a256be495cd659510",
+				"DiscoKey":   "discokey:ce25a7fc5374aa1b58acebc8fb2f96ce85f52df6f41a53f9800d077c8886eb5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57271", "10.65.0.27:57271", "172.17.0.1:57271"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:39:16.711978643Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         772643950650921,
+				"StableID":   "ntWC8h3w2711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:27d5c5ffd86aeecb038a64611415fc5edd4dbac279739b59695aead4d3ebdd3f",
+				"KeyExpiry":  "2026-10-26T10:39:17Z",
+				"DiscoKey":   "discokey:a9ba90b0f7b55ea781f9a843710555436d205019d7890ab1e95320529c6ccf23",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33641", "10.65.0.27:33641", "172.17.0.1:33641"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:39:17.212580332Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5796044830383630,
+				"StableID":   "nRaC3dG3Gn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd34d3a1c6643648cb53f7e317eaea9cad77726f5ea632463bcad3336e9b5c01",
+				"KeyExpiry":  "2026-10-26T10:39:17Z",
+				"DiscoKey":   "discokey:1651f7a4fed3e75b02b6b3f7af48ecf598388b97cec91497f34da5a84452b237",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52149", "10.65.0.27:52149", "172.17.0.1:52149"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:39:17.792488063Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8780606967579194,
+				"StableID":   "nZS3x2fkZB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1ec87c8975e68992eae89c834b9e75aad838c8cd7d6dfb5dbda82d5441da6b66",
+				"KeyExpiry":  "2026-10-26T10:39:18Z",
+				"DiscoKey":   "discokey:def02699535980143cbb0da404d721dbce7a6366ae2f18f971dd5bddc5c5de3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:56061", "10.65.0.27:56061", "172.17.0.1:56061"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:39:18.317065956Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4643946780644944": {
+				"ID":          4643946780644944,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         772643950650921,
+				"StableID":   "ntWC8h3w2711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:27d5c5ffd86aeecb038a64611415fc5edd4dbac279739b59695aead4d3ebdd3f",
+				"KeyExpiry":  "2026-10-26T10:39:17Z",
+				"DiscoKey":   "discokey:a9ba90b0f7b55ea781f9a843710555436d205019d7890ab1e95320529c6ccf23",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33641", "10.65.0.27:33641", "172.17.0.1:33641"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:39:17.212580332Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:27d5c5ffd86aeecb038a64611415fc5edd4dbac279739b59695aead4d3ebdd3f",
+			"MachineKey": "mkey:de2bbbecd2d906d75fcf451443554781c50c55175ab15cd27a0353c5b45aef49",
+			"Peers": [{
+				"ID":         4643946780644944,
+				"StableID":   "nDZJZDcFGd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1fbe70b883e5054a9767a4361556608f8a2e0638daf9eb455baa4c88f672af1f",
+				"DiscoKey":   "discokey:336ee1c334ac5ea06a2150eb8a933440089e5468a732d6cb97216287dad0f747",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:51903", "10.65.0.27:51903", "172.17.0.1:51903"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:39:14.482920693Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6605059533556240,
+				"StableID":   "nRox1QiSat11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21c0d4e84af962dc6409df3dff17105f69929a82b55cd3a71f6b02b3dedcf37f",
+				"DiscoKey":   "discokey:2e4924cd5d98cbcf66b834159ff45a7068344938fad1b5b75421b51cf22ed31b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54508", "10.65.0.27:54508", "172.17.0.1:54508"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:39:15.044496951Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6781198105298853,
+				"StableID":   "nCCiSNaDxu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26bad139f355c177a2eaad2ef59f65a8e745d5b7e68349685e448909a7fff214",
+				"DiscoKey":   "discokey:97bd894d3f77932e1e7e87342f9db339ce8ffc4a7e2ae95c900133824ef0913e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47788", "10.65.0.27:47788", "172.17.0.1:47788"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:39:15.608543833Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8266086595639517,
+				"StableID":   "ntLEaX5jY721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb11c9420a8af35433b446e92746034c61412b607400dccceba1a5f54375c73",
+				"DiscoKey":   "discokey:9981efb3619dcabb52688602f28843251af6037b64215b03f67635085f38e120",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56292", "10.65.0.27:56292", "172.17.0.1:56292"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:39:16.142765235Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6428733811929947,
+				"StableID":   "nEC9oHwaCs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:94b33de474979bfcd1dd06182db13a6be88723620dade46a256be495cd659510",
+				"DiscoKey":   "discokey:ce25a7fc5374aa1b58acebc8fb2f96ce85f52df6f41a53f9800d077c8886eb5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57271", "10.65.0.27:57271", "172.17.0.1:57271"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:39:16.711978643Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5796044830383630,
+				"StableID":   "nRaC3dG3Gn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd34d3a1c6643648cb53f7e317eaea9cad77726f5ea632463bcad3336e9b5c01",
+				"KeyExpiry":  "2026-10-26T10:39:17Z",
+				"DiscoKey":   "discokey:1651f7a4fed3e75b02b6b3f7af48ecf598388b97cec91497f34da5a84452b237",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52149", "10.65.0.27:52149", "172.17.0.1:52149"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:39:17.792488063Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8780606967579194,
+				"StableID":   "nZS3x2fkZB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1ec87c8975e68992eae89c834b9e75aad838c8cd7d6dfb5dbda82d5441da6b66",
+				"KeyExpiry":  "2026-10-26T10:39:18Z",
+				"DiscoKey":   "discokey:def02699535980143cbb0da404d721dbce7a6366ae2f18f971dd5bddc5c5de3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:56061", "10.65.0.27:56061", "172.17.0.1:56061"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:39:18.317065956Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8266086595639517,
+				"StableID":   "ntLEaX5jY721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       8266086595639517,
+				"Key":        "nodekey:cdb11c9420a8af35433b446e92746034c61412b607400dccceba1a5f54375c73",
+				"DiscoKey":   "discokey:9981efb3619dcabb52688602f28843251af6037b64215b03f67635085f38e120",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56292", "10.65.0.27:56292", "172.17.0.1:56292"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:39:16.142765235Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cdb11c9420a8af35433b446e92746034c61412b607400dccceba1a5f54375c73",
+			"MachineKey": "mkey:71454cf29442ce8eea03cebb0d13c9fc4b298efa7293267ec68e769ca2fc8226",
+			"Peers": [{
+				"ID":         4643946780644944,
+				"StableID":   "nDZJZDcFGd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1fbe70b883e5054a9767a4361556608f8a2e0638daf9eb455baa4c88f672af1f",
+				"DiscoKey":   "discokey:336ee1c334ac5ea06a2150eb8a933440089e5468a732d6cb97216287dad0f747",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:51903", "10.65.0.27:51903", "172.17.0.1:51903"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:39:14.482920693Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6605059533556240,
+				"StableID":   "nRox1QiSat11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21c0d4e84af962dc6409df3dff17105f69929a82b55cd3a71f6b02b3dedcf37f",
+				"DiscoKey":   "discokey:2e4924cd5d98cbcf66b834159ff45a7068344938fad1b5b75421b51cf22ed31b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54508", "10.65.0.27:54508", "172.17.0.1:54508"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:39:15.044496951Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6781198105298853,
+				"StableID":   "nCCiSNaDxu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26bad139f355c177a2eaad2ef59f65a8e745d5b7e68349685e448909a7fff214",
+				"DiscoKey":   "discokey:97bd894d3f77932e1e7e87342f9db339ce8ffc4a7e2ae95c900133824ef0913e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47788", "10.65.0.27:47788", "172.17.0.1:47788"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:39:15.608543833Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6428733811929947,
+				"StableID":   "nEC9oHwaCs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:94b33de474979bfcd1dd06182db13a6be88723620dade46a256be495cd659510",
+				"DiscoKey":   "discokey:ce25a7fc5374aa1b58acebc8fb2f96ce85f52df6f41a53f9800d077c8886eb5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57271", "10.65.0.27:57271", "172.17.0.1:57271"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:39:16.711978643Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         772643950650921,
+				"StableID":   "ntWC8h3w2711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:27d5c5ffd86aeecb038a64611415fc5edd4dbac279739b59695aead4d3ebdd3f",
+				"KeyExpiry":  "2026-10-26T10:39:17Z",
+				"DiscoKey":   "discokey:a9ba90b0f7b55ea781f9a843710555436d205019d7890ab1e95320529c6ccf23",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33641", "10.65.0.27:33641", "172.17.0.1:33641"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:39:17.212580332Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5796044830383630,
+				"StableID":   "nRaC3dG3Gn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd34d3a1c6643648cb53f7e317eaea9cad77726f5ea632463bcad3336e9b5c01",
+				"KeyExpiry":  "2026-10-26T10:39:17Z",
+				"DiscoKey":   "discokey:1651f7a4fed3e75b02b6b3f7af48ecf598388b97cec91497f34da5a84452b237",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52149", "10.65.0.27:52149", "172.17.0.1:52149"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:39:17.792488063Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8780606967579194,
+				"StableID":   "nZS3x2fkZB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1ec87c8975e68992eae89c834b9e75aad838c8cd7d6dfb5dbda82d5441da6b66",
+				"KeyExpiry":  "2026-10-26T10:39:18Z",
+				"DiscoKey":   "discokey:def02699535980143cbb0da404d721dbce7a6366ae2f18f971dd5bddc5c5de3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:56061", "10.65.0.27:56061", "172.17.0.1:56061"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:39:18.317065956Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8266086595639517": {
+				"ID":          8266086595639517,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6605059533556240,
+				"StableID":   "nRox1QiSat11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       6605059533556240,
+				"Key":        "nodekey:21c0d4e84af962dc6409df3dff17105f69929a82b55cd3a71f6b02b3dedcf37f",
+				"DiscoKey":   "discokey:2e4924cd5d98cbcf66b834159ff45a7068344938fad1b5b75421b51cf22ed31b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54508", "10.65.0.27:54508", "172.17.0.1:54508"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:39:15.044496951Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:21c0d4e84af962dc6409df3dff17105f69929a82b55cd3a71f6b02b3dedcf37f",
+			"MachineKey": "mkey:aec01caa77f259ef185b164e2a6af31fda0ec0b4f128cb12cab55626710fdd7b",
+			"Peers": [{
+				"ID":         4643946780644944,
+				"StableID":   "nDZJZDcFGd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1fbe70b883e5054a9767a4361556608f8a2e0638daf9eb455baa4c88f672af1f",
+				"DiscoKey":   "discokey:336ee1c334ac5ea06a2150eb8a933440089e5468a732d6cb97216287dad0f747",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:51903", "10.65.0.27:51903", "172.17.0.1:51903"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:39:14.482920693Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6781198105298853,
+				"StableID":   "nCCiSNaDxu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26bad139f355c177a2eaad2ef59f65a8e745d5b7e68349685e448909a7fff214",
+				"DiscoKey":   "discokey:97bd894d3f77932e1e7e87342f9db339ce8ffc4a7e2ae95c900133824ef0913e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47788", "10.65.0.27:47788", "172.17.0.1:47788"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:39:15.608543833Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8266086595639517,
+				"StableID":   "ntLEaX5jY721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb11c9420a8af35433b446e92746034c61412b607400dccceba1a5f54375c73",
+				"DiscoKey":   "discokey:9981efb3619dcabb52688602f28843251af6037b64215b03f67635085f38e120",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56292", "10.65.0.27:56292", "172.17.0.1:56292"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:39:16.142765235Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6428733811929947,
+				"StableID":   "nEC9oHwaCs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:94b33de474979bfcd1dd06182db13a6be88723620dade46a256be495cd659510",
+				"DiscoKey":   "discokey:ce25a7fc5374aa1b58acebc8fb2f96ce85f52df6f41a53f9800d077c8886eb5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57271", "10.65.0.27:57271", "172.17.0.1:57271"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:39:16.711978643Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         772643950650921,
+				"StableID":   "ntWC8h3w2711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:27d5c5ffd86aeecb038a64611415fc5edd4dbac279739b59695aead4d3ebdd3f",
+				"KeyExpiry":  "2026-10-26T10:39:17Z",
+				"DiscoKey":   "discokey:a9ba90b0f7b55ea781f9a843710555436d205019d7890ab1e95320529c6ccf23",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33641", "10.65.0.27:33641", "172.17.0.1:33641"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:39:17.212580332Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5796044830383630,
+				"StableID":   "nRaC3dG3Gn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd34d3a1c6643648cb53f7e317eaea9cad77726f5ea632463bcad3336e9b5c01",
+				"KeyExpiry":  "2026-10-26T10:39:17Z",
+				"DiscoKey":   "discokey:1651f7a4fed3e75b02b6b3f7af48ecf598388b97cec91497f34da5a84452b237",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52149", "10.65.0.27:52149", "172.17.0.1:52149"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:39:17.792488063Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8780606967579194,
+				"StableID":   "nZS3x2fkZB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1ec87c8975e68992eae89c834b9e75aad838c8cd7d6dfb5dbda82d5441da6b66",
+				"KeyExpiry":  "2026-10-26T10:39:18Z",
+				"DiscoKey":   "discokey:def02699535980143cbb0da404d721dbce7a6366ae2f18f971dd5bddc5c5de3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:56061", "10.65.0.27:56061", "172.17.0.1:56061"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:39:18.317065956Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6605059533556240": {
+				"ID":          6605059533556240,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5796044830383630,
+				"StableID":   "nRaC3dG3Gn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd34d3a1c6643648cb53f7e317eaea9cad77726f5ea632463bcad3336e9b5c01",
+				"KeyExpiry":  "2026-10-26T10:39:17Z",
+				"DiscoKey":   "discokey:1651f7a4fed3e75b02b6b3f7af48ecf598388b97cec91497f34da5a84452b237",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52149", "10.65.0.27:52149", "172.17.0.1:52149"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:39:17.792488063Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fd34d3a1c6643648cb53f7e317eaea9cad77726f5ea632463bcad3336e9b5c01",
+			"MachineKey": "mkey:b528f66e616a61fb903d2be5ade40d35f5f45a94e9b18ad7302381131b5f5b20",
+			"Peers": [{
+				"ID":         4643946780644944,
+				"StableID":   "nDZJZDcFGd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1fbe70b883e5054a9767a4361556608f8a2e0638daf9eb455baa4c88f672af1f",
+				"DiscoKey":   "discokey:336ee1c334ac5ea06a2150eb8a933440089e5468a732d6cb97216287dad0f747",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:51903", "10.65.0.27:51903", "172.17.0.1:51903"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:39:14.482920693Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6605059533556240,
+				"StableID":   "nRox1QiSat11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21c0d4e84af962dc6409df3dff17105f69929a82b55cd3a71f6b02b3dedcf37f",
+				"DiscoKey":   "discokey:2e4924cd5d98cbcf66b834159ff45a7068344938fad1b5b75421b51cf22ed31b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54508", "10.65.0.27:54508", "172.17.0.1:54508"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:39:15.044496951Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6781198105298853,
+				"StableID":   "nCCiSNaDxu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26bad139f355c177a2eaad2ef59f65a8e745d5b7e68349685e448909a7fff214",
+				"DiscoKey":   "discokey:97bd894d3f77932e1e7e87342f9db339ce8ffc4a7e2ae95c900133824ef0913e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47788", "10.65.0.27:47788", "172.17.0.1:47788"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:39:15.608543833Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8266086595639517,
+				"StableID":   "ntLEaX5jY721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb11c9420a8af35433b446e92746034c61412b607400dccceba1a5f54375c73",
+				"DiscoKey":   "discokey:9981efb3619dcabb52688602f28843251af6037b64215b03f67635085f38e120",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56292", "10.65.0.27:56292", "172.17.0.1:56292"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:39:16.142765235Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6428733811929947,
+				"StableID":   "nEC9oHwaCs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:94b33de474979bfcd1dd06182db13a6be88723620dade46a256be495cd659510",
+				"DiscoKey":   "discokey:ce25a7fc5374aa1b58acebc8fb2f96ce85f52df6f41a53f9800d077c8886eb5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57271", "10.65.0.27:57271", "172.17.0.1:57271"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:39:16.711978643Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         772643950650921,
+				"StableID":   "ntWC8h3w2711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:27d5c5ffd86aeecb038a64611415fc5edd4dbac279739b59695aead4d3ebdd3f",
+				"KeyExpiry":  "2026-10-26T10:39:17Z",
+				"DiscoKey":   "discokey:a9ba90b0f7b55ea781f9a843710555436d205019d7890ab1e95320529c6ccf23",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33641", "10.65.0.27:33641", "172.17.0.1:33641"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:39:17.212580332Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8780606967579194,
+				"StableID":   "nZS3x2fkZB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1ec87c8975e68992eae89c834b9e75aad838c8cd7d6dfb5dbda82d5441da6b66",
+				"KeyExpiry":  "2026-10-26T10:39:18Z",
+				"DiscoKey":   "discokey:def02699535980143cbb0da404d721dbce7a6366ae2f18f971dd5bddc5c5de3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:56061", "10.65.0.27:56061", "172.17.0.1:56061"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:39:18.317065956Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6781198105298853,
+				"StableID":   "nCCiSNaDxu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       6781198105298853,
+				"Key":        "nodekey:26bad139f355c177a2eaad2ef59f65a8e745d5b7e68349685e448909a7fff214",
+				"DiscoKey":   "discokey:97bd894d3f77932e1e7e87342f9db339ce8ffc4a7e2ae95c900133824ef0913e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47788", "10.65.0.27:47788", "172.17.0.1:47788"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:39:15.608543833Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:26bad139f355c177a2eaad2ef59f65a8e745d5b7e68349685e448909a7fff214",
+			"MachineKey": "mkey:2e7256cfcb69c6d90ca9b7c67df71e43e6ed32c349d3686b6e2fbab3092c4e4d",
+			"Peers": [{
+				"ID":         4643946780644944,
+				"StableID":   "nDZJZDcFGd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1fbe70b883e5054a9767a4361556608f8a2e0638daf9eb455baa4c88f672af1f",
+				"DiscoKey":   "discokey:336ee1c334ac5ea06a2150eb8a933440089e5468a732d6cb97216287dad0f747",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:51903", "10.65.0.27:51903", "172.17.0.1:51903"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:39:14.482920693Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6605059533556240,
+				"StableID":   "nRox1QiSat11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21c0d4e84af962dc6409df3dff17105f69929a82b55cd3a71f6b02b3dedcf37f",
+				"DiscoKey":   "discokey:2e4924cd5d98cbcf66b834159ff45a7068344938fad1b5b75421b51cf22ed31b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54508", "10.65.0.27:54508", "172.17.0.1:54508"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:39:15.044496951Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8266086595639517,
+				"StableID":   "ntLEaX5jY721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb11c9420a8af35433b446e92746034c61412b607400dccceba1a5f54375c73",
+				"DiscoKey":   "discokey:9981efb3619dcabb52688602f28843251af6037b64215b03f67635085f38e120",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56292", "10.65.0.27:56292", "172.17.0.1:56292"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:39:16.142765235Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6428733811929947,
+				"StableID":   "nEC9oHwaCs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:94b33de474979bfcd1dd06182db13a6be88723620dade46a256be495cd659510",
+				"DiscoKey":   "discokey:ce25a7fc5374aa1b58acebc8fb2f96ce85f52df6f41a53f9800d077c8886eb5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57271", "10.65.0.27:57271", "172.17.0.1:57271"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:39:16.711978643Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         772643950650921,
+				"StableID":   "ntWC8h3w2711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:27d5c5ffd86aeecb038a64611415fc5edd4dbac279739b59695aead4d3ebdd3f",
+				"KeyExpiry":  "2026-10-26T10:39:17Z",
+				"DiscoKey":   "discokey:a9ba90b0f7b55ea781f9a843710555436d205019d7890ab1e95320529c6ccf23",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33641", "10.65.0.27:33641", "172.17.0.1:33641"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:39:17.212580332Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5796044830383630,
+				"StableID":   "nRaC3dG3Gn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd34d3a1c6643648cb53f7e317eaea9cad77726f5ea632463bcad3336e9b5c01",
+				"KeyExpiry":  "2026-10-26T10:39:17Z",
+				"DiscoKey":   "discokey:1651f7a4fed3e75b02b6b3f7af48ecf598388b97cec91497f34da5a84452b237",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52149", "10.65.0.27:52149", "172.17.0.1:52149"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:39:17.792488063Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8780606967579194,
+				"StableID":   "nZS3x2fkZB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1ec87c8975e68992eae89c834b9e75aad838c8cd7d6dfb5dbda82d5441da6b66",
+				"KeyExpiry":  "2026-10-26T10:39:18Z",
+				"DiscoKey":   "discokey:def02699535980143cbb0da404d721dbce7a6366ae2f18f971dd5bddc5c5de3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:56061", "10.65.0.27:56061", "172.17.0.1:56061"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:39:18.317065956Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6781198105298853": {
+				"ID":          6781198105298853,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-accept-fail-proto-icmp-not-allowed.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-accept-fail-proto-icmp-not-allowed.hujson
@@ -1,0 +1,8848 @@
+// policytest-accept-fail-proto-icmp-not-allowed
+//
+// tests block accept-fail: rule proto=tcp, test proto=icmp
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:39:40Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-accept-fail-proto-icmp-not-allowed",
+	"description":    "tests block accept-fail: rule proto=tcp, test proto=icmp",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:39:40.039541091Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                \n  \n                                                                       \n                                                  \n{\n\t\"id\":          \"policytest-accept-fail-proto-icmp-not-allowed\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block accept-fail: rule proto=tcp, test proto=icmp\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"proto\": \"tcp\", \"src\": [\"group:developers\"], \"dst\": [\"webserver:*\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"proto\": \"icmp\", \"accept\": [\"webserver:*\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-accept-fail-proto-icmp-not-allowed.hujson",
+		"full_policy": {
+			"acls": [{
+				"action": "accept",
+				"dst":    ["webserver:*"],
+				"proto":  "tcp",
+				"src":    ["group:developers"]
+			}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["webserver:*"], "proto": "icmp", "src": "thor@example.org"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8892169179343338,
+				"StableID":   "nBqPawCHSC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       8892169179343338,
+				"Key":        "nodekey:9624fbe173f354babc741fb458377d4e3ab0c696491edabbac4c3f8f54970741",
+				"DiscoKey":   "discokey:93da2dc768bc6b62e71e4858854a8983e83dbb2e0b40b9794cf33fbee487aa4f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:47664", "10.65.0.27:47664", "172.17.0.1:47664"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:39:43.756348112Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9624fbe173f354babc741fb458377d4e3ab0c696491edabbac4c3f8f54970741",
+			"MachineKey": "mkey:093d9010a7d38880916367624d1a3349dfcf559d809fbe4bbf723a80bf6b1532",
+			"Peers": [{
+				"ID":         3890472715494223,
+				"StableID":   "nAU5a281PX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f4554d75e0385b508444e14ed018eeb3e306b402fa320ab542ada0afcff3626",
+				"DiscoKey":   "discokey:837161b5024704df5f51057ab1f91370b8eeaead197dfba17de89b5c4c0ed87e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56246", "10.65.0.27:56246", "172.17.0.1:56246"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:39:41.615613883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3758602958888168,
+				"StableID":   "nKpFkK8HMW11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9dea9a92eb087aebb9bed7f6fb231e6510c1507a2eb46f9b6da1cbbd36623570",
+				"DiscoKey":   "discokey:1109c42c056723e2b0f410f60dfc78b64b1058c04181c1e87595d133aa6e1d1b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58592", "10.65.0.27:58592", "172.17.0.1:58592"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:39:42.145157708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5642960804234229,
+				"StableID":   "nrjorf1i4m11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:587aa9fe798752d9ef1413907fe308670cd2abec3f55620e8f07659989477453",
+				"DiscoKey":   "discokey:01fe93ec22142b9b885e70fb8d70b2f86ebde8b61245ac749bb763b793eec97b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:32886", "10.65.0.27:32886", "172.17.0.1:32886"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:39:42.708695749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6888271019215254,
+				"StableID":   "nmE9CZCinv11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25370056780d9196fab147d6135eeda1c9e9d72e6a309776b0b6e19a5394c47",
+				"DiscoKey":   "discokey:212a56322816dcc9aefcb109c317124742ad867e14d515ee87383f37c0252e09",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:54680", "10.65.0.27:54680", "172.17.0.1:54680"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:39:43.216546842Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7425825804103003,
+				"StableID":   "nGuEmQrAzz11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b034d475308434c3c3792dc108488d1dcdb66f0a63d09bed2857ec0e1a437a5b",
+				"KeyExpiry":  "2026-10-26T10:39:44Z",
+				"DiscoKey":   "discokey:d134b551ca5b833e4f46f5426d40dbf22a9975740630f72978da4a9f0cf57556",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52992", "10.65.0.27:52992", "172.17.0.1:52992"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:39:44.319183888Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7952905381852552,
+				"StableID":   "nd7f9eLt6521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:06859d911547d79c4efda22af33f4fa98198c61123cae27e5cda1101b7254426",
+				"KeyExpiry":  "2026-10-26T10:39:44Z",
+				"DiscoKey":   "discokey:2aee702990c49987f7714d2668f67f3b2b4f2d062ab652f2075f2169be75c11c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45993", "10.65.0.27:45993", "172.17.0.1:45993"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:39:44.830714436Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5015851152918823,
+				"StableID":   "nrpfQTugAg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0b41f6bf8df5bdbc8754c1aad4d7db8fab51ab9f6fbed0fbba46136f5bb8f772",
+				"KeyExpiry":  "2026-10-26T10:39:45Z",
+				"DiscoKey":   "discokey:b3add8b662a42255c723638ff364c73fe9c2c64c9798c933b9ea1ecd935d521b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34444", "10.65.0.27:34444", "172.17.0.1:34444"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:39:45.370409786Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8892169179343338": {
+				"ID":          8892169179343338,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5015851152918823,
+				"StableID":   "nrpfQTugAg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0b41f6bf8df5bdbc8754c1aad4d7db8fab51ab9f6fbed0fbba46136f5bb8f772",
+				"KeyExpiry":  "2026-10-26T10:39:45Z",
+				"DiscoKey":   "discokey:b3add8b662a42255c723638ff364c73fe9c2c64c9798c933b9ea1ecd935d521b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34444", "10.65.0.27:34444", "172.17.0.1:34444"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:39:45.370409786Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0b41f6bf8df5bdbc8754c1aad4d7db8fab51ab9f6fbed0fbba46136f5bb8f772",
+			"MachineKey": "mkey:cff06286b1a8b7aed88eecf87f2070537f010a8b761c593c1f7523fb7104d862",
+			"Peers": [{
+				"ID":         3890472715494223,
+				"StableID":   "nAU5a281PX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f4554d75e0385b508444e14ed018eeb3e306b402fa320ab542ada0afcff3626",
+				"DiscoKey":   "discokey:837161b5024704df5f51057ab1f91370b8eeaead197dfba17de89b5c4c0ed87e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56246", "10.65.0.27:56246", "172.17.0.1:56246"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:39:41.615613883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3758602958888168,
+				"StableID":   "nKpFkK8HMW11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9dea9a92eb087aebb9bed7f6fb231e6510c1507a2eb46f9b6da1cbbd36623570",
+				"DiscoKey":   "discokey:1109c42c056723e2b0f410f60dfc78b64b1058c04181c1e87595d133aa6e1d1b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58592", "10.65.0.27:58592", "172.17.0.1:58592"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:39:42.145157708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5642960804234229,
+				"StableID":   "nrjorf1i4m11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:587aa9fe798752d9ef1413907fe308670cd2abec3f55620e8f07659989477453",
+				"DiscoKey":   "discokey:01fe93ec22142b9b885e70fb8d70b2f86ebde8b61245ac749bb763b793eec97b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:32886", "10.65.0.27:32886", "172.17.0.1:32886"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:39:42.708695749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6888271019215254,
+				"StableID":   "nmE9CZCinv11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25370056780d9196fab147d6135eeda1c9e9d72e6a309776b0b6e19a5394c47",
+				"DiscoKey":   "discokey:212a56322816dcc9aefcb109c317124742ad867e14d515ee87383f37c0252e09",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:54680", "10.65.0.27:54680", "172.17.0.1:54680"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:39:43.216546842Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8892169179343338,
+				"StableID":   "nBqPawCHSC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9624fbe173f354babc741fb458377d4e3ab0c696491edabbac4c3f8f54970741",
+				"DiscoKey":   "discokey:93da2dc768bc6b62e71e4858854a8983e83dbb2e0b40b9794cf33fbee487aa4f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:47664", "10.65.0.27:47664", "172.17.0.1:47664"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:39:43.756348112Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7425825804103003,
+				"StableID":   "nGuEmQrAzz11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b034d475308434c3c3792dc108488d1dcdb66f0a63d09bed2857ec0e1a437a5b",
+				"KeyExpiry":  "2026-10-26T10:39:44Z",
+				"DiscoKey":   "discokey:d134b551ca5b833e4f46f5426d40dbf22a9975740630f72978da4a9f0cf57556",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52992", "10.65.0.27:52992", "172.17.0.1:52992"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:39:44.319183888Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7952905381852552,
+				"StableID":   "nd7f9eLt6521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:06859d911547d79c4efda22af33f4fa98198c61123cae27e5cda1101b7254426",
+				"KeyExpiry":  "2026-10-26T10:39:44Z",
+				"DiscoKey":   "discokey:2aee702990c49987f7714d2668f67f3b2b4f2d062ab652f2075f2169be75c11c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45993", "10.65.0.27:45993", "172.17.0.1:45993"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:39:44.830714436Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3890472715494223,
+				"StableID":   "nAU5a281PX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       3890472715494223,
+				"Key":        "nodekey:5f4554d75e0385b508444e14ed018eeb3e306b402fa320ab542ada0afcff3626",
+				"DiscoKey":   "discokey:837161b5024704df5f51057ab1f91370b8eeaead197dfba17de89b5c4c0ed87e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56246", "10.65.0.27:56246", "172.17.0.1:56246"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:39:41.615613883Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5f4554d75e0385b508444e14ed018eeb3e306b402fa320ab542ada0afcff3626",
+			"MachineKey": "mkey:8cf1aed203cd63be006a931d1d749d9333c1e48b7a42471c39ec5fd03eae5514",
+			"Peers": [{
+				"ID":         3758602958888168,
+				"StableID":   "nKpFkK8HMW11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9dea9a92eb087aebb9bed7f6fb231e6510c1507a2eb46f9b6da1cbbd36623570",
+				"DiscoKey":   "discokey:1109c42c056723e2b0f410f60dfc78b64b1058c04181c1e87595d133aa6e1d1b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58592", "10.65.0.27:58592", "172.17.0.1:58592"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:39:42.145157708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5642960804234229,
+				"StableID":   "nrjorf1i4m11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:587aa9fe798752d9ef1413907fe308670cd2abec3f55620e8f07659989477453",
+				"DiscoKey":   "discokey:01fe93ec22142b9b885e70fb8d70b2f86ebde8b61245ac749bb763b793eec97b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:32886", "10.65.0.27:32886", "172.17.0.1:32886"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:39:42.708695749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6888271019215254,
+				"StableID":   "nmE9CZCinv11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25370056780d9196fab147d6135eeda1c9e9d72e6a309776b0b6e19a5394c47",
+				"DiscoKey":   "discokey:212a56322816dcc9aefcb109c317124742ad867e14d515ee87383f37c0252e09",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:54680", "10.65.0.27:54680", "172.17.0.1:54680"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:39:43.216546842Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8892169179343338,
+				"StableID":   "nBqPawCHSC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9624fbe173f354babc741fb458377d4e3ab0c696491edabbac4c3f8f54970741",
+				"DiscoKey":   "discokey:93da2dc768bc6b62e71e4858854a8983e83dbb2e0b40b9794cf33fbee487aa4f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:47664", "10.65.0.27:47664", "172.17.0.1:47664"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:39:43.756348112Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7425825804103003,
+				"StableID":   "nGuEmQrAzz11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b034d475308434c3c3792dc108488d1dcdb66f0a63d09bed2857ec0e1a437a5b",
+				"KeyExpiry":  "2026-10-26T10:39:44Z",
+				"DiscoKey":   "discokey:d134b551ca5b833e4f46f5426d40dbf22a9975740630f72978da4a9f0cf57556",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52992", "10.65.0.27:52992", "172.17.0.1:52992"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:39:44.319183888Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7952905381852552,
+				"StableID":   "nd7f9eLt6521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:06859d911547d79c4efda22af33f4fa98198c61123cae27e5cda1101b7254426",
+				"KeyExpiry":  "2026-10-26T10:39:44Z",
+				"DiscoKey":   "discokey:2aee702990c49987f7714d2668f67f3b2b4f2d062ab652f2075f2169be75c11c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45993", "10.65.0.27:45993", "172.17.0.1:45993"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:39:44.830714436Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5015851152918823,
+				"StableID":   "nrpfQTugAg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0b41f6bf8df5bdbc8754c1aad4d7db8fab51ab9f6fbed0fbba46136f5bb8f772",
+				"KeyExpiry":  "2026-10-26T10:39:45Z",
+				"DiscoKey":   "discokey:b3add8b662a42255c723638ff364c73fe9c2c64c9798c933b9ea1ecd935d521b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34444", "10.65.0.27:34444", "172.17.0.1:34444"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:39:45.370409786Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3890472715494223": {
+				"ID":          3890472715494223,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7425825804103003,
+				"StableID":   "nGuEmQrAzz11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b034d475308434c3c3792dc108488d1dcdb66f0a63d09bed2857ec0e1a437a5b",
+				"KeyExpiry":  "2026-10-26T10:39:44Z",
+				"DiscoKey":   "discokey:d134b551ca5b833e4f46f5426d40dbf22a9975740630f72978da4a9f0cf57556",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52992", "10.65.0.27:52992", "172.17.0.1:52992"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:39:44.319183888Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b034d475308434c3c3792dc108488d1dcdb66f0a63d09bed2857ec0e1a437a5b",
+			"MachineKey": "mkey:35771f357a7e9bf19b8790b14f96dff261d8b0c2b3e9f5be165a2c310c8fc82a",
+			"Peers": [{
+				"ID":         3890472715494223,
+				"StableID":   "nAU5a281PX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f4554d75e0385b508444e14ed018eeb3e306b402fa320ab542ada0afcff3626",
+				"DiscoKey":   "discokey:837161b5024704df5f51057ab1f91370b8eeaead197dfba17de89b5c4c0ed87e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56246", "10.65.0.27:56246", "172.17.0.1:56246"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:39:41.615613883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3758602958888168,
+				"StableID":   "nKpFkK8HMW11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9dea9a92eb087aebb9bed7f6fb231e6510c1507a2eb46f9b6da1cbbd36623570",
+				"DiscoKey":   "discokey:1109c42c056723e2b0f410f60dfc78b64b1058c04181c1e87595d133aa6e1d1b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58592", "10.65.0.27:58592", "172.17.0.1:58592"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:39:42.145157708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5642960804234229,
+				"StableID":   "nrjorf1i4m11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:587aa9fe798752d9ef1413907fe308670cd2abec3f55620e8f07659989477453",
+				"DiscoKey":   "discokey:01fe93ec22142b9b885e70fb8d70b2f86ebde8b61245ac749bb763b793eec97b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:32886", "10.65.0.27:32886", "172.17.0.1:32886"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:39:42.708695749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6888271019215254,
+				"StableID":   "nmE9CZCinv11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25370056780d9196fab147d6135eeda1c9e9d72e6a309776b0b6e19a5394c47",
+				"DiscoKey":   "discokey:212a56322816dcc9aefcb109c317124742ad867e14d515ee87383f37c0252e09",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:54680", "10.65.0.27:54680", "172.17.0.1:54680"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:39:43.216546842Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8892169179343338,
+				"StableID":   "nBqPawCHSC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9624fbe173f354babc741fb458377d4e3ab0c696491edabbac4c3f8f54970741",
+				"DiscoKey":   "discokey:93da2dc768bc6b62e71e4858854a8983e83dbb2e0b40b9794cf33fbee487aa4f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:47664", "10.65.0.27:47664", "172.17.0.1:47664"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:39:43.756348112Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7952905381852552,
+				"StableID":   "nd7f9eLt6521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:06859d911547d79c4efda22af33f4fa98198c61123cae27e5cda1101b7254426",
+				"KeyExpiry":  "2026-10-26T10:39:44Z",
+				"DiscoKey":   "discokey:2aee702990c49987f7714d2668f67f3b2b4f2d062ab652f2075f2169be75c11c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45993", "10.65.0.27:45993", "172.17.0.1:45993"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:39:44.830714436Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5015851152918823,
+				"StableID":   "nrpfQTugAg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0b41f6bf8df5bdbc8754c1aad4d7db8fab51ab9f6fbed0fbba46136f5bb8f772",
+				"KeyExpiry":  "2026-10-26T10:39:45Z",
+				"DiscoKey":   "discokey:b3add8b662a42255c723638ff364c73fe9c2c64c9798c933b9ea1ecd935d521b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34444", "10.65.0.27:34444", "172.17.0.1:34444"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:39:45.370409786Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6888271019215254,
+				"StableID":   "nmE9CZCinv11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       6888271019215254,
+				"Key":        "nodekey:b25370056780d9196fab147d6135eeda1c9e9d72e6a309776b0b6e19a5394c47",
+				"DiscoKey":   "discokey:212a56322816dcc9aefcb109c317124742ad867e14d515ee87383f37c0252e09",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:54680", "10.65.0.27:54680", "172.17.0.1:54680"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:39:43.216546842Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b25370056780d9196fab147d6135eeda1c9e9d72e6a309776b0b6e19a5394c47",
+			"MachineKey": "mkey:5484fc6ed5bd8c01fbc962167b5aa5c46177094641e97920c5ab734400863617",
+			"Peers": [{
+				"ID":         3890472715494223,
+				"StableID":   "nAU5a281PX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f4554d75e0385b508444e14ed018eeb3e306b402fa320ab542ada0afcff3626",
+				"DiscoKey":   "discokey:837161b5024704df5f51057ab1f91370b8eeaead197dfba17de89b5c4c0ed87e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56246", "10.65.0.27:56246", "172.17.0.1:56246"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:39:41.615613883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3758602958888168,
+				"StableID":   "nKpFkK8HMW11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9dea9a92eb087aebb9bed7f6fb231e6510c1507a2eb46f9b6da1cbbd36623570",
+				"DiscoKey":   "discokey:1109c42c056723e2b0f410f60dfc78b64b1058c04181c1e87595d133aa6e1d1b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58592", "10.65.0.27:58592", "172.17.0.1:58592"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:39:42.145157708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5642960804234229,
+				"StableID":   "nrjorf1i4m11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:587aa9fe798752d9ef1413907fe308670cd2abec3f55620e8f07659989477453",
+				"DiscoKey":   "discokey:01fe93ec22142b9b885e70fb8d70b2f86ebde8b61245ac749bb763b793eec97b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:32886", "10.65.0.27:32886", "172.17.0.1:32886"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:39:42.708695749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8892169179343338,
+				"StableID":   "nBqPawCHSC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9624fbe173f354babc741fb458377d4e3ab0c696491edabbac4c3f8f54970741",
+				"DiscoKey":   "discokey:93da2dc768bc6b62e71e4858854a8983e83dbb2e0b40b9794cf33fbee487aa4f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:47664", "10.65.0.27:47664", "172.17.0.1:47664"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:39:43.756348112Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7425825804103003,
+				"StableID":   "nGuEmQrAzz11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b034d475308434c3c3792dc108488d1dcdb66f0a63d09bed2857ec0e1a437a5b",
+				"KeyExpiry":  "2026-10-26T10:39:44Z",
+				"DiscoKey":   "discokey:d134b551ca5b833e4f46f5426d40dbf22a9975740630f72978da4a9f0cf57556",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52992", "10.65.0.27:52992", "172.17.0.1:52992"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:39:44.319183888Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7952905381852552,
+				"StableID":   "nd7f9eLt6521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:06859d911547d79c4efda22af33f4fa98198c61123cae27e5cda1101b7254426",
+				"KeyExpiry":  "2026-10-26T10:39:44Z",
+				"DiscoKey":   "discokey:2aee702990c49987f7714d2668f67f3b2b4f2d062ab652f2075f2169be75c11c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45993", "10.65.0.27:45993", "172.17.0.1:45993"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:39:44.830714436Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5015851152918823,
+				"StableID":   "nrpfQTugAg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0b41f6bf8df5bdbc8754c1aad4d7db8fab51ab9f6fbed0fbba46136f5bb8f772",
+				"KeyExpiry":  "2026-10-26T10:39:45Z",
+				"DiscoKey":   "discokey:b3add8b662a42255c723638ff364c73fe9c2c64c9798c933b9ea1ecd935d521b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34444", "10.65.0.27:34444", "172.17.0.1:34444"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:39:45.370409786Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6888271019215254": {
+				"ID":          6888271019215254,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3758602958888168,
+				"StableID":   "nKpFkK8HMW11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       3758602958888168,
+				"Key":        "nodekey:9dea9a92eb087aebb9bed7f6fb231e6510c1507a2eb46f9b6da1cbbd36623570",
+				"DiscoKey":   "discokey:1109c42c056723e2b0f410f60dfc78b64b1058c04181c1e87595d133aa6e1d1b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58592", "10.65.0.27:58592", "172.17.0.1:58592"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:39:42.145157708Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9dea9a92eb087aebb9bed7f6fb231e6510c1507a2eb46f9b6da1cbbd36623570",
+			"MachineKey": "mkey:8e5f45be2a52bd138ea7952f4e87b9aa6bd447ba05faf4b717f7daba206c0400",
+			"Peers": [{
+				"ID":         3890472715494223,
+				"StableID":   "nAU5a281PX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f4554d75e0385b508444e14ed018eeb3e306b402fa320ab542ada0afcff3626",
+				"DiscoKey":   "discokey:837161b5024704df5f51057ab1f91370b8eeaead197dfba17de89b5c4c0ed87e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56246", "10.65.0.27:56246", "172.17.0.1:56246"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:39:41.615613883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5642960804234229,
+				"StableID":   "nrjorf1i4m11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:587aa9fe798752d9ef1413907fe308670cd2abec3f55620e8f07659989477453",
+				"DiscoKey":   "discokey:01fe93ec22142b9b885e70fb8d70b2f86ebde8b61245ac749bb763b793eec97b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:32886", "10.65.0.27:32886", "172.17.0.1:32886"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:39:42.708695749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6888271019215254,
+				"StableID":   "nmE9CZCinv11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25370056780d9196fab147d6135eeda1c9e9d72e6a309776b0b6e19a5394c47",
+				"DiscoKey":   "discokey:212a56322816dcc9aefcb109c317124742ad867e14d515ee87383f37c0252e09",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:54680", "10.65.0.27:54680", "172.17.0.1:54680"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:39:43.216546842Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8892169179343338,
+				"StableID":   "nBqPawCHSC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9624fbe173f354babc741fb458377d4e3ab0c696491edabbac4c3f8f54970741",
+				"DiscoKey":   "discokey:93da2dc768bc6b62e71e4858854a8983e83dbb2e0b40b9794cf33fbee487aa4f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:47664", "10.65.0.27:47664", "172.17.0.1:47664"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:39:43.756348112Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7425825804103003,
+				"StableID":   "nGuEmQrAzz11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b034d475308434c3c3792dc108488d1dcdb66f0a63d09bed2857ec0e1a437a5b",
+				"KeyExpiry":  "2026-10-26T10:39:44Z",
+				"DiscoKey":   "discokey:d134b551ca5b833e4f46f5426d40dbf22a9975740630f72978da4a9f0cf57556",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52992", "10.65.0.27:52992", "172.17.0.1:52992"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:39:44.319183888Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7952905381852552,
+				"StableID":   "nd7f9eLt6521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:06859d911547d79c4efda22af33f4fa98198c61123cae27e5cda1101b7254426",
+				"KeyExpiry":  "2026-10-26T10:39:44Z",
+				"DiscoKey":   "discokey:2aee702990c49987f7714d2668f67f3b2b4f2d062ab652f2075f2169be75c11c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45993", "10.65.0.27:45993", "172.17.0.1:45993"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:39:44.830714436Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5015851152918823,
+				"StableID":   "nrpfQTugAg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0b41f6bf8df5bdbc8754c1aad4d7db8fab51ab9f6fbed0fbba46136f5bb8f772",
+				"KeyExpiry":  "2026-10-26T10:39:45Z",
+				"DiscoKey":   "discokey:b3add8b662a42255c723638ff364c73fe9c2c64c9798c933b9ea1ecd935d521b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34444", "10.65.0.27:34444", "172.17.0.1:34444"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:39:45.370409786Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3758602958888168": {
+				"ID":          3758602958888168,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7952905381852552,
+				"StableID":   "nd7f9eLt6521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:06859d911547d79c4efda22af33f4fa98198c61123cae27e5cda1101b7254426",
+				"KeyExpiry":  "2026-10-26T10:39:44Z",
+				"DiscoKey":   "discokey:2aee702990c49987f7714d2668f67f3b2b4f2d062ab652f2075f2169be75c11c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45993", "10.65.0.27:45993", "172.17.0.1:45993"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:39:44.830714436Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:06859d911547d79c4efda22af33f4fa98198c61123cae27e5cda1101b7254426",
+			"MachineKey": "mkey:8c6d14d8c8906b1e6ea453287ac4e479781bb30168f47744f2216b476528411a",
+			"Peers": [{
+				"ID":         3890472715494223,
+				"StableID":   "nAU5a281PX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f4554d75e0385b508444e14ed018eeb3e306b402fa320ab542ada0afcff3626",
+				"DiscoKey":   "discokey:837161b5024704df5f51057ab1f91370b8eeaead197dfba17de89b5c4c0ed87e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56246", "10.65.0.27:56246", "172.17.0.1:56246"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:39:41.615613883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3758602958888168,
+				"StableID":   "nKpFkK8HMW11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9dea9a92eb087aebb9bed7f6fb231e6510c1507a2eb46f9b6da1cbbd36623570",
+				"DiscoKey":   "discokey:1109c42c056723e2b0f410f60dfc78b64b1058c04181c1e87595d133aa6e1d1b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58592", "10.65.0.27:58592", "172.17.0.1:58592"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:39:42.145157708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5642960804234229,
+				"StableID":   "nrjorf1i4m11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:587aa9fe798752d9ef1413907fe308670cd2abec3f55620e8f07659989477453",
+				"DiscoKey":   "discokey:01fe93ec22142b9b885e70fb8d70b2f86ebde8b61245ac749bb763b793eec97b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:32886", "10.65.0.27:32886", "172.17.0.1:32886"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:39:42.708695749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6888271019215254,
+				"StableID":   "nmE9CZCinv11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25370056780d9196fab147d6135eeda1c9e9d72e6a309776b0b6e19a5394c47",
+				"DiscoKey":   "discokey:212a56322816dcc9aefcb109c317124742ad867e14d515ee87383f37c0252e09",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:54680", "10.65.0.27:54680", "172.17.0.1:54680"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:39:43.216546842Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8892169179343338,
+				"StableID":   "nBqPawCHSC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9624fbe173f354babc741fb458377d4e3ab0c696491edabbac4c3f8f54970741",
+				"DiscoKey":   "discokey:93da2dc768bc6b62e71e4858854a8983e83dbb2e0b40b9794cf33fbee487aa4f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:47664", "10.65.0.27:47664", "172.17.0.1:47664"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:39:43.756348112Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7425825804103003,
+				"StableID":   "nGuEmQrAzz11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b034d475308434c3c3792dc108488d1dcdb66f0a63d09bed2857ec0e1a437a5b",
+				"KeyExpiry":  "2026-10-26T10:39:44Z",
+				"DiscoKey":   "discokey:d134b551ca5b833e4f46f5426d40dbf22a9975740630f72978da4a9f0cf57556",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52992", "10.65.0.27:52992", "172.17.0.1:52992"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:39:44.319183888Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5015851152918823,
+				"StableID":   "nrpfQTugAg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0b41f6bf8df5bdbc8754c1aad4d7db8fab51ab9f6fbed0fbba46136f5bb8f772",
+				"KeyExpiry":  "2026-10-26T10:39:45Z",
+				"DiscoKey":   "discokey:b3add8b662a42255c723638ff364c73fe9c2c64c9798c933b9ea1ecd935d521b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34444", "10.65.0.27:34444", "172.17.0.1:34444"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:39:45.370409786Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5642960804234229,
+				"StableID":   "nrjorf1i4m11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       5642960804234229,
+				"Key":        "nodekey:587aa9fe798752d9ef1413907fe308670cd2abec3f55620e8f07659989477453",
+				"DiscoKey":   "discokey:01fe93ec22142b9b885e70fb8d70b2f86ebde8b61245ac749bb763b793eec97b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:32886", "10.65.0.27:32886", "172.17.0.1:32886"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:39:42.708695749Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:587aa9fe798752d9ef1413907fe308670cd2abec3f55620e8f07659989477453",
+			"MachineKey": "mkey:394d7f7934c70563bd7517c0d7a97be18066cd0d20ce5e26a8fee144546d7535",
+			"Peers": [{
+				"ID":         3890472715494223,
+				"StableID":   "nAU5a281PX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f4554d75e0385b508444e14ed018eeb3e306b402fa320ab542ada0afcff3626",
+				"DiscoKey":   "discokey:837161b5024704df5f51057ab1f91370b8eeaead197dfba17de89b5c4c0ed87e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56246", "10.65.0.27:56246", "172.17.0.1:56246"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:39:41.615613883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3758602958888168,
+				"StableID":   "nKpFkK8HMW11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9dea9a92eb087aebb9bed7f6fb231e6510c1507a2eb46f9b6da1cbbd36623570",
+				"DiscoKey":   "discokey:1109c42c056723e2b0f410f60dfc78b64b1058c04181c1e87595d133aa6e1d1b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58592", "10.65.0.27:58592", "172.17.0.1:58592"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:39:42.145157708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6888271019215254,
+				"StableID":   "nmE9CZCinv11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25370056780d9196fab147d6135eeda1c9e9d72e6a309776b0b6e19a5394c47",
+				"DiscoKey":   "discokey:212a56322816dcc9aefcb109c317124742ad867e14d515ee87383f37c0252e09",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:54680", "10.65.0.27:54680", "172.17.0.1:54680"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:39:43.216546842Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8892169179343338,
+				"StableID":   "nBqPawCHSC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9624fbe173f354babc741fb458377d4e3ab0c696491edabbac4c3f8f54970741",
+				"DiscoKey":   "discokey:93da2dc768bc6b62e71e4858854a8983e83dbb2e0b40b9794cf33fbee487aa4f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:47664", "10.65.0.27:47664", "172.17.0.1:47664"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:39:43.756348112Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7425825804103003,
+				"StableID":   "nGuEmQrAzz11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b034d475308434c3c3792dc108488d1dcdb66f0a63d09bed2857ec0e1a437a5b",
+				"KeyExpiry":  "2026-10-26T10:39:44Z",
+				"DiscoKey":   "discokey:d134b551ca5b833e4f46f5426d40dbf22a9975740630f72978da4a9f0cf57556",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52992", "10.65.0.27:52992", "172.17.0.1:52992"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:39:44.319183888Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7952905381852552,
+				"StableID":   "nd7f9eLt6521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:06859d911547d79c4efda22af33f4fa98198c61123cae27e5cda1101b7254426",
+				"KeyExpiry":  "2026-10-26T10:39:44Z",
+				"DiscoKey":   "discokey:2aee702990c49987f7714d2668f67f3b2b4f2d062ab652f2075f2169be75c11c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45993", "10.65.0.27:45993", "172.17.0.1:45993"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:39:44.830714436Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5015851152918823,
+				"StableID":   "nrpfQTugAg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0b41f6bf8df5bdbc8754c1aad4d7db8fab51ab9f6fbed0fbba46136f5bb8f772",
+				"KeyExpiry":  "2026-10-26T10:39:45Z",
+				"DiscoKey":   "discokey:b3add8b662a42255c723638ff364c73fe9c2c64c9798c933b9ea1ecd935d521b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34444", "10.65.0.27:34444", "172.17.0.1:34444"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:39:45.370409786Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5642960804234229": {
+				"ID":          5642960804234229,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-accept-fail-proto-mismatch-tcp-vs-udp.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-accept-fail-proto-mismatch-tcp-vs-udp.hujson
@@ -1,0 +1,8848 @@
+// policytest-accept-fail-proto-mismatch-tcp-vs-udp
+//
+// tests block accept-fail: rule proto=tcp, test proto=udp
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:40:07Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-accept-fail-proto-mismatch-tcp-vs-udp",
+	"description":    "tests block accept-fail: rule proto=tcp, test proto=udp",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:40:07.087292106Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                   \n  \n                                                                    \n                                                                 \n{\n\t\"id\":          \"policytest-accept-fail-proto-mismatch-tcp-vs-udp\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block accept-fail: rule proto=tcp, test proto=udp\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"proto\": \"tcp\", \"src\": [\"group:developers\"], \"dst\": [\"webserver:53\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"proto\": \"udp\", \"accept\": [\"webserver:53\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-accept-fail-proto-mismatch-tcp-vs-udp.hujson",
+		"full_policy": {
+			"acls": [{
+				"action": "accept",
+				"dst":    ["webserver:53"],
+				"proto":  "tcp",
+				"src":    ["group:developers"]
+			}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["webserver:53"], "proto": "udp", "src": "thor@example.org"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6627734880480008,
+				"StableID":   "nm12ngMikt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6627734880480008,
+				"Key":        "nodekey:1b45a52cad59e112afdfdc8420af5f32267d146128a886e6942c02b3b30c0b2f",
+				"DiscoKey":   "discokey:0dcf2d3f449f1cb136d8494bdaea27a04dbac1898e231138ad14a04ddc44da6f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:35526", "10.65.0.27:35526", "172.17.0.1:35526"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:40:10.853188947Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1b45a52cad59e112afdfdc8420af5f32267d146128a886e6942c02b3b30c0b2f",
+			"MachineKey": "mkey:54e1e0e496f6c46952604235afec6ccada573ac4043f9e81709ebc75c0d11f04",
+			"Peers": [{
+				"ID":         8308597661845150,
+				"StableID":   "nPyRvkmys721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d321f0fe2970cdd111adc60ca1a864ef0110b8c1fe00cb53f12c25d27425e369",
+				"DiscoKey":   "discokey:11509a612ce7803625a5ab005545987e3bcdd879135ea32083f33ef13b9af745",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37694", "10.65.0.27:37694", "172.17.0.1:37694"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:40:08.696194413Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1359941637466085,
+				"StableID":   "nEXtbvMvcB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c1a81e65ef472f91bed942dc624a2c425c42bb78adb0c81d73007962f90ca2b",
+				"DiscoKey":   "discokey:279c14bffc09aa93f18f247cc6112f781d1825e5776c0802a447cb1911d15631",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46828", "10.65.0.27:46828", "172.17.0.1:46828"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:40:09.241872979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5180600964560629,
+				"StableID":   "n6h17xbJTh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca688ef45b825913d732cd277ce6b8b3cce6245103494bc9de86663fdb13cd14",
+				"DiscoKey":   "discokey:cbd8da0d712407c99f1dcb3bfa036da21e3ab62b2947f347b0dcaf0f3b4be907",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54493", "10.65.0.27:54493", "172.17.0.1:54493"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:40:09.765520134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6738440615352599,
+				"StableID":   "nakRUhQrcu11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fcce41c91459464e2dc5946c0a5765fa53fde27cd9ffcd99135b342724699941",
+				"DiscoKey":   "discokey:0f175125ac7aa89d7d23911f7f7cd544a2a68f8d4e516f86e5b404b7d36b013d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:39401", "10.65.0.27:39401", "172.17.0.1:39401"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:40:10.351827874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6881674721193239,
+				"StableID":   "n8savgvijv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5b9193bddd5ba26e3217fbd184d053a1402158f37ab11631c1b169a30739f701",
+				"KeyExpiry":  "2026-10-26T10:40:11Z",
+				"DiscoKey":   "discokey:df8d9a09839b2a88e1098a2bbaa9d9feece5e15f5be5595e1359696c5bb44419",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:48455", "10.65.0.27:48455", "172.17.0.1:48455"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:40:11.368622702Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4792313087255189,
+				"StableID":   "nNHu1SwSRe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f0558dc4410321e1f583ee75503fb773f234486f13113d2860c25c3b12199321",
+				"KeyExpiry":  "2026-10-26T10:40:11Z",
+				"DiscoKey":   "discokey:0e991794bc5c5a08f9de53ef4d14fbbb75947545c20186ad75d6a9ecf4ff916c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:42307", "10.65.0.27:42307", "172.17.0.1:42307"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:40:11.916114668Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3069294581062906,
+				"StableID":   "nVcjpWA6yQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bd7cde6dc62e80dceda3191c626f2f566ea5dbd6bbe31115514addea7edfde0d",
+				"KeyExpiry":  "2026-10-26T10:40:12Z",
+				"DiscoKey":   "discokey:1334534fd60b0fb2711105ec239bc9d13552b88f62e401b781fbe2aec8478474",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36616", "10.65.0.27:36616", "172.17.0.1:36616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:40:12.509555496Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6627734880480008": {
+				"ID":          6627734880480008,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3069294581062906,
+				"StableID":   "nVcjpWA6yQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bd7cde6dc62e80dceda3191c626f2f566ea5dbd6bbe31115514addea7edfde0d",
+				"KeyExpiry":  "2026-10-26T10:40:12Z",
+				"DiscoKey":   "discokey:1334534fd60b0fb2711105ec239bc9d13552b88f62e401b781fbe2aec8478474",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36616", "10.65.0.27:36616", "172.17.0.1:36616"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:40:12.509555496Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bd7cde6dc62e80dceda3191c626f2f566ea5dbd6bbe31115514addea7edfde0d",
+			"MachineKey": "mkey:e225394b6a7099de0463d1c74e77fbb0029d0633e7ed96c06e6a1aa930117b3c",
+			"Peers": [{
+				"ID":         8308597661845150,
+				"StableID":   "nPyRvkmys721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d321f0fe2970cdd111adc60ca1a864ef0110b8c1fe00cb53f12c25d27425e369",
+				"DiscoKey":   "discokey:11509a612ce7803625a5ab005545987e3bcdd879135ea32083f33ef13b9af745",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37694", "10.65.0.27:37694", "172.17.0.1:37694"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:40:08.696194413Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1359941637466085,
+				"StableID":   "nEXtbvMvcB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c1a81e65ef472f91bed942dc624a2c425c42bb78adb0c81d73007962f90ca2b",
+				"DiscoKey":   "discokey:279c14bffc09aa93f18f247cc6112f781d1825e5776c0802a447cb1911d15631",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46828", "10.65.0.27:46828", "172.17.0.1:46828"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:40:09.241872979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5180600964560629,
+				"StableID":   "n6h17xbJTh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca688ef45b825913d732cd277ce6b8b3cce6245103494bc9de86663fdb13cd14",
+				"DiscoKey":   "discokey:cbd8da0d712407c99f1dcb3bfa036da21e3ab62b2947f347b0dcaf0f3b4be907",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54493", "10.65.0.27:54493", "172.17.0.1:54493"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:40:09.765520134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6738440615352599,
+				"StableID":   "nakRUhQrcu11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fcce41c91459464e2dc5946c0a5765fa53fde27cd9ffcd99135b342724699941",
+				"DiscoKey":   "discokey:0f175125ac7aa89d7d23911f7f7cd544a2a68f8d4e516f86e5b404b7d36b013d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:39401", "10.65.0.27:39401", "172.17.0.1:39401"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:40:10.351827874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6627734880480008,
+				"StableID":   "nm12ngMikt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1b45a52cad59e112afdfdc8420af5f32267d146128a886e6942c02b3b30c0b2f",
+				"DiscoKey":   "discokey:0dcf2d3f449f1cb136d8494bdaea27a04dbac1898e231138ad14a04ddc44da6f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:35526", "10.65.0.27:35526", "172.17.0.1:35526"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:40:10.853188947Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6881674721193239,
+				"StableID":   "n8savgvijv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5b9193bddd5ba26e3217fbd184d053a1402158f37ab11631c1b169a30739f701",
+				"KeyExpiry":  "2026-10-26T10:40:11Z",
+				"DiscoKey":   "discokey:df8d9a09839b2a88e1098a2bbaa9d9feece5e15f5be5595e1359696c5bb44419",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:48455", "10.65.0.27:48455", "172.17.0.1:48455"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:40:11.368622702Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4792313087255189,
+				"StableID":   "nNHu1SwSRe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f0558dc4410321e1f583ee75503fb773f234486f13113d2860c25c3b12199321",
+				"KeyExpiry":  "2026-10-26T10:40:11Z",
+				"DiscoKey":   "discokey:0e991794bc5c5a08f9de53ef4d14fbbb75947545c20186ad75d6a9ecf4ff916c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:42307", "10.65.0.27:42307", "172.17.0.1:42307"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:40:11.916114668Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8308597661845150,
+				"StableID":   "nPyRvkmys721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       8308597661845150,
+				"Key":        "nodekey:d321f0fe2970cdd111adc60ca1a864ef0110b8c1fe00cb53f12c25d27425e369",
+				"DiscoKey":   "discokey:11509a612ce7803625a5ab005545987e3bcdd879135ea32083f33ef13b9af745",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37694", "10.65.0.27:37694", "172.17.0.1:37694"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:40:08.696194413Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d321f0fe2970cdd111adc60ca1a864ef0110b8c1fe00cb53f12c25d27425e369",
+			"MachineKey": "mkey:bfc47ed55b74608cddea2a35dad95bce67d3994e90678bb67fcc1e1028935448",
+			"Peers": [{
+				"ID":         1359941637466085,
+				"StableID":   "nEXtbvMvcB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c1a81e65ef472f91bed942dc624a2c425c42bb78adb0c81d73007962f90ca2b",
+				"DiscoKey":   "discokey:279c14bffc09aa93f18f247cc6112f781d1825e5776c0802a447cb1911d15631",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46828", "10.65.0.27:46828", "172.17.0.1:46828"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:40:09.241872979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5180600964560629,
+				"StableID":   "n6h17xbJTh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca688ef45b825913d732cd277ce6b8b3cce6245103494bc9de86663fdb13cd14",
+				"DiscoKey":   "discokey:cbd8da0d712407c99f1dcb3bfa036da21e3ab62b2947f347b0dcaf0f3b4be907",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54493", "10.65.0.27:54493", "172.17.0.1:54493"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:40:09.765520134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6738440615352599,
+				"StableID":   "nakRUhQrcu11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fcce41c91459464e2dc5946c0a5765fa53fde27cd9ffcd99135b342724699941",
+				"DiscoKey":   "discokey:0f175125ac7aa89d7d23911f7f7cd544a2a68f8d4e516f86e5b404b7d36b013d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:39401", "10.65.0.27:39401", "172.17.0.1:39401"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:40:10.351827874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6627734880480008,
+				"StableID":   "nm12ngMikt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1b45a52cad59e112afdfdc8420af5f32267d146128a886e6942c02b3b30c0b2f",
+				"DiscoKey":   "discokey:0dcf2d3f449f1cb136d8494bdaea27a04dbac1898e231138ad14a04ddc44da6f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:35526", "10.65.0.27:35526", "172.17.0.1:35526"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:40:10.853188947Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6881674721193239,
+				"StableID":   "n8savgvijv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5b9193bddd5ba26e3217fbd184d053a1402158f37ab11631c1b169a30739f701",
+				"KeyExpiry":  "2026-10-26T10:40:11Z",
+				"DiscoKey":   "discokey:df8d9a09839b2a88e1098a2bbaa9d9feece5e15f5be5595e1359696c5bb44419",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:48455", "10.65.0.27:48455", "172.17.0.1:48455"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:40:11.368622702Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4792313087255189,
+				"StableID":   "nNHu1SwSRe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f0558dc4410321e1f583ee75503fb773f234486f13113d2860c25c3b12199321",
+				"KeyExpiry":  "2026-10-26T10:40:11Z",
+				"DiscoKey":   "discokey:0e991794bc5c5a08f9de53ef4d14fbbb75947545c20186ad75d6a9ecf4ff916c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:42307", "10.65.0.27:42307", "172.17.0.1:42307"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:40:11.916114668Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3069294581062906,
+				"StableID":   "nVcjpWA6yQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bd7cde6dc62e80dceda3191c626f2f566ea5dbd6bbe31115514addea7edfde0d",
+				"KeyExpiry":  "2026-10-26T10:40:12Z",
+				"DiscoKey":   "discokey:1334534fd60b0fb2711105ec239bc9d13552b88f62e401b781fbe2aec8478474",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36616", "10.65.0.27:36616", "172.17.0.1:36616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:40:12.509555496Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8308597661845150": {
+				"ID":          8308597661845150,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6881674721193239,
+				"StableID":   "n8savgvijv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5b9193bddd5ba26e3217fbd184d053a1402158f37ab11631c1b169a30739f701",
+				"KeyExpiry":  "2026-10-26T10:40:11Z",
+				"DiscoKey":   "discokey:df8d9a09839b2a88e1098a2bbaa9d9feece5e15f5be5595e1359696c5bb44419",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:48455", "10.65.0.27:48455", "172.17.0.1:48455"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:40:11.368622702Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5b9193bddd5ba26e3217fbd184d053a1402158f37ab11631c1b169a30739f701",
+			"MachineKey": "mkey:7d4c24b83278e7def2273f1933ea500f046af7244caafb8a23f3d7d907555b2e",
+			"Peers": [{
+				"ID":         8308597661845150,
+				"StableID":   "nPyRvkmys721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d321f0fe2970cdd111adc60ca1a864ef0110b8c1fe00cb53f12c25d27425e369",
+				"DiscoKey":   "discokey:11509a612ce7803625a5ab005545987e3bcdd879135ea32083f33ef13b9af745",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37694", "10.65.0.27:37694", "172.17.0.1:37694"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:40:08.696194413Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1359941637466085,
+				"StableID":   "nEXtbvMvcB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c1a81e65ef472f91bed942dc624a2c425c42bb78adb0c81d73007962f90ca2b",
+				"DiscoKey":   "discokey:279c14bffc09aa93f18f247cc6112f781d1825e5776c0802a447cb1911d15631",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46828", "10.65.0.27:46828", "172.17.0.1:46828"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:40:09.241872979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5180600964560629,
+				"StableID":   "n6h17xbJTh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca688ef45b825913d732cd277ce6b8b3cce6245103494bc9de86663fdb13cd14",
+				"DiscoKey":   "discokey:cbd8da0d712407c99f1dcb3bfa036da21e3ab62b2947f347b0dcaf0f3b4be907",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54493", "10.65.0.27:54493", "172.17.0.1:54493"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:40:09.765520134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6738440615352599,
+				"StableID":   "nakRUhQrcu11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fcce41c91459464e2dc5946c0a5765fa53fde27cd9ffcd99135b342724699941",
+				"DiscoKey":   "discokey:0f175125ac7aa89d7d23911f7f7cd544a2a68f8d4e516f86e5b404b7d36b013d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:39401", "10.65.0.27:39401", "172.17.0.1:39401"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:40:10.351827874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6627734880480008,
+				"StableID":   "nm12ngMikt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1b45a52cad59e112afdfdc8420af5f32267d146128a886e6942c02b3b30c0b2f",
+				"DiscoKey":   "discokey:0dcf2d3f449f1cb136d8494bdaea27a04dbac1898e231138ad14a04ddc44da6f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:35526", "10.65.0.27:35526", "172.17.0.1:35526"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:40:10.853188947Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4792313087255189,
+				"StableID":   "nNHu1SwSRe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f0558dc4410321e1f583ee75503fb773f234486f13113d2860c25c3b12199321",
+				"KeyExpiry":  "2026-10-26T10:40:11Z",
+				"DiscoKey":   "discokey:0e991794bc5c5a08f9de53ef4d14fbbb75947545c20186ad75d6a9ecf4ff916c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:42307", "10.65.0.27:42307", "172.17.0.1:42307"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:40:11.916114668Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3069294581062906,
+				"StableID":   "nVcjpWA6yQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bd7cde6dc62e80dceda3191c626f2f566ea5dbd6bbe31115514addea7edfde0d",
+				"KeyExpiry":  "2026-10-26T10:40:12Z",
+				"DiscoKey":   "discokey:1334534fd60b0fb2711105ec239bc9d13552b88f62e401b781fbe2aec8478474",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36616", "10.65.0.27:36616", "172.17.0.1:36616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:40:12.509555496Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6738440615352599,
+				"StableID":   "nakRUhQrcu11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       6738440615352599,
+				"Key":        "nodekey:fcce41c91459464e2dc5946c0a5765fa53fde27cd9ffcd99135b342724699941",
+				"DiscoKey":   "discokey:0f175125ac7aa89d7d23911f7f7cd544a2a68f8d4e516f86e5b404b7d36b013d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:39401", "10.65.0.27:39401", "172.17.0.1:39401"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:40:10.351827874Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fcce41c91459464e2dc5946c0a5765fa53fde27cd9ffcd99135b342724699941",
+			"MachineKey": "mkey:40d0f8e80d4ff7dc2af48c55d803529641cf22c6b82efe8804f4346b954b2842",
+			"Peers": [{
+				"ID":         8308597661845150,
+				"StableID":   "nPyRvkmys721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d321f0fe2970cdd111adc60ca1a864ef0110b8c1fe00cb53f12c25d27425e369",
+				"DiscoKey":   "discokey:11509a612ce7803625a5ab005545987e3bcdd879135ea32083f33ef13b9af745",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37694", "10.65.0.27:37694", "172.17.0.1:37694"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:40:08.696194413Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1359941637466085,
+				"StableID":   "nEXtbvMvcB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c1a81e65ef472f91bed942dc624a2c425c42bb78adb0c81d73007962f90ca2b",
+				"DiscoKey":   "discokey:279c14bffc09aa93f18f247cc6112f781d1825e5776c0802a447cb1911d15631",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46828", "10.65.0.27:46828", "172.17.0.1:46828"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:40:09.241872979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5180600964560629,
+				"StableID":   "n6h17xbJTh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca688ef45b825913d732cd277ce6b8b3cce6245103494bc9de86663fdb13cd14",
+				"DiscoKey":   "discokey:cbd8da0d712407c99f1dcb3bfa036da21e3ab62b2947f347b0dcaf0f3b4be907",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54493", "10.65.0.27:54493", "172.17.0.1:54493"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:40:09.765520134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6627734880480008,
+				"StableID":   "nm12ngMikt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1b45a52cad59e112afdfdc8420af5f32267d146128a886e6942c02b3b30c0b2f",
+				"DiscoKey":   "discokey:0dcf2d3f449f1cb136d8494bdaea27a04dbac1898e231138ad14a04ddc44da6f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:35526", "10.65.0.27:35526", "172.17.0.1:35526"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:40:10.853188947Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6881674721193239,
+				"StableID":   "n8savgvijv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5b9193bddd5ba26e3217fbd184d053a1402158f37ab11631c1b169a30739f701",
+				"KeyExpiry":  "2026-10-26T10:40:11Z",
+				"DiscoKey":   "discokey:df8d9a09839b2a88e1098a2bbaa9d9feece5e15f5be5595e1359696c5bb44419",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:48455", "10.65.0.27:48455", "172.17.0.1:48455"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:40:11.368622702Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4792313087255189,
+				"StableID":   "nNHu1SwSRe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f0558dc4410321e1f583ee75503fb773f234486f13113d2860c25c3b12199321",
+				"KeyExpiry":  "2026-10-26T10:40:11Z",
+				"DiscoKey":   "discokey:0e991794bc5c5a08f9de53ef4d14fbbb75947545c20186ad75d6a9ecf4ff916c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:42307", "10.65.0.27:42307", "172.17.0.1:42307"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:40:11.916114668Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3069294581062906,
+				"StableID":   "nVcjpWA6yQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bd7cde6dc62e80dceda3191c626f2f566ea5dbd6bbe31115514addea7edfde0d",
+				"KeyExpiry":  "2026-10-26T10:40:12Z",
+				"DiscoKey":   "discokey:1334534fd60b0fb2711105ec239bc9d13552b88f62e401b781fbe2aec8478474",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36616", "10.65.0.27:36616", "172.17.0.1:36616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:40:12.509555496Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6738440615352599": {
+				"ID":          6738440615352599,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1359941637466085,
+				"StableID":   "nEXtbvMvcB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1359941637466085,
+				"Key":        "nodekey:2c1a81e65ef472f91bed942dc624a2c425c42bb78adb0c81d73007962f90ca2b",
+				"DiscoKey":   "discokey:279c14bffc09aa93f18f247cc6112f781d1825e5776c0802a447cb1911d15631",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46828", "10.65.0.27:46828", "172.17.0.1:46828"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:40:09.241872979Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2c1a81e65ef472f91bed942dc624a2c425c42bb78adb0c81d73007962f90ca2b",
+			"MachineKey": "mkey:40e6a751f640fd36c59fd79ede40c1f72726ecee04841e0d0afe25088b312973",
+			"Peers": [{
+				"ID":         8308597661845150,
+				"StableID":   "nPyRvkmys721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d321f0fe2970cdd111adc60ca1a864ef0110b8c1fe00cb53f12c25d27425e369",
+				"DiscoKey":   "discokey:11509a612ce7803625a5ab005545987e3bcdd879135ea32083f33ef13b9af745",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37694", "10.65.0.27:37694", "172.17.0.1:37694"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:40:08.696194413Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5180600964560629,
+				"StableID":   "n6h17xbJTh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca688ef45b825913d732cd277ce6b8b3cce6245103494bc9de86663fdb13cd14",
+				"DiscoKey":   "discokey:cbd8da0d712407c99f1dcb3bfa036da21e3ab62b2947f347b0dcaf0f3b4be907",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54493", "10.65.0.27:54493", "172.17.0.1:54493"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:40:09.765520134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6738440615352599,
+				"StableID":   "nakRUhQrcu11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fcce41c91459464e2dc5946c0a5765fa53fde27cd9ffcd99135b342724699941",
+				"DiscoKey":   "discokey:0f175125ac7aa89d7d23911f7f7cd544a2a68f8d4e516f86e5b404b7d36b013d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:39401", "10.65.0.27:39401", "172.17.0.1:39401"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:40:10.351827874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6627734880480008,
+				"StableID":   "nm12ngMikt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1b45a52cad59e112afdfdc8420af5f32267d146128a886e6942c02b3b30c0b2f",
+				"DiscoKey":   "discokey:0dcf2d3f449f1cb136d8494bdaea27a04dbac1898e231138ad14a04ddc44da6f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:35526", "10.65.0.27:35526", "172.17.0.1:35526"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:40:10.853188947Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6881674721193239,
+				"StableID":   "n8savgvijv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5b9193bddd5ba26e3217fbd184d053a1402158f37ab11631c1b169a30739f701",
+				"KeyExpiry":  "2026-10-26T10:40:11Z",
+				"DiscoKey":   "discokey:df8d9a09839b2a88e1098a2bbaa9d9feece5e15f5be5595e1359696c5bb44419",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:48455", "10.65.0.27:48455", "172.17.0.1:48455"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:40:11.368622702Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4792313087255189,
+				"StableID":   "nNHu1SwSRe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f0558dc4410321e1f583ee75503fb773f234486f13113d2860c25c3b12199321",
+				"KeyExpiry":  "2026-10-26T10:40:11Z",
+				"DiscoKey":   "discokey:0e991794bc5c5a08f9de53ef4d14fbbb75947545c20186ad75d6a9ecf4ff916c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:42307", "10.65.0.27:42307", "172.17.0.1:42307"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:40:11.916114668Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3069294581062906,
+				"StableID":   "nVcjpWA6yQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bd7cde6dc62e80dceda3191c626f2f566ea5dbd6bbe31115514addea7edfde0d",
+				"KeyExpiry":  "2026-10-26T10:40:12Z",
+				"DiscoKey":   "discokey:1334534fd60b0fb2711105ec239bc9d13552b88f62e401b781fbe2aec8478474",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36616", "10.65.0.27:36616", "172.17.0.1:36616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:40:12.509555496Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1359941637466085": {
+				"ID":          1359941637466085,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4792313087255189,
+				"StableID":   "nNHu1SwSRe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f0558dc4410321e1f583ee75503fb773f234486f13113d2860c25c3b12199321",
+				"KeyExpiry":  "2026-10-26T10:40:11Z",
+				"DiscoKey":   "discokey:0e991794bc5c5a08f9de53ef4d14fbbb75947545c20186ad75d6a9ecf4ff916c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:42307", "10.65.0.27:42307", "172.17.0.1:42307"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:40:11.916114668Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f0558dc4410321e1f583ee75503fb773f234486f13113d2860c25c3b12199321",
+			"MachineKey": "mkey:0efbce24836f0e4eadb01250986390b6708570d399cb6e9840a9942b670b7f2d",
+			"Peers": [{
+				"ID":         8308597661845150,
+				"StableID":   "nPyRvkmys721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d321f0fe2970cdd111adc60ca1a864ef0110b8c1fe00cb53f12c25d27425e369",
+				"DiscoKey":   "discokey:11509a612ce7803625a5ab005545987e3bcdd879135ea32083f33ef13b9af745",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37694", "10.65.0.27:37694", "172.17.0.1:37694"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:40:08.696194413Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1359941637466085,
+				"StableID":   "nEXtbvMvcB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c1a81e65ef472f91bed942dc624a2c425c42bb78adb0c81d73007962f90ca2b",
+				"DiscoKey":   "discokey:279c14bffc09aa93f18f247cc6112f781d1825e5776c0802a447cb1911d15631",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46828", "10.65.0.27:46828", "172.17.0.1:46828"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:40:09.241872979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5180600964560629,
+				"StableID":   "n6h17xbJTh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca688ef45b825913d732cd277ce6b8b3cce6245103494bc9de86663fdb13cd14",
+				"DiscoKey":   "discokey:cbd8da0d712407c99f1dcb3bfa036da21e3ab62b2947f347b0dcaf0f3b4be907",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54493", "10.65.0.27:54493", "172.17.0.1:54493"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:40:09.765520134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6738440615352599,
+				"StableID":   "nakRUhQrcu11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fcce41c91459464e2dc5946c0a5765fa53fde27cd9ffcd99135b342724699941",
+				"DiscoKey":   "discokey:0f175125ac7aa89d7d23911f7f7cd544a2a68f8d4e516f86e5b404b7d36b013d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:39401", "10.65.0.27:39401", "172.17.0.1:39401"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:40:10.351827874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6627734880480008,
+				"StableID":   "nm12ngMikt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1b45a52cad59e112afdfdc8420af5f32267d146128a886e6942c02b3b30c0b2f",
+				"DiscoKey":   "discokey:0dcf2d3f449f1cb136d8494bdaea27a04dbac1898e231138ad14a04ddc44da6f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:35526", "10.65.0.27:35526", "172.17.0.1:35526"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:40:10.853188947Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6881674721193239,
+				"StableID":   "n8savgvijv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5b9193bddd5ba26e3217fbd184d053a1402158f37ab11631c1b169a30739f701",
+				"KeyExpiry":  "2026-10-26T10:40:11Z",
+				"DiscoKey":   "discokey:df8d9a09839b2a88e1098a2bbaa9d9feece5e15f5be5595e1359696c5bb44419",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:48455", "10.65.0.27:48455", "172.17.0.1:48455"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:40:11.368622702Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3069294581062906,
+				"StableID":   "nVcjpWA6yQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bd7cde6dc62e80dceda3191c626f2f566ea5dbd6bbe31115514addea7edfde0d",
+				"KeyExpiry":  "2026-10-26T10:40:12Z",
+				"DiscoKey":   "discokey:1334534fd60b0fb2711105ec239bc9d13552b88f62e401b781fbe2aec8478474",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36616", "10.65.0.27:36616", "172.17.0.1:36616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:40:12.509555496Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5180600964560629,
+				"StableID":   "n6h17xbJTh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       5180600964560629,
+				"Key":        "nodekey:ca688ef45b825913d732cd277ce6b8b3cce6245103494bc9de86663fdb13cd14",
+				"DiscoKey":   "discokey:cbd8da0d712407c99f1dcb3bfa036da21e3ab62b2947f347b0dcaf0f3b4be907",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54493", "10.65.0.27:54493", "172.17.0.1:54493"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:40:09.765520134Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ca688ef45b825913d732cd277ce6b8b3cce6245103494bc9de86663fdb13cd14",
+			"MachineKey": "mkey:5232eb84d487e67887353ac09df6def0f587e6fa80d2e95f5a25fd2f2585f60c",
+			"Peers": [{
+				"ID":         8308597661845150,
+				"StableID":   "nPyRvkmys721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d321f0fe2970cdd111adc60ca1a864ef0110b8c1fe00cb53f12c25d27425e369",
+				"DiscoKey":   "discokey:11509a612ce7803625a5ab005545987e3bcdd879135ea32083f33ef13b9af745",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37694", "10.65.0.27:37694", "172.17.0.1:37694"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:40:08.696194413Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1359941637466085,
+				"StableID":   "nEXtbvMvcB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c1a81e65ef472f91bed942dc624a2c425c42bb78adb0c81d73007962f90ca2b",
+				"DiscoKey":   "discokey:279c14bffc09aa93f18f247cc6112f781d1825e5776c0802a447cb1911d15631",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46828", "10.65.0.27:46828", "172.17.0.1:46828"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:40:09.241872979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6738440615352599,
+				"StableID":   "nakRUhQrcu11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fcce41c91459464e2dc5946c0a5765fa53fde27cd9ffcd99135b342724699941",
+				"DiscoKey":   "discokey:0f175125ac7aa89d7d23911f7f7cd544a2a68f8d4e516f86e5b404b7d36b013d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:39401", "10.65.0.27:39401", "172.17.0.1:39401"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:40:10.351827874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6627734880480008,
+				"StableID":   "nm12ngMikt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1b45a52cad59e112afdfdc8420af5f32267d146128a886e6942c02b3b30c0b2f",
+				"DiscoKey":   "discokey:0dcf2d3f449f1cb136d8494bdaea27a04dbac1898e231138ad14a04ddc44da6f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:35526", "10.65.0.27:35526", "172.17.0.1:35526"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:40:10.853188947Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6881674721193239,
+				"StableID":   "n8savgvijv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5b9193bddd5ba26e3217fbd184d053a1402158f37ab11631c1b169a30739f701",
+				"KeyExpiry":  "2026-10-26T10:40:11Z",
+				"DiscoKey":   "discokey:df8d9a09839b2a88e1098a2bbaa9d9feece5e15f5be5595e1359696c5bb44419",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:48455", "10.65.0.27:48455", "172.17.0.1:48455"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:40:11.368622702Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4792313087255189,
+				"StableID":   "nNHu1SwSRe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f0558dc4410321e1f583ee75503fb773f234486f13113d2860c25c3b12199321",
+				"KeyExpiry":  "2026-10-26T10:40:11Z",
+				"DiscoKey":   "discokey:0e991794bc5c5a08f9de53ef4d14fbbb75947545c20186ad75d6a9ecf4ff916c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:42307", "10.65.0.27:42307", "172.17.0.1:42307"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:40:11.916114668Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3069294581062906,
+				"StableID":   "nVcjpWA6yQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bd7cde6dc62e80dceda3191c626f2f566ea5dbd6bbe31115514addea7edfde0d",
+				"KeyExpiry":  "2026-10-26T10:40:12Z",
+				"DiscoKey":   "discokey:1334534fd60b0fb2711105ec239bc9d13552b88f62e401b781fbe2aec8478474",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36616", "10.65.0.27:36616", "172.17.0.1:36616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:40:12.509555496Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5180600964560629": {
+				"ID":          5180600964560629,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-accept-fail-proto-numeric-mismatch.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-accept-fail-proto-numeric-mismatch.hujson
@@ -1,0 +1,8848 @@
+// policytest-accept-fail-proto-numeric-mismatch
+//
+// tests block accept-fail: rule proto=6 (tcp), test proto=17 (udp)
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:40:34Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-accept-fail-proto-numeric-mismatch",
+	"description":    "tests block accept-fail: rule proto=6 (tcp), test proto=17 (udp)",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:40:34.186216629Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                \n  \n                                                                 \n                                       \n{\n\t\"id\":          \"policytest-accept-fail-proto-numeric-mismatch\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block accept-fail: rule proto=6 (tcp), test proto=17 (udp)\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"proto\": \"6\", \"src\": [\"group:developers\"], \"dst\": [\"webserver:443\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"proto\": \"17\", \"accept\": [\"webserver:443\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-accept-fail-proto-numeric-mismatch.hujson",
+		"full_policy": {
+			"acls": [{
+				"action": "accept",
+				"dst":    ["webserver:443"],
+				"proto":  "6",
+				"src":    ["group:developers"]
+			}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["webserver:443"], "proto": "17", "src": "thor@example.org"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7506903361382821,
+				"StableID":   "npW2s4dtc121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       7506903361382821,
+				"Key":        "nodekey:47dfb9283b5829863038b892a565a2be6e7cff655000ec46de257dec61f70038",
+				"DiscoKey":   "discokey:31a9c129823188d8b67f2aeb12772964ab5a72f4aba130f8610b90ddd4182d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45290", "10.65.0.27:45290", "172.17.0.1:45290"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:40:37.789444173Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:47dfb9283b5829863038b892a565a2be6e7cff655000ec46de257dec61f70038",
+			"MachineKey": "mkey:64b96e8994bd304a816d3d796caf868cdcf773f2da009bfbb589ace035e36910",
+			"Peers": [{
+				"ID":         6916911002018148,
+				"StableID":   "nDXAQLXg1w11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a09e21e022def0b2e453f10ce4648d99f3f2952c9bc77579488221100a578d05",
+				"DiscoKey":   "discokey:c8ad22a69421965783d7c6b9f9a5cb2c471c07a1ad47a3d2e21b274cf37a9149",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60884", "10.65.0.27:60884", "172.17.0.1:60884"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:40:35.704921636Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4633463033924039,
+				"StableID":   "nWg2maDWBd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c8b8a8e1a943eb3c823e3d1e71ab8c8175e8acab064d43ac8d0f4d5478ac03a",
+				"DiscoKey":   "discokey:3af4be02e8764b850731b4bb4cf39ee4f9b397670400ce1967866973cf7bcd1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56068", "10.65.0.27:56068", "172.17.0.1:56068"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:40:36.174587869Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3047495726239346,
+				"StableID":   "nMGofcYDoQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af04b33be2cf76a37bcb493e9d89cf85dae962e7b748f44bb3c6e01df255cc0e",
+				"DiscoKey":   "discokey:30dd032f467a09d8aff0a3d9746627c9bfc7c03e1761c85ade6ace667363ab63",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57294", "10.65.0.27:57294", "172.17.0.1:57294"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:40:36.713974487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1186719096833611,
+				"StableID":   "n8Borh6UGA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23858d2ef3456c3fee07c2e58558f2254ad5e5c32ddf6ddd4f1b7c29ee7ce03b",
+				"DiscoKey":   "discokey:a2a47eb0ef2cd8932b1bd34ce26dd5d3de55de8ef8d85a4d3242646ada666a07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47704", "10.65.0.27:47704", "172.17.0.1:47704"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:40:37.241000002Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         420841166150816,
+				"StableID":   "n5bVkTnbH411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f29415eeb0c9ed9ba345d83bb773e73f2b9fb22fd6fc83c1b963a2bd46cf0e40",
+				"KeyExpiry":  "2026-10-26T10:40:38Z",
+				"DiscoKey":   "discokey:325719425c545d225b9e4b7acb14ff52bded078ca34e7c877750466fd071b534",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54522", "10.65.0.27:54522", "172.17.0.1:54522"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:40:38.318105372Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1383409590414762,
+				"StableID":   "nhxzEopYoB11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:7a0a2cd0ce346a5f8e018eee4e9c17122bec16c3c37c1d630f5528d2923f376f",
+				"KeyExpiry":  "2026-10-26T10:40:38Z",
+				"DiscoKey":   "discokey:3efdbcf4a697b512b860fbdd00ebada8ea5e9a4e6ac7cf2cda80e1156eaf1b5a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:49837", "10.65.0.27:49837", "172.17.0.1:49837"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:40:38.868582247Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3695163137830796,
+				"StableID":   "nmduzqfYrV11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2ad1daec3d473cbdc5c568e1460429a124caff531417c4b8b95697ea3c4f8535",
+				"KeyExpiry":  "2026-10-26T10:40:39Z",
+				"DiscoKey":   "discokey:011dca5d27c4b2d940fecf2cb4fdbd73edc968e7b349736ce9e78756d25c2017",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58405", "10.65.0.27:58405", "172.17.0.1:58405"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:40:39.403418071Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7506903361382821": {
+				"ID":          7506903361382821,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3695163137830796,
+				"StableID":   "nmduzqfYrV11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2ad1daec3d473cbdc5c568e1460429a124caff531417c4b8b95697ea3c4f8535",
+				"KeyExpiry":  "2026-10-26T10:40:39Z",
+				"DiscoKey":   "discokey:011dca5d27c4b2d940fecf2cb4fdbd73edc968e7b349736ce9e78756d25c2017",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58405", "10.65.0.27:58405", "172.17.0.1:58405"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:40:39.403418071Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2ad1daec3d473cbdc5c568e1460429a124caff531417c4b8b95697ea3c4f8535",
+			"MachineKey": "mkey:0dce120ddea5b9d5160f6d25d3e77ba1f30c090a386e65dcc6977ead7d712e63",
+			"Peers": [{
+				"ID":         6916911002018148,
+				"StableID":   "nDXAQLXg1w11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a09e21e022def0b2e453f10ce4648d99f3f2952c9bc77579488221100a578d05",
+				"DiscoKey":   "discokey:c8ad22a69421965783d7c6b9f9a5cb2c471c07a1ad47a3d2e21b274cf37a9149",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60884", "10.65.0.27:60884", "172.17.0.1:60884"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:40:35.704921636Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4633463033924039,
+				"StableID":   "nWg2maDWBd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c8b8a8e1a943eb3c823e3d1e71ab8c8175e8acab064d43ac8d0f4d5478ac03a",
+				"DiscoKey":   "discokey:3af4be02e8764b850731b4bb4cf39ee4f9b397670400ce1967866973cf7bcd1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56068", "10.65.0.27:56068", "172.17.0.1:56068"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:40:36.174587869Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3047495726239346,
+				"StableID":   "nMGofcYDoQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af04b33be2cf76a37bcb493e9d89cf85dae962e7b748f44bb3c6e01df255cc0e",
+				"DiscoKey":   "discokey:30dd032f467a09d8aff0a3d9746627c9bfc7c03e1761c85ade6ace667363ab63",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57294", "10.65.0.27:57294", "172.17.0.1:57294"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:40:36.713974487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1186719096833611,
+				"StableID":   "n8Borh6UGA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23858d2ef3456c3fee07c2e58558f2254ad5e5c32ddf6ddd4f1b7c29ee7ce03b",
+				"DiscoKey":   "discokey:a2a47eb0ef2cd8932b1bd34ce26dd5d3de55de8ef8d85a4d3242646ada666a07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47704", "10.65.0.27:47704", "172.17.0.1:47704"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:40:37.241000002Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7506903361382821,
+				"StableID":   "npW2s4dtc121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47dfb9283b5829863038b892a565a2be6e7cff655000ec46de257dec61f70038",
+				"DiscoKey":   "discokey:31a9c129823188d8b67f2aeb12772964ab5a72f4aba130f8610b90ddd4182d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45290", "10.65.0.27:45290", "172.17.0.1:45290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:40:37.789444173Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         420841166150816,
+				"StableID":   "n5bVkTnbH411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f29415eeb0c9ed9ba345d83bb773e73f2b9fb22fd6fc83c1b963a2bd46cf0e40",
+				"KeyExpiry":  "2026-10-26T10:40:38Z",
+				"DiscoKey":   "discokey:325719425c545d225b9e4b7acb14ff52bded078ca34e7c877750466fd071b534",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54522", "10.65.0.27:54522", "172.17.0.1:54522"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:40:38.318105372Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1383409590414762,
+				"StableID":   "nhxzEopYoB11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:7a0a2cd0ce346a5f8e018eee4e9c17122bec16c3c37c1d630f5528d2923f376f",
+				"KeyExpiry":  "2026-10-26T10:40:38Z",
+				"DiscoKey":   "discokey:3efdbcf4a697b512b860fbdd00ebada8ea5e9a4e6ac7cf2cda80e1156eaf1b5a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:49837", "10.65.0.27:49837", "172.17.0.1:49837"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:40:38.868582247Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6916911002018148,
+				"StableID":   "nDXAQLXg1w11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       6916911002018148,
+				"Key":        "nodekey:a09e21e022def0b2e453f10ce4648d99f3f2952c9bc77579488221100a578d05",
+				"DiscoKey":   "discokey:c8ad22a69421965783d7c6b9f9a5cb2c471c07a1ad47a3d2e21b274cf37a9149",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60884", "10.65.0.27:60884", "172.17.0.1:60884"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:40:35.704921636Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a09e21e022def0b2e453f10ce4648d99f3f2952c9bc77579488221100a578d05",
+			"MachineKey": "mkey:bf2fc3a82dd1b134071cbf8241b293288997c6f06f16b22788dfbf5c177b6a24",
+			"Peers": [{
+				"ID":         4633463033924039,
+				"StableID":   "nWg2maDWBd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c8b8a8e1a943eb3c823e3d1e71ab8c8175e8acab064d43ac8d0f4d5478ac03a",
+				"DiscoKey":   "discokey:3af4be02e8764b850731b4bb4cf39ee4f9b397670400ce1967866973cf7bcd1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56068", "10.65.0.27:56068", "172.17.0.1:56068"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:40:36.174587869Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3047495726239346,
+				"StableID":   "nMGofcYDoQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af04b33be2cf76a37bcb493e9d89cf85dae962e7b748f44bb3c6e01df255cc0e",
+				"DiscoKey":   "discokey:30dd032f467a09d8aff0a3d9746627c9bfc7c03e1761c85ade6ace667363ab63",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57294", "10.65.0.27:57294", "172.17.0.1:57294"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:40:36.713974487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1186719096833611,
+				"StableID":   "n8Borh6UGA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23858d2ef3456c3fee07c2e58558f2254ad5e5c32ddf6ddd4f1b7c29ee7ce03b",
+				"DiscoKey":   "discokey:a2a47eb0ef2cd8932b1bd34ce26dd5d3de55de8ef8d85a4d3242646ada666a07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47704", "10.65.0.27:47704", "172.17.0.1:47704"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:40:37.241000002Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7506903361382821,
+				"StableID":   "npW2s4dtc121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47dfb9283b5829863038b892a565a2be6e7cff655000ec46de257dec61f70038",
+				"DiscoKey":   "discokey:31a9c129823188d8b67f2aeb12772964ab5a72f4aba130f8610b90ddd4182d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45290", "10.65.0.27:45290", "172.17.0.1:45290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:40:37.789444173Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         420841166150816,
+				"StableID":   "n5bVkTnbH411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f29415eeb0c9ed9ba345d83bb773e73f2b9fb22fd6fc83c1b963a2bd46cf0e40",
+				"KeyExpiry":  "2026-10-26T10:40:38Z",
+				"DiscoKey":   "discokey:325719425c545d225b9e4b7acb14ff52bded078ca34e7c877750466fd071b534",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54522", "10.65.0.27:54522", "172.17.0.1:54522"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:40:38.318105372Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1383409590414762,
+				"StableID":   "nhxzEopYoB11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:7a0a2cd0ce346a5f8e018eee4e9c17122bec16c3c37c1d630f5528d2923f376f",
+				"KeyExpiry":  "2026-10-26T10:40:38Z",
+				"DiscoKey":   "discokey:3efdbcf4a697b512b860fbdd00ebada8ea5e9a4e6ac7cf2cda80e1156eaf1b5a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:49837", "10.65.0.27:49837", "172.17.0.1:49837"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:40:38.868582247Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3695163137830796,
+				"StableID":   "nmduzqfYrV11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2ad1daec3d473cbdc5c568e1460429a124caff531417c4b8b95697ea3c4f8535",
+				"KeyExpiry":  "2026-10-26T10:40:39Z",
+				"DiscoKey":   "discokey:011dca5d27c4b2d940fecf2cb4fdbd73edc968e7b349736ce9e78756d25c2017",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58405", "10.65.0.27:58405", "172.17.0.1:58405"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:40:39.403418071Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6916911002018148": {
+				"ID":          6916911002018148,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         420841166150816,
+				"StableID":   "n5bVkTnbH411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f29415eeb0c9ed9ba345d83bb773e73f2b9fb22fd6fc83c1b963a2bd46cf0e40",
+				"KeyExpiry":  "2026-10-26T10:40:38Z",
+				"DiscoKey":   "discokey:325719425c545d225b9e4b7acb14ff52bded078ca34e7c877750466fd071b534",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54522", "10.65.0.27:54522", "172.17.0.1:54522"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:40:38.318105372Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f29415eeb0c9ed9ba345d83bb773e73f2b9fb22fd6fc83c1b963a2bd46cf0e40",
+			"MachineKey": "mkey:1d858b38aac36f18465ea707597076bcd0eeee4e7b42277f4791636203241950",
+			"Peers": [{
+				"ID":         6916911002018148,
+				"StableID":   "nDXAQLXg1w11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a09e21e022def0b2e453f10ce4648d99f3f2952c9bc77579488221100a578d05",
+				"DiscoKey":   "discokey:c8ad22a69421965783d7c6b9f9a5cb2c471c07a1ad47a3d2e21b274cf37a9149",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60884", "10.65.0.27:60884", "172.17.0.1:60884"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:40:35.704921636Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4633463033924039,
+				"StableID":   "nWg2maDWBd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c8b8a8e1a943eb3c823e3d1e71ab8c8175e8acab064d43ac8d0f4d5478ac03a",
+				"DiscoKey":   "discokey:3af4be02e8764b850731b4bb4cf39ee4f9b397670400ce1967866973cf7bcd1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56068", "10.65.0.27:56068", "172.17.0.1:56068"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:40:36.174587869Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3047495726239346,
+				"StableID":   "nMGofcYDoQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af04b33be2cf76a37bcb493e9d89cf85dae962e7b748f44bb3c6e01df255cc0e",
+				"DiscoKey":   "discokey:30dd032f467a09d8aff0a3d9746627c9bfc7c03e1761c85ade6ace667363ab63",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57294", "10.65.0.27:57294", "172.17.0.1:57294"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:40:36.713974487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1186719096833611,
+				"StableID":   "n8Borh6UGA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23858d2ef3456c3fee07c2e58558f2254ad5e5c32ddf6ddd4f1b7c29ee7ce03b",
+				"DiscoKey":   "discokey:a2a47eb0ef2cd8932b1bd34ce26dd5d3de55de8ef8d85a4d3242646ada666a07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47704", "10.65.0.27:47704", "172.17.0.1:47704"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:40:37.241000002Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7506903361382821,
+				"StableID":   "npW2s4dtc121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47dfb9283b5829863038b892a565a2be6e7cff655000ec46de257dec61f70038",
+				"DiscoKey":   "discokey:31a9c129823188d8b67f2aeb12772964ab5a72f4aba130f8610b90ddd4182d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45290", "10.65.0.27:45290", "172.17.0.1:45290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:40:37.789444173Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1383409590414762,
+				"StableID":   "nhxzEopYoB11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:7a0a2cd0ce346a5f8e018eee4e9c17122bec16c3c37c1d630f5528d2923f376f",
+				"KeyExpiry":  "2026-10-26T10:40:38Z",
+				"DiscoKey":   "discokey:3efdbcf4a697b512b860fbdd00ebada8ea5e9a4e6ac7cf2cda80e1156eaf1b5a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:49837", "10.65.0.27:49837", "172.17.0.1:49837"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:40:38.868582247Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3695163137830796,
+				"StableID":   "nmduzqfYrV11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2ad1daec3d473cbdc5c568e1460429a124caff531417c4b8b95697ea3c4f8535",
+				"KeyExpiry":  "2026-10-26T10:40:39Z",
+				"DiscoKey":   "discokey:011dca5d27c4b2d940fecf2cb4fdbd73edc968e7b349736ce9e78756d25c2017",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58405", "10.65.0.27:58405", "172.17.0.1:58405"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:40:39.403418071Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1186719096833611,
+				"StableID":   "n8Borh6UGA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1186719096833611,
+				"Key":        "nodekey:23858d2ef3456c3fee07c2e58558f2254ad5e5c32ddf6ddd4f1b7c29ee7ce03b",
+				"DiscoKey":   "discokey:a2a47eb0ef2cd8932b1bd34ce26dd5d3de55de8ef8d85a4d3242646ada666a07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47704", "10.65.0.27:47704", "172.17.0.1:47704"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:40:37.241000002Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:23858d2ef3456c3fee07c2e58558f2254ad5e5c32ddf6ddd4f1b7c29ee7ce03b",
+			"MachineKey": "mkey:3b3a0521808241f2c731448fc749a38b86e6a3d2fb92a19c62ca92615be8735b",
+			"Peers": [{
+				"ID":         6916911002018148,
+				"StableID":   "nDXAQLXg1w11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a09e21e022def0b2e453f10ce4648d99f3f2952c9bc77579488221100a578d05",
+				"DiscoKey":   "discokey:c8ad22a69421965783d7c6b9f9a5cb2c471c07a1ad47a3d2e21b274cf37a9149",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60884", "10.65.0.27:60884", "172.17.0.1:60884"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:40:35.704921636Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4633463033924039,
+				"StableID":   "nWg2maDWBd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c8b8a8e1a943eb3c823e3d1e71ab8c8175e8acab064d43ac8d0f4d5478ac03a",
+				"DiscoKey":   "discokey:3af4be02e8764b850731b4bb4cf39ee4f9b397670400ce1967866973cf7bcd1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56068", "10.65.0.27:56068", "172.17.0.1:56068"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:40:36.174587869Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3047495726239346,
+				"StableID":   "nMGofcYDoQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af04b33be2cf76a37bcb493e9d89cf85dae962e7b748f44bb3c6e01df255cc0e",
+				"DiscoKey":   "discokey:30dd032f467a09d8aff0a3d9746627c9bfc7c03e1761c85ade6ace667363ab63",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57294", "10.65.0.27:57294", "172.17.0.1:57294"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:40:36.713974487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7506903361382821,
+				"StableID":   "npW2s4dtc121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47dfb9283b5829863038b892a565a2be6e7cff655000ec46de257dec61f70038",
+				"DiscoKey":   "discokey:31a9c129823188d8b67f2aeb12772964ab5a72f4aba130f8610b90ddd4182d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45290", "10.65.0.27:45290", "172.17.0.1:45290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:40:37.789444173Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         420841166150816,
+				"StableID":   "n5bVkTnbH411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f29415eeb0c9ed9ba345d83bb773e73f2b9fb22fd6fc83c1b963a2bd46cf0e40",
+				"KeyExpiry":  "2026-10-26T10:40:38Z",
+				"DiscoKey":   "discokey:325719425c545d225b9e4b7acb14ff52bded078ca34e7c877750466fd071b534",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54522", "10.65.0.27:54522", "172.17.0.1:54522"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:40:38.318105372Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1383409590414762,
+				"StableID":   "nhxzEopYoB11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:7a0a2cd0ce346a5f8e018eee4e9c17122bec16c3c37c1d630f5528d2923f376f",
+				"KeyExpiry":  "2026-10-26T10:40:38Z",
+				"DiscoKey":   "discokey:3efdbcf4a697b512b860fbdd00ebada8ea5e9a4e6ac7cf2cda80e1156eaf1b5a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:49837", "10.65.0.27:49837", "172.17.0.1:49837"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:40:38.868582247Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3695163137830796,
+				"StableID":   "nmduzqfYrV11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2ad1daec3d473cbdc5c568e1460429a124caff531417c4b8b95697ea3c4f8535",
+				"KeyExpiry":  "2026-10-26T10:40:39Z",
+				"DiscoKey":   "discokey:011dca5d27c4b2d940fecf2cb4fdbd73edc968e7b349736ce9e78756d25c2017",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58405", "10.65.0.27:58405", "172.17.0.1:58405"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:40:39.403418071Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1186719096833611": {
+				"ID":          1186719096833611,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4633463033924039,
+				"StableID":   "nWg2maDWBd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       4633463033924039,
+				"Key":        "nodekey:2c8b8a8e1a943eb3c823e3d1e71ab8c8175e8acab064d43ac8d0f4d5478ac03a",
+				"DiscoKey":   "discokey:3af4be02e8764b850731b4bb4cf39ee4f9b397670400ce1967866973cf7bcd1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56068", "10.65.0.27:56068", "172.17.0.1:56068"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:40:36.174587869Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2c8b8a8e1a943eb3c823e3d1e71ab8c8175e8acab064d43ac8d0f4d5478ac03a",
+			"MachineKey": "mkey:6093d7cfeea78077310b8e6033a6ce6504f9912039d37f3eb6702fadeb11b672",
+			"Peers": [{
+				"ID":         6916911002018148,
+				"StableID":   "nDXAQLXg1w11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a09e21e022def0b2e453f10ce4648d99f3f2952c9bc77579488221100a578d05",
+				"DiscoKey":   "discokey:c8ad22a69421965783d7c6b9f9a5cb2c471c07a1ad47a3d2e21b274cf37a9149",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60884", "10.65.0.27:60884", "172.17.0.1:60884"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:40:35.704921636Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3047495726239346,
+				"StableID":   "nMGofcYDoQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af04b33be2cf76a37bcb493e9d89cf85dae962e7b748f44bb3c6e01df255cc0e",
+				"DiscoKey":   "discokey:30dd032f467a09d8aff0a3d9746627c9bfc7c03e1761c85ade6ace667363ab63",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57294", "10.65.0.27:57294", "172.17.0.1:57294"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:40:36.713974487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1186719096833611,
+				"StableID":   "n8Borh6UGA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23858d2ef3456c3fee07c2e58558f2254ad5e5c32ddf6ddd4f1b7c29ee7ce03b",
+				"DiscoKey":   "discokey:a2a47eb0ef2cd8932b1bd34ce26dd5d3de55de8ef8d85a4d3242646ada666a07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47704", "10.65.0.27:47704", "172.17.0.1:47704"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:40:37.241000002Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7506903361382821,
+				"StableID":   "npW2s4dtc121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47dfb9283b5829863038b892a565a2be6e7cff655000ec46de257dec61f70038",
+				"DiscoKey":   "discokey:31a9c129823188d8b67f2aeb12772964ab5a72f4aba130f8610b90ddd4182d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45290", "10.65.0.27:45290", "172.17.0.1:45290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:40:37.789444173Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         420841166150816,
+				"StableID":   "n5bVkTnbH411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f29415eeb0c9ed9ba345d83bb773e73f2b9fb22fd6fc83c1b963a2bd46cf0e40",
+				"KeyExpiry":  "2026-10-26T10:40:38Z",
+				"DiscoKey":   "discokey:325719425c545d225b9e4b7acb14ff52bded078ca34e7c877750466fd071b534",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54522", "10.65.0.27:54522", "172.17.0.1:54522"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:40:38.318105372Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1383409590414762,
+				"StableID":   "nhxzEopYoB11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:7a0a2cd0ce346a5f8e018eee4e9c17122bec16c3c37c1d630f5528d2923f376f",
+				"KeyExpiry":  "2026-10-26T10:40:38Z",
+				"DiscoKey":   "discokey:3efdbcf4a697b512b860fbdd00ebada8ea5e9a4e6ac7cf2cda80e1156eaf1b5a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:49837", "10.65.0.27:49837", "172.17.0.1:49837"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:40:38.868582247Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3695163137830796,
+				"StableID":   "nmduzqfYrV11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2ad1daec3d473cbdc5c568e1460429a124caff531417c4b8b95697ea3c4f8535",
+				"KeyExpiry":  "2026-10-26T10:40:39Z",
+				"DiscoKey":   "discokey:011dca5d27c4b2d940fecf2cb4fdbd73edc968e7b349736ce9e78756d25c2017",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58405", "10.65.0.27:58405", "172.17.0.1:58405"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:40:39.403418071Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4633463033924039": {
+				"ID":          4633463033924039,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1383409590414762,
+				"StableID":   "nhxzEopYoB11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:7a0a2cd0ce346a5f8e018eee4e9c17122bec16c3c37c1d630f5528d2923f376f",
+				"KeyExpiry":  "2026-10-26T10:40:38Z",
+				"DiscoKey":   "discokey:3efdbcf4a697b512b860fbdd00ebada8ea5e9a4e6ac7cf2cda80e1156eaf1b5a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:49837", "10.65.0.27:49837", "172.17.0.1:49837"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:40:38.868582247Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7a0a2cd0ce346a5f8e018eee4e9c17122bec16c3c37c1d630f5528d2923f376f",
+			"MachineKey": "mkey:bfd739f8d05fb060f6a155ee022781596442d2218497ac4652816628ce842c6f",
+			"Peers": [{
+				"ID":         6916911002018148,
+				"StableID":   "nDXAQLXg1w11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a09e21e022def0b2e453f10ce4648d99f3f2952c9bc77579488221100a578d05",
+				"DiscoKey":   "discokey:c8ad22a69421965783d7c6b9f9a5cb2c471c07a1ad47a3d2e21b274cf37a9149",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60884", "10.65.0.27:60884", "172.17.0.1:60884"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:40:35.704921636Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4633463033924039,
+				"StableID":   "nWg2maDWBd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c8b8a8e1a943eb3c823e3d1e71ab8c8175e8acab064d43ac8d0f4d5478ac03a",
+				"DiscoKey":   "discokey:3af4be02e8764b850731b4bb4cf39ee4f9b397670400ce1967866973cf7bcd1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56068", "10.65.0.27:56068", "172.17.0.1:56068"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:40:36.174587869Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3047495726239346,
+				"StableID":   "nMGofcYDoQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af04b33be2cf76a37bcb493e9d89cf85dae962e7b748f44bb3c6e01df255cc0e",
+				"DiscoKey":   "discokey:30dd032f467a09d8aff0a3d9746627c9bfc7c03e1761c85ade6ace667363ab63",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57294", "10.65.0.27:57294", "172.17.0.1:57294"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:40:36.713974487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1186719096833611,
+				"StableID":   "n8Borh6UGA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23858d2ef3456c3fee07c2e58558f2254ad5e5c32ddf6ddd4f1b7c29ee7ce03b",
+				"DiscoKey":   "discokey:a2a47eb0ef2cd8932b1bd34ce26dd5d3de55de8ef8d85a4d3242646ada666a07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47704", "10.65.0.27:47704", "172.17.0.1:47704"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:40:37.241000002Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7506903361382821,
+				"StableID":   "npW2s4dtc121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47dfb9283b5829863038b892a565a2be6e7cff655000ec46de257dec61f70038",
+				"DiscoKey":   "discokey:31a9c129823188d8b67f2aeb12772964ab5a72f4aba130f8610b90ddd4182d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45290", "10.65.0.27:45290", "172.17.0.1:45290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:40:37.789444173Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         420841166150816,
+				"StableID":   "n5bVkTnbH411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f29415eeb0c9ed9ba345d83bb773e73f2b9fb22fd6fc83c1b963a2bd46cf0e40",
+				"KeyExpiry":  "2026-10-26T10:40:38Z",
+				"DiscoKey":   "discokey:325719425c545d225b9e4b7acb14ff52bded078ca34e7c877750466fd071b534",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54522", "10.65.0.27:54522", "172.17.0.1:54522"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:40:38.318105372Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3695163137830796,
+				"StableID":   "nmduzqfYrV11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2ad1daec3d473cbdc5c568e1460429a124caff531417c4b8b95697ea3c4f8535",
+				"KeyExpiry":  "2026-10-26T10:40:39Z",
+				"DiscoKey":   "discokey:011dca5d27c4b2d940fecf2cb4fdbd73edc968e7b349736ce9e78756d25c2017",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58405", "10.65.0.27:58405", "172.17.0.1:58405"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:40:39.403418071Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3047495726239346,
+				"StableID":   "nMGofcYDoQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       3047495726239346,
+				"Key":        "nodekey:af04b33be2cf76a37bcb493e9d89cf85dae962e7b748f44bb3c6e01df255cc0e",
+				"DiscoKey":   "discokey:30dd032f467a09d8aff0a3d9746627c9bfc7c03e1761c85ade6ace667363ab63",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57294", "10.65.0.27:57294", "172.17.0.1:57294"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:40:36.713974487Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:af04b33be2cf76a37bcb493e9d89cf85dae962e7b748f44bb3c6e01df255cc0e",
+			"MachineKey": "mkey:7927aaba06030c4804af2c977a3a1f3ddadfcef835653731026e661f435be510",
+			"Peers": [{
+				"ID":         6916911002018148,
+				"StableID":   "nDXAQLXg1w11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a09e21e022def0b2e453f10ce4648d99f3f2952c9bc77579488221100a578d05",
+				"DiscoKey":   "discokey:c8ad22a69421965783d7c6b9f9a5cb2c471c07a1ad47a3d2e21b274cf37a9149",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60884", "10.65.0.27:60884", "172.17.0.1:60884"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:40:35.704921636Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4633463033924039,
+				"StableID":   "nWg2maDWBd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c8b8a8e1a943eb3c823e3d1e71ab8c8175e8acab064d43ac8d0f4d5478ac03a",
+				"DiscoKey":   "discokey:3af4be02e8764b850731b4bb4cf39ee4f9b397670400ce1967866973cf7bcd1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56068", "10.65.0.27:56068", "172.17.0.1:56068"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:40:36.174587869Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1186719096833611,
+				"StableID":   "n8Borh6UGA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23858d2ef3456c3fee07c2e58558f2254ad5e5c32ddf6ddd4f1b7c29ee7ce03b",
+				"DiscoKey":   "discokey:a2a47eb0ef2cd8932b1bd34ce26dd5d3de55de8ef8d85a4d3242646ada666a07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47704", "10.65.0.27:47704", "172.17.0.1:47704"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:40:37.241000002Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7506903361382821,
+				"StableID":   "npW2s4dtc121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47dfb9283b5829863038b892a565a2be6e7cff655000ec46de257dec61f70038",
+				"DiscoKey":   "discokey:31a9c129823188d8b67f2aeb12772964ab5a72f4aba130f8610b90ddd4182d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45290", "10.65.0.27:45290", "172.17.0.1:45290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:40:37.789444173Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         420841166150816,
+				"StableID":   "n5bVkTnbH411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f29415eeb0c9ed9ba345d83bb773e73f2b9fb22fd6fc83c1b963a2bd46cf0e40",
+				"KeyExpiry":  "2026-10-26T10:40:38Z",
+				"DiscoKey":   "discokey:325719425c545d225b9e4b7acb14ff52bded078ca34e7c877750466fd071b534",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54522", "10.65.0.27:54522", "172.17.0.1:54522"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:40:38.318105372Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1383409590414762,
+				"StableID":   "nhxzEopYoB11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:7a0a2cd0ce346a5f8e018eee4e9c17122bec16c3c37c1d630f5528d2923f376f",
+				"KeyExpiry":  "2026-10-26T10:40:38Z",
+				"DiscoKey":   "discokey:3efdbcf4a697b512b860fbdd00ebada8ea5e9a4e6ac7cf2cda80e1156eaf1b5a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:49837", "10.65.0.27:49837", "172.17.0.1:49837"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:40:38.868582247Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3695163137830796,
+				"StableID":   "nmduzqfYrV11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2ad1daec3d473cbdc5c568e1460429a124caff531417c4b8b95697ea3c4f8535",
+				"KeyExpiry":  "2026-10-26T10:40:39Z",
+				"DiscoKey":   "discokey:011dca5d27c4b2d940fecf2cb4fdbd73edc968e7b349736ce9e78756d25c2017",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58405", "10.65.0.27:58405", "172.17.0.1:58405"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:40:39.403418071Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3047495726239346": {
+				"ID":          3047495726239346,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-accept-fail-tag-src-host-dst.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-accept-fail-tag-src-host-dst.hujson
@@ -1,0 +1,8843 @@
+// policytest-accept-fail-tag-src-host-dst
+//
+// tests block accept-fail: tag src to host dst on wrong port
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:41:01Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-accept-fail-tag-src-host-dst",
+	"description":    "tests block accept-fail: tag src to host dst on wrong port",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:41:01.121904229Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                          \n  \n                                                                       \n                                                                    \n                     \n{\n\t\"id\":          \"policytest-accept-fail-tag-src-host-dst\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block accept-fail: tag src to host dst on wrong port\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"tag:client\"], \"dst\": [\"webserver:80\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"tag:client\", \"accept\": [\"webserver:443\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-accept-fail-tag-src-host-dst.hujson",
+		"full_policy": {
+			"acls": [{"action": "accept", "dst": ["webserver:80"], "src": ["tag:client"]}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["webserver:443"], "src": "tag:client"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3628507124416184,
+				"StableID":   "n174MJjMLV11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       3628507124416184,
+				"Key":        "nodekey:ce607c883d316f42ef2adf8915cd619beb7221bb5fd19cd3d3f21a864ab1d23b",
+				"DiscoKey":   "discokey:cc1a1e939656c7f0f786cd5411bdffca34ecaa99e3b66d73693730fa7e164c49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:41976", "10.65.0.27:41976", "172.17.0.1:41976"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:41:04.839160561Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ce607c883d316f42ef2adf8915cd619beb7221bb5fd19cd3d3f21a864ab1d23b",
+			"MachineKey": "mkey:d042b99f3efcfb5c67e1d2a4e3985ffddc56140c94885a730963f7716c1ee70e",
+			"Peers": [{
+				"ID":         6030384571078947,
+				"StableID":   "nELwTfyA6p11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a12488fa29a0a2ac9dc31008b23b3fd5fddb23517be9a85eff75602636737a77",
+				"DiscoKey":   "discokey:0c7e627891e31b0a8f499e3e30de795bd80afe794a896557e2f0dc269e34a723",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:51573", "10.65.0.27:51573", "172.17.0.1:51573"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:41:02.702211621Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3018051913499631,
+				"StableID":   "nAnEm97tZQ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d05ce18e13a64ffda8fca1c50325080fa11661d2e1fc465397c9a8eac81427c",
+				"DiscoKey":   "discokey:fd7fe7bc52c622270457df39cb4d3ad5b51f5d3512a328dd1664b97f570c8253",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60789", "10.65.0.27:60789", "172.17.0.1:60789"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:41:03.221947156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6583927606589653,
+				"StableID":   "nzuczbcsQt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3e1f44181d36af260df80afb3544a24a970c0ce972707fea54e0b61b831c24d",
+				"DiscoKey":   "discokey:156e10a77179d6667aa6079797761242eb5daf12fea6b3c79d11e2030b718f13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:51019", "10.65.0.27:51019", "172.17.0.1:51019"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:41:03.741234927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         707181887821496,
+				"StableID":   "n9MBoCUHX611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06eeefa8c5caf0ae5c0f572875e09e3f7187bcfafd90a3e1fede05df3ea2760b",
+				"DiscoKey":   "discokey:692e23216ee6e4e86fbb7d69e8e920fb1f09251468e462eea5026fe607c99904",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53279", "10.65.0.27:53279", "172.17.0.1:53279"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:41:04.29906102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2551959797582664,
+				"StableID":   "nX88Y5fnvL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1502c64212273a63afbaaae2eb6ff027184d9e333780e1d11055aa95ed160371",
+				"KeyExpiry":  "2026-10-26T10:41:05Z",
+				"DiscoKey":   "discokey:10e2d63dbd00b78424ac7f57554732df968c753d6530a2c45eda1ef8509e9336",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:42712", "10.65.0.27:42712", "172.17.0.1:42712"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:41:05.409455646Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6031238229336382,
+				"StableID":   "n5GeKGQZ6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:caef4fd2cbab93af4d05532e379f48dc5103b137a4be0778d7f0b73b30a2e24e",
+				"KeyExpiry":  "2026-10-26T10:41:05Z",
+				"DiscoKey":   "discokey:af2ea202887cf7e767d842e42a0a049bfe7dafe6aa6e06edb938af2140bc432c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53268", "10.65.0.27:53268", "172.17.0.1:53268"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:41:05.931891568Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1599579790711358,
+				"StableID":   "nXTtbRFTVD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4af5dcd590b774ea51f84f4ee57f02eb23a6e5f55fa6afc9ede7632915c6910",
+				"KeyExpiry":  "2026-10-26T10:41:06Z",
+				"DiscoKey":   "discokey:7f6e4bee7ef721fbcf65578ea0452b06e3da4259168931280f9c5dce13df9737",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34895", "10.65.0.27:34895", "172.17.0.1:34895"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:41:06.474546058Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3628507124416184": {
+				"ID":          3628507124416184,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1599579790711358,
+				"StableID":   "nXTtbRFTVD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4af5dcd590b774ea51f84f4ee57f02eb23a6e5f55fa6afc9ede7632915c6910",
+				"KeyExpiry":  "2026-10-26T10:41:06Z",
+				"DiscoKey":   "discokey:7f6e4bee7ef721fbcf65578ea0452b06e3da4259168931280f9c5dce13df9737",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34895", "10.65.0.27:34895", "172.17.0.1:34895"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:41:06.474546058Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e4af5dcd590b774ea51f84f4ee57f02eb23a6e5f55fa6afc9ede7632915c6910",
+			"MachineKey": "mkey:3f8e1034ab34891e0d53081a0547df58fd798fead5d3a82b95b346835518033c",
+			"Peers": [{
+				"ID":         6030384571078947,
+				"StableID":   "nELwTfyA6p11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a12488fa29a0a2ac9dc31008b23b3fd5fddb23517be9a85eff75602636737a77",
+				"DiscoKey":   "discokey:0c7e627891e31b0a8f499e3e30de795bd80afe794a896557e2f0dc269e34a723",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:51573", "10.65.0.27:51573", "172.17.0.1:51573"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:41:02.702211621Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3018051913499631,
+				"StableID":   "nAnEm97tZQ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d05ce18e13a64ffda8fca1c50325080fa11661d2e1fc465397c9a8eac81427c",
+				"DiscoKey":   "discokey:fd7fe7bc52c622270457df39cb4d3ad5b51f5d3512a328dd1664b97f570c8253",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60789", "10.65.0.27:60789", "172.17.0.1:60789"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:41:03.221947156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6583927606589653,
+				"StableID":   "nzuczbcsQt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3e1f44181d36af260df80afb3544a24a970c0ce972707fea54e0b61b831c24d",
+				"DiscoKey":   "discokey:156e10a77179d6667aa6079797761242eb5daf12fea6b3c79d11e2030b718f13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:51019", "10.65.0.27:51019", "172.17.0.1:51019"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:41:03.741234927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         707181887821496,
+				"StableID":   "n9MBoCUHX611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06eeefa8c5caf0ae5c0f572875e09e3f7187bcfafd90a3e1fede05df3ea2760b",
+				"DiscoKey":   "discokey:692e23216ee6e4e86fbb7d69e8e920fb1f09251468e462eea5026fe607c99904",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53279", "10.65.0.27:53279", "172.17.0.1:53279"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:41:04.29906102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3628507124416184,
+				"StableID":   "n174MJjMLV11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce607c883d316f42ef2adf8915cd619beb7221bb5fd19cd3d3f21a864ab1d23b",
+				"DiscoKey":   "discokey:cc1a1e939656c7f0f786cd5411bdffca34ecaa99e3b66d73693730fa7e164c49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:41976", "10.65.0.27:41976", "172.17.0.1:41976"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:41:04.839160561Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2551959797582664,
+				"StableID":   "nX88Y5fnvL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1502c64212273a63afbaaae2eb6ff027184d9e333780e1d11055aa95ed160371",
+				"KeyExpiry":  "2026-10-26T10:41:05Z",
+				"DiscoKey":   "discokey:10e2d63dbd00b78424ac7f57554732df968c753d6530a2c45eda1ef8509e9336",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:42712", "10.65.0.27:42712", "172.17.0.1:42712"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:41:05.409455646Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6031238229336382,
+				"StableID":   "n5GeKGQZ6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:caef4fd2cbab93af4d05532e379f48dc5103b137a4be0778d7f0b73b30a2e24e",
+				"KeyExpiry":  "2026-10-26T10:41:05Z",
+				"DiscoKey":   "discokey:af2ea202887cf7e767d842e42a0a049bfe7dafe6aa6e06edb938af2140bc432c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53268", "10.65.0.27:53268", "172.17.0.1:53268"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:41:05.931891568Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6030384571078947,
+				"StableID":   "nELwTfyA6p11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       6030384571078947,
+				"Key":        "nodekey:a12488fa29a0a2ac9dc31008b23b3fd5fddb23517be9a85eff75602636737a77",
+				"DiscoKey":   "discokey:0c7e627891e31b0a8f499e3e30de795bd80afe794a896557e2f0dc269e34a723",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:51573", "10.65.0.27:51573", "172.17.0.1:51573"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:41:02.702211621Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a12488fa29a0a2ac9dc31008b23b3fd5fddb23517be9a85eff75602636737a77",
+			"MachineKey": "mkey:b8d0218718b272befb0110cfaec1a563a6a4f0fd07ecd598659b226b8d8cb402",
+			"Peers": [{
+				"ID":         3018051913499631,
+				"StableID":   "nAnEm97tZQ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d05ce18e13a64ffda8fca1c50325080fa11661d2e1fc465397c9a8eac81427c",
+				"DiscoKey":   "discokey:fd7fe7bc52c622270457df39cb4d3ad5b51f5d3512a328dd1664b97f570c8253",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60789", "10.65.0.27:60789", "172.17.0.1:60789"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:41:03.221947156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6583927606589653,
+				"StableID":   "nzuczbcsQt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3e1f44181d36af260df80afb3544a24a970c0ce972707fea54e0b61b831c24d",
+				"DiscoKey":   "discokey:156e10a77179d6667aa6079797761242eb5daf12fea6b3c79d11e2030b718f13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:51019", "10.65.0.27:51019", "172.17.0.1:51019"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:41:03.741234927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         707181887821496,
+				"StableID":   "n9MBoCUHX611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06eeefa8c5caf0ae5c0f572875e09e3f7187bcfafd90a3e1fede05df3ea2760b",
+				"DiscoKey":   "discokey:692e23216ee6e4e86fbb7d69e8e920fb1f09251468e462eea5026fe607c99904",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53279", "10.65.0.27:53279", "172.17.0.1:53279"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:41:04.29906102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3628507124416184,
+				"StableID":   "n174MJjMLV11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce607c883d316f42ef2adf8915cd619beb7221bb5fd19cd3d3f21a864ab1d23b",
+				"DiscoKey":   "discokey:cc1a1e939656c7f0f786cd5411bdffca34ecaa99e3b66d73693730fa7e164c49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:41976", "10.65.0.27:41976", "172.17.0.1:41976"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:41:04.839160561Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2551959797582664,
+				"StableID":   "nX88Y5fnvL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1502c64212273a63afbaaae2eb6ff027184d9e333780e1d11055aa95ed160371",
+				"KeyExpiry":  "2026-10-26T10:41:05Z",
+				"DiscoKey":   "discokey:10e2d63dbd00b78424ac7f57554732df968c753d6530a2c45eda1ef8509e9336",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:42712", "10.65.0.27:42712", "172.17.0.1:42712"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:41:05.409455646Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6031238229336382,
+				"StableID":   "n5GeKGQZ6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:caef4fd2cbab93af4d05532e379f48dc5103b137a4be0778d7f0b73b30a2e24e",
+				"KeyExpiry":  "2026-10-26T10:41:05Z",
+				"DiscoKey":   "discokey:af2ea202887cf7e767d842e42a0a049bfe7dafe6aa6e06edb938af2140bc432c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53268", "10.65.0.27:53268", "172.17.0.1:53268"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:41:05.931891568Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1599579790711358,
+				"StableID":   "nXTtbRFTVD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4af5dcd590b774ea51f84f4ee57f02eb23a6e5f55fa6afc9ede7632915c6910",
+				"KeyExpiry":  "2026-10-26T10:41:06Z",
+				"DiscoKey":   "discokey:7f6e4bee7ef721fbcf65578ea0452b06e3da4259168931280f9c5dce13df9737",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34895", "10.65.0.27:34895", "172.17.0.1:34895"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:41:06.474546058Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6030384571078947": {
+				"ID":          6030384571078947,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2551959797582664,
+				"StableID":   "nX88Y5fnvL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1502c64212273a63afbaaae2eb6ff027184d9e333780e1d11055aa95ed160371",
+				"KeyExpiry":  "2026-10-26T10:41:05Z",
+				"DiscoKey":   "discokey:10e2d63dbd00b78424ac7f57554732df968c753d6530a2c45eda1ef8509e9336",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:42712", "10.65.0.27:42712", "172.17.0.1:42712"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:41:05.409455646Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1502c64212273a63afbaaae2eb6ff027184d9e333780e1d11055aa95ed160371",
+			"MachineKey": "mkey:4dfd1b331f2f746398be009af1979e8f63800ff3ac9495c091d43fa41f03205a",
+			"Peers": [{
+				"ID":         6030384571078947,
+				"StableID":   "nELwTfyA6p11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a12488fa29a0a2ac9dc31008b23b3fd5fddb23517be9a85eff75602636737a77",
+				"DiscoKey":   "discokey:0c7e627891e31b0a8f499e3e30de795bd80afe794a896557e2f0dc269e34a723",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:51573", "10.65.0.27:51573", "172.17.0.1:51573"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:41:02.702211621Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3018051913499631,
+				"StableID":   "nAnEm97tZQ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d05ce18e13a64ffda8fca1c50325080fa11661d2e1fc465397c9a8eac81427c",
+				"DiscoKey":   "discokey:fd7fe7bc52c622270457df39cb4d3ad5b51f5d3512a328dd1664b97f570c8253",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60789", "10.65.0.27:60789", "172.17.0.1:60789"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:41:03.221947156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6583927606589653,
+				"StableID":   "nzuczbcsQt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3e1f44181d36af260df80afb3544a24a970c0ce972707fea54e0b61b831c24d",
+				"DiscoKey":   "discokey:156e10a77179d6667aa6079797761242eb5daf12fea6b3c79d11e2030b718f13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:51019", "10.65.0.27:51019", "172.17.0.1:51019"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:41:03.741234927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         707181887821496,
+				"StableID":   "n9MBoCUHX611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06eeefa8c5caf0ae5c0f572875e09e3f7187bcfafd90a3e1fede05df3ea2760b",
+				"DiscoKey":   "discokey:692e23216ee6e4e86fbb7d69e8e920fb1f09251468e462eea5026fe607c99904",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53279", "10.65.0.27:53279", "172.17.0.1:53279"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:41:04.29906102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3628507124416184,
+				"StableID":   "n174MJjMLV11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce607c883d316f42ef2adf8915cd619beb7221bb5fd19cd3d3f21a864ab1d23b",
+				"DiscoKey":   "discokey:cc1a1e939656c7f0f786cd5411bdffca34ecaa99e3b66d73693730fa7e164c49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:41976", "10.65.0.27:41976", "172.17.0.1:41976"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:41:04.839160561Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6031238229336382,
+				"StableID":   "n5GeKGQZ6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:caef4fd2cbab93af4d05532e379f48dc5103b137a4be0778d7f0b73b30a2e24e",
+				"KeyExpiry":  "2026-10-26T10:41:05Z",
+				"DiscoKey":   "discokey:af2ea202887cf7e767d842e42a0a049bfe7dafe6aa6e06edb938af2140bc432c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53268", "10.65.0.27:53268", "172.17.0.1:53268"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:41:05.931891568Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1599579790711358,
+				"StableID":   "nXTtbRFTVD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4af5dcd590b774ea51f84f4ee57f02eb23a6e5f55fa6afc9ede7632915c6910",
+				"KeyExpiry":  "2026-10-26T10:41:06Z",
+				"DiscoKey":   "discokey:7f6e4bee7ef721fbcf65578ea0452b06e3da4259168931280f9c5dce13df9737",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34895", "10.65.0.27:34895", "172.17.0.1:34895"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:41:06.474546058Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         707181887821496,
+				"StableID":   "n9MBoCUHX611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       707181887821496,
+				"Key":        "nodekey:06eeefa8c5caf0ae5c0f572875e09e3f7187bcfafd90a3e1fede05df3ea2760b",
+				"DiscoKey":   "discokey:692e23216ee6e4e86fbb7d69e8e920fb1f09251468e462eea5026fe607c99904",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53279", "10.65.0.27:53279", "172.17.0.1:53279"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:41:04.29906102Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:06eeefa8c5caf0ae5c0f572875e09e3f7187bcfafd90a3e1fede05df3ea2760b",
+			"MachineKey": "mkey:c626ce77fdd143cddf0b560f5c9a5d4a6507c3c24801b19400203782c6178c69",
+			"Peers": [{
+				"ID":         6030384571078947,
+				"StableID":   "nELwTfyA6p11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a12488fa29a0a2ac9dc31008b23b3fd5fddb23517be9a85eff75602636737a77",
+				"DiscoKey":   "discokey:0c7e627891e31b0a8f499e3e30de795bd80afe794a896557e2f0dc269e34a723",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:51573", "10.65.0.27:51573", "172.17.0.1:51573"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:41:02.702211621Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3018051913499631,
+				"StableID":   "nAnEm97tZQ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d05ce18e13a64ffda8fca1c50325080fa11661d2e1fc465397c9a8eac81427c",
+				"DiscoKey":   "discokey:fd7fe7bc52c622270457df39cb4d3ad5b51f5d3512a328dd1664b97f570c8253",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60789", "10.65.0.27:60789", "172.17.0.1:60789"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:41:03.221947156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6583927606589653,
+				"StableID":   "nzuczbcsQt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3e1f44181d36af260df80afb3544a24a970c0ce972707fea54e0b61b831c24d",
+				"DiscoKey":   "discokey:156e10a77179d6667aa6079797761242eb5daf12fea6b3c79d11e2030b718f13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:51019", "10.65.0.27:51019", "172.17.0.1:51019"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:41:03.741234927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3628507124416184,
+				"StableID":   "n174MJjMLV11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce607c883d316f42ef2adf8915cd619beb7221bb5fd19cd3d3f21a864ab1d23b",
+				"DiscoKey":   "discokey:cc1a1e939656c7f0f786cd5411bdffca34ecaa99e3b66d73693730fa7e164c49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:41976", "10.65.0.27:41976", "172.17.0.1:41976"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:41:04.839160561Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2551959797582664,
+				"StableID":   "nX88Y5fnvL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1502c64212273a63afbaaae2eb6ff027184d9e333780e1d11055aa95ed160371",
+				"KeyExpiry":  "2026-10-26T10:41:05Z",
+				"DiscoKey":   "discokey:10e2d63dbd00b78424ac7f57554732df968c753d6530a2c45eda1ef8509e9336",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:42712", "10.65.0.27:42712", "172.17.0.1:42712"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:41:05.409455646Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6031238229336382,
+				"StableID":   "n5GeKGQZ6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:caef4fd2cbab93af4d05532e379f48dc5103b137a4be0778d7f0b73b30a2e24e",
+				"KeyExpiry":  "2026-10-26T10:41:05Z",
+				"DiscoKey":   "discokey:af2ea202887cf7e767d842e42a0a049bfe7dafe6aa6e06edb938af2140bc432c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53268", "10.65.0.27:53268", "172.17.0.1:53268"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:41:05.931891568Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1599579790711358,
+				"StableID":   "nXTtbRFTVD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4af5dcd590b774ea51f84f4ee57f02eb23a6e5f55fa6afc9ede7632915c6910",
+				"KeyExpiry":  "2026-10-26T10:41:06Z",
+				"DiscoKey":   "discokey:7f6e4bee7ef721fbcf65578ea0452b06e3da4259168931280f9c5dce13df9737",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34895", "10.65.0.27:34895", "172.17.0.1:34895"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:41:06.474546058Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "707181887821496": {
+				"ID":          707181887821496,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3018051913499631,
+				"StableID":   "nAnEm97tZQ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       3018051913499631,
+				"Key":        "nodekey:5d05ce18e13a64ffda8fca1c50325080fa11661d2e1fc465397c9a8eac81427c",
+				"DiscoKey":   "discokey:fd7fe7bc52c622270457df39cb4d3ad5b51f5d3512a328dd1664b97f570c8253",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60789", "10.65.0.27:60789", "172.17.0.1:60789"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:41:03.221947156Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5d05ce18e13a64ffda8fca1c50325080fa11661d2e1fc465397c9a8eac81427c",
+			"MachineKey": "mkey:1e7ebbd1997728b7170d8469ec6c2b0e729193be1effa248728d8660e1adaa54",
+			"Peers": [{
+				"ID":         6030384571078947,
+				"StableID":   "nELwTfyA6p11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a12488fa29a0a2ac9dc31008b23b3fd5fddb23517be9a85eff75602636737a77",
+				"DiscoKey":   "discokey:0c7e627891e31b0a8f499e3e30de795bd80afe794a896557e2f0dc269e34a723",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:51573", "10.65.0.27:51573", "172.17.0.1:51573"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:41:02.702211621Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6583927606589653,
+				"StableID":   "nzuczbcsQt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3e1f44181d36af260df80afb3544a24a970c0ce972707fea54e0b61b831c24d",
+				"DiscoKey":   "discokey:156e10a77179d6667aa6079797761242eb5daf12fea6b3c79d11e2030b718f13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:51019", "10.65.0.27:51019", "172.17.0.1:51019"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:41:03.741234927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         707181887821496,
+				"StableID":   "n9MBoCUHX611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06eeefa8c5caf0ae5c0f572875e09e3f7187bcfafd90a3e1fede05df3ea2760b",
+				"DiscoKey":   "discokey:692e23216ee6e4e86fbb7d69e8e920fb1f09251468e462eea5026fe607c99904",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53279", "10.65.0.27:53279", "172.17.0.1:53279"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:41:04.29906102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3628507124416184,
+				"StableID":   "n174MJjMLV11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce607c883d316f42ef2adf8915cd619beb7221bb5fd19cd3d3f21a864ab1d23b",
+				"DiscoKey":   "discokey:cc1a1e939656c7f0f786cd5411bdffca34ecaa99e3b66d73693730fa7e164c49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:41976", "10.65.0.27:41976", "172.17.0.1:41976"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:41:04.839160561Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2551959797582664,
+				"StableID":   "nX88Y5fnvL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1502c64212273a63afbaaae2eb6ff027184d9e333780e1d11055aa95ed160371",
+				"KeyExpiry":  "2026-10-26T10:41:05Z",
+				"DiscoKey":   "discokey:10e2d63dbd00b78424ac7f57554732df968c753d6530a2c45eda1ef8509e9336",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:42712", "10.65.0.27:42712", "172.17.0.1:42712"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:41:05.409455646Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6031238229336382,
+				"StableID":   "n5GeKGQZ6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:caef4fd2cbab93af4d05532e379f48dc5103b137a4be0778d7f0b73b30a2e24e",
+				"KeyExpiry":  "2026-10-26T10:41:05Z",
+				"DiscoKey":   "discokey:af2ea202887cf7e767d842e42a0a049bfe7dafe6aa6e06edb938af2140bc432c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53268", "10.65.0.27:53268", "172.17.0.1:53268"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:41:05.931891568Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1599579790711358,
+				"StableID":   "nXTtbRFTVD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4af5dcd590b774ea51f84f4ee57f02eb23a6e5f55fa6afc9ede7632915c6910",
+				"KeyExpiry":  "2026-10-26T10:41:06Z",
+				"DiscoKey":   "discokey:7f6e4bee7ef721fbcf65578ea0452b06e3da4259168931280f9c5dce13df9737",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34895", "10.65.0.27:34895", "172.17.0.1:34895"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:41:06.474546058Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3018051913499631": {
+				"ID":          3018051913499631,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6031238229336382,
+				"StableID":   "n5GeKGQZ6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:caef4fd2cbab93af4d05532e379f48dc5103b137a4be0778d7f0b73b30a2e24e",
+				"KeyExpiry":  "2026-10-26T10:41:05Z",
+				"DiscoKey":   "discokey:af2ea202887cf7e767d842e42a0a049bfe7dafe6aa6e06edb938af2140bc432c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53268", "10.65.0.27:53268", "172.17.0.1:53268"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:41:05.931891568Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:caef4fd2cbab93af4d05532e379f48dc5103b137a4be0778d7f0b73b30a2e24e",
+			"MachineKey": "mkey:6c0b04a40b7d16d5adfb7f362392612d095735e684c161840d1b58a6488aa354",
+			"Peers": [{
+				"ID":         6030384571078947,
+				"StableID":   "nELwTfyA6p11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a12488fa29a0a2ac9dc31008b23b3fd5fddb23517be9a85eff75602636737a77",
+				"DiscoKey":   "discokey:0c7e627891e31b0a8f499e3e30de795bd80afe794a896557e2f0dc269e34a723",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:51573", "10.65.0.27:51573", "172.17.0.1:51573"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:41:02.702211621Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3018051913499631,
+				"StableID":   "nAnEm97tZQ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d05ce18e13a64ffda8fca1c50325080fa11661d2e1fc465397c9a8eac81427c",
+				"DiscoKey":   "discokey:fd7fe7bc52c622270457df39cb4d3ad5b51f5d3512a328dd1664b97f570c8253",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60789", "10.65.0.27:60789", "172.17.0.1:60789"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:41:03.221947156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6583927606589653,
+				"StableID":   "nzuczbcsQt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3e1f44181d36af260df80afb3544a24a970c0ce972707fea54e0b61b831c24d",
+				"DiscoKey":   "discokey:156e10a77179d6667aa6079797761242eb5daf12fea6b3c79d11e2030b718f13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:51019", "10.65.0.27:51019", "172.17.0.1:51019"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:41:03.741234927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         707181887821496,
+				"StableID":   "n9MBoCUHX611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06eeefa8c5caf0ae5c0f572875e09e3f7187bcfafd90a3e1fede05df3ea2760b",
+				"DiscoKey":   "discokey:692e23216ee6e4e86fbb7d69e8e920fb1f09251468e462eea5026fe607c99904",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53279", "10.65.0.27:53279", "172.17.0.1:53279"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:41:04.29906102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3628507124416184,
+				"StableID":   "n174MJjMLV11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce607c883d316f42ef2adf8915cd619beb7221bb5fd19cd3d3f21a864ab1d23b",
+				"DiscoKey":   "discokey:cc1a1e939656c7f0f786cd5411bdffca34ecaa99e3b66d73693730fa7e164c49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:41976", "10.65.0.27:41976", "172.17.0.1:41976"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:41:04.839160561Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2551959797582664,
+				"StableID":   "nX88Y5fnvL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1502c64212273a63afbaaae2eb6ff027184d9e333780e1d11055aa95ed160371",
+				"KeyExpiry":  "2026-10-26T10:41:05Z",
+				"DiscoKey":   "discokey:10e2d63dbd00b78424ac7f57554732df968c753d6530a2c45eda1ef8509e9336",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:42712", "10.65.0.27:42712", "172.17.0.1:42712"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:41:05.409455646Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1599579790711358,
+				"StableID":   "nXTtbRFTVD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4af5dcd590b774ea51f84f4ee57f02eb23a6e5f55fa6afc9ede7632915c6910",
+				"KeyExpiry":  "2026-10-26T10:41:06Z",
+				"DiscoKey":   "discokey:7f6e4bee7ef721fbcf65578ea0452b06e3da4259168931280f9c5dce13df9737",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34895", "10.65.0.27:34895", "172.17.0.1:34895"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:41:06.474546058Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6583927606589653,
+				"StableID":   "nzuczbcsQt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       6583927606589653,
+				"Key":        "nodekey:e3e1f44181d36af260df80afb3544a24a970c0ce972707fea54e0b61b831c24d",
+				"DiscoKey":   "discokey:156e10a77179d6667aa6079797761242eb5daf12fea6b3c79d11e2030b718f13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:51019", "10.65.0.27:51019", "172.17.0.1:51019"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:41:03.741234927Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e3e1f44181d36af260df80afb3544a24a970c0ce972707fea54e0b61b831c24d",
+			"MachineKey": "mkey:273ed720ee09a65e494c6915e33e8c9cc6591f93e6c8de5c8f505c442a17925e",
+			"Peers": [{
+				"ID":         6030384571078947,
+				"StableID":   "nELwTfyA6p11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a12488fa29a0a2ac9dc31008b23b3fd5fddb23517be9a85eff75602636737a77",
+				"DiscoKey":   "discokey:0c7e627891e31b0a8f499e3e30de795bd80afe794a896557e2f0dc269e34a723",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:51573", "10.65.0.27:51573", "172.17.0.1:51573"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:41:02.702211621Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3018051913499631,
+				"StableID":   "nAnEm97tZQ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d05ce18e13a64ffda8fca1c50325080fa11661d2e1fc465397c9a8eac81427c",
+				"DiscoKey":   "discokey:fd7fe7bc52c622270457df39cb4d3ad5b51f5d3512a328dd1664b97f570c8253",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60789", "10.65.0.27:60789", "172.17.0.1:60789"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:41:03.221947156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         707181887821496,
+				"StableID":   "n9MBoCUHX611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06eeefa8c5caf0ae5c0f572875e09e3f7187bcfafd90a3e1fede05df3ea2760b",
+				"DiscoKey":   "discokey:692e23216ee6e4e86fbb7d69e8e920fb1f09251468e462eea5026fe607c99904",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53279", "10.65.0.27:53279", "172.17.0.1:53279"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:41:04.29906102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3628507124416184,
+				"StableID":   "n174MJjMLV11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce607c883d316f42ef2adf8915cd619beb7221bb5fd19cd3d3f21a864ab1d23b",
+				"DiscoKey":   "discokey:cc1a1e939656c7f0f786cd5411bdffca34ecaa99e3b66d73693730fa7e164c49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:41976", "10.65.0.27:41976", "172.17.0.1:41976"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:41:04.839160561Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2551959797582664,
+				"StableID":   "nX88Y5fnvL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1502c64212273a63afbaaae2eb6ff027184d9e333780e1d11055aa95ed160371",
+				"KeyExpiry":  "2026-10-26T10:41:05Z",
+				"DiscoKey":   "discokey:10e2d63dbd00b78424ac7f57554732df968c753d6530a2c45eda1ef8509e9336",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:42712", "10.65.0.27:42712", "172.17.0.1:42712"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:41:05.409455646Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6031238229336382,
+				"StableID":   "n5GeKGQZ6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:caef4fd2cbab93af4d05532e379f48dc5103b137a4be0778d7f0b73b30a2e24e",
+				"KeyExpiry":  "2026-10-26T10:41:05Z",
+				"DiscoKey":   "discokey:af2ea202887cf7e767d842e42a0a049bfe7dafe6aa6e06edb938af2140bc432c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53268", "10.65.0.27:53268", "172.17.0.1:53268"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:41:05.931891568Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1599579790711358,
+				"StableID":   "nXTtbRFTVD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4af5dcd590b774ea51f84f4ee57f02eb23a6e5f55fa6afc9ede7632915c6910",
+				"KeyExpiry":  "2026-10-26T10:41:06Z",
+				"DiscoKey":   "discokey:7f6e4bee7ef721fbcf65578ea0452b06e3da4259168931280f9c5dce13df9737",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:34895", "10.65.0.27:34895", "172.17.0.1:34895"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:41:06.474546058Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6583927606589653": {
+				"ID":          6583927606589653,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-accept-fail-user-src-cidr-dst.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-accept-fail-user-src-cidr-dst.hujson
@@ -1,0 +1,8841 @@
+// policytest-accept-fail-user-src-cidr-dst
+//
+// tests block accept-fail: user src to cidr dst, no covering rule
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:41:28Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-accept-fail-user-src-cidr-dst",
+	"description":    "tests block accept-fail: user src to cidr dst, no covering rule",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:41:28.174858334Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                           \n  \n                                                                      \n                          \n{\n\t\"id\":          \"policytest-accept-fail-user-src-cidr-dst\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block accept-fail: user src to cidr dst, no covering rule\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"thor@example.org\"], \"dst\": [\"tag:server:22\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"accept\": [\"10.0.0.0/8:22\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-accept-fail-user-src-cidr-dst.hujson",
+		"full_policy": {"acls": [{
+			"action": "accept",
+			"dst":    ["tag:server:22"],
+			"src":    ["thor@example.org"]
+		}], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [{"accept": ["10.0.0.0/8:22"], "src": "thor@example.org"}]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4774901373693190,
+				"StableID":   "nsHgWcZZHe11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       4774901373693190,
+				"Key":        "nodekey:8cb378dcdd3755a0d4ae49124e0b0bfe7a60a774a35614173b73a308fcc0d428",
+				"DiscoKey":   "discokey:c25053eb1334fb8282271b328e2b10ee084dfd1d143e3883a9250d158ff4ca4f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:43330", "10.65.0.27:43330", "172.17.0.1:43330"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:41:31.822887591Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8cb378dcdd3755a0d4ae49124e0b0bfe7a60a774a35614173b73a308fcc0d428",
+			"MachineKey": "mkey:5ea6af631c68c238f4b49981d2c46754dd685750424f0b854c9e1a66fe0c3a7c",
+			"Peers": [{
+				"ID":         1164851287676903,
+				"StableID":   "n6vsSkfZ6A11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9a102d548cd95bcab5c9240466f98fff2c0f15e85fd942757c6c23440318830",
+				"DiscoKey":   "discokey:5422f9bf5c8f5e0ca7ed4ba1b169f927ea37a33e6bed803849ca5ecfcdab1d19",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:36724", "10.65.0.27:36724", "172.17.0.1:36724"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:41:29.663738156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4581455073616816,
+				"StableID":   "nKUBQF4xmc11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:279d08d331623930fd54516b7070af939bd4508393113e6925a6e9cde5d89366",
+				"DiscoKey":   "discokey:af0f5d540ba81838e3e55206a76bf8c8ceabe85ccc4d4b4de056abed6c0efd22",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:53679", "10.65.0.27:53679", "172.17.0.1:53679"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:41:30.224583256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8414384166007848,
+				"StableID":   "nq5d32cth821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55d723b81a40b5a04cdb6f3ea539fea8c244c7b29f27e2fc844305f0d2021b4c",
+				"DiscoKey":   "discokey:d751795579eae1c3f3a13b55d95956e5e92f2871b867de5fcc0b795928fa6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37239", "10.65.0.27:37239", "172.17.0.1:37239"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:41:30.725555302Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5880529504649908,
+				"StableID":   "nF68QEYJvn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:761b3d6016c76ff48631554e5ee9ada10999646d887640ecc1885f4a2409f745",
+				"DiscoKey":   "discokey:cd2ec87b615a1a80ddfd6509f29d30ef69e5a1de58660fd37cd60d3063b43c15",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59011", "10.65.0.27:59011", "172.17.0.1:59011"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:41:31.267544095Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2076698043972355,
+				"StableID":   "nYdzpVLYDH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1946e977609333d4c16166ba0691e1f7eb14a518f8bd5976660919d7b75c569",
+				"KeyExpiry":  "2026-10-26T10:41:32Z",
+				"DiscoKey":   "discokey:a1ce915620701d095a0295d7aa92c83eefe3d411f60a54a21884caddf42f794a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:47630", "10.65.0.27:47630", "172.17.0.1:47630"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:41:32.357373593Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8526217598177442,
+				"StableID":   "nXqSV9HYa921CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:72bf4397b09cb51a207b6c82248aeb269962a8bb9b902fffd0a726ad02ffb740",
+				"KeyExpiry":  "2026-10-26T10:41:32Z",
+				"DiscoKey":   "discokey:9cf45968469ef62c0e9d376a460499cb5a6f0b84cd024307cd3156a9194d9f47",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53951", "10.65.0.27:53951", "172.17.0.1:53951"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:41:32.885083862Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8654059984069183,
+				"StableID":   "nWceMuUSaA21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c7cbe03e07a1c7031b86080bc341380681b0f7093870793b0a559512bc7ec28",
+				"KeyExpiry":  "2026-10-26T10:41:33Z",
+				"DiscoKey":   "discokey:00883b9ddacb614b2b0ab83c11238be8eb1e94b397cc3313a3e2c30e0baf5c4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52924", "10.65.0.27:52924", "172.17.0.1:52924"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:41:33.414079737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4774901373693190": {
+				"ID":          4774901373693190,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8654059984069183,
+				"StableID":   "nWceMuUSaA21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c7cbe03e07a1c7031b86080bc341380681b0f7093870793b0a559512bc7ec28",
+				"KeyExpiry":  "2026-10-26T10:41:33Z",
+				"DiscoKey":   "discokey:00883b9ddacb614b2b0ab83c11238be8eb1e94b397cc3313a3e2c30e0baf5c4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52924", "10.65.0.27:52924", "172.17.0.1:52924"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:41:33.414079737Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8c7cbe03e07a1c7031b86080bc341380681b0f7093870793b0a559512bc7ec28",
+			"MachineKey": "mkey:746ac4765f2615f76792c485a57f898f426188254790b33d04a3f4171b154b43",
+			"Peers": [{
+				"ID":         1164851287676903,
+				"StableID":   "n6vsSkfZ6A11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9a102d548cd95bcab5c9240466f98fff2c0f15e85fd942757c6c23440318830",
+				"DiscoKey":   "discokey:5422f9bf5c8f5e0ca7ed4ba1b169f927ea37a33e6bed803849ca5ecfcdab1d19",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:36724", "10.65.0.27:36724", "172.17.0.1:36724"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:41:29.663738156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4581455073616816,
+				"StableID":   "nKUBQF4xmc11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:279d08d331623930fd54516b7070af939bd4508393113e6925a6e9cde5d89366",
+				"DiscoKey":   "discokey:af0f5d540ba81838e3e55206a76bf8c8ceabe85ccc4d4b4de056abed6c0efd22",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:53679", "10.65.0.27:53679", "172.17.0.1:53679"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:41:30.224583256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8414384166007848,
+				"StableID":   "nq5d32cth821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55d723b81a40b5a04cdb6f3ea539fea8c244c7b29f27e2fc844305f0d2021b4c",
+				"DiscoKey":   "discokey:d751795579eae1c3f3a13b55d95956e5e92f2871b867de5fcc0b795928fa6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37239", "10.65.0.27:37239", "172.17.0.1:37239"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:41:30.725555302Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5880529504649908,
+				"StableID":   "nF68QEYJvn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:761b3d6016c76ff48631554e5ee9ada10999646d887640ecc1885f4a2409f745",
+				"DiscoKey":   "discokey:cd2ec87b615a1a80ddfd6509f29d30ef69e5a1de58660fd37cd60d3063b43c15",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59011", "10.65.0.27:59011", "172.17.0.1:59011"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:41:31.267544095Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4774901373693190,
+				"StableID":   "nsHgWcZZHe11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8cb378dcdd3755a0d4ae49124e0b0bfe7a60a774a35614173b73a308fcc0d428",
+				"DiscoKey":   "discokey:c25053eb1334fb8282271b328e2b10ee084dfd1d143e3883a9250d158ff4ca4f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:43330", "10.65.0.27:43330", "172.17.0.1:43330"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:41:31.822887591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2076698043972355,
+				"StableID":   "nYdzpVLYDH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1946e977609333d4c16166ba0691e1f7eb14a518f8bd5976660919d7b75c569",
+				"KeyExpiry":  "2026-10-26T10:41:32Z",
+				"DiscoKey":   "discokey:a1ce915620701d095a0295d7aa92c83eefe3d411f60a54a21884caddf42f794a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:47630", "10.65.0.27:47630", "172.17.0.1:47630"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:41:32.357373593Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8526217598177442,
+				"StableID":   "nXqSV9HYa921CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:72bf4397b09cb51a207b6c82248aeb269962a8bb9b902fffd0a726ad02ffb740",
+				"KeyExpiry":  "2026-10-26T10:41:32Z",
+				"DiscoKey":   "discokey:9cf45968469ef62c0e9d376a460499cb5a6f0b84cd024307cd3156a9194d9f47",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53951", "10.65.0.27:53951", "172.17.0.1:53951"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:41:32.885083862Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1164851287676903,
+				"StableID":   "n6vsSkfZ6A11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1164851287676903,
+				"Key":        "nodekey:b9a102d548cd95bcab5c9240466f98fff2c0f15e85fd942757c6c23440318830",
+				"DiscoKey":   "discokey:5422f9bf5c8f5e0ca7ed4ba1b169f927ea37a33e6bed803849ca5ecfcdab1d19",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:36724", "10.65.0.27:36724", "172.17.0.1:36724"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:41:29.663738156Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b9a102d548cd95bcab5c9240466f98fff2c0f15e85fd942757c6c23440318830",
+			"MachineKey": "mkey:2f6269c7156f143a47da489beb7d5fab78f85c116dbc1353778a53f9807cd66d",
+			"Peers": [{
+				"ID":         4581455073616816,
+				"StableID":   "nKUBQF4xmc11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:279d08d331623930fd54516b7070af939bd4508393113e6925a6e9cde5d89366",
+				"DiscoKey":   "discokey:af0f5d540ba81838e3e55206a76bf8c8ceabe85ccc4d4b4de056abed6c0efd22",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:53679", "10.65.0.27:53679", "172.17.0.1:53679"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:41:30.224583256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8414384166007848,
+				"StableID":   "nq5d32cth821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55d723b81a40b5a04cdb6f3ea539fea8c244c7b29f27e2fc844305f0d2021b4c",
+				"DiscoKey":   "discokey:d751795579eae1c3f3a13b55d95956e5e92f2871b867de5fcc0b795928fa6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37239", "10.65.0.27:37239", "172.17.0.1:37239"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:41:30.725555302Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5880529504649908,
+				"StableID":   "nF68QEYJvn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:761b3d6016c76ff48631554e5ee9ada10999646d887640ecc1885f4a2409f745",
+				"DiscoKey":   "discokey:cd2ec87b615a1a80ddfd6509f29d30ef69e5a1de58660fd37cd60d3063b43c15",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59011", "10.65.0.27:59011", "172.17.0.1:59011"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:41:31.267544095Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4774901373693190,
+				"StableID":   "nsHgWcZZHe11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8cb378dcdd3755a0d4ae49124e0b0bfe7a60a774a35614173b73a308fcc0d428",
+				"DiscoKey":   "discokey:c25053eb1334fb8282271b328e2b10ee084dfd1d143e3883a9250d158ff4ca4f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:43330", "10.65.0.27:43330", "172.17.0.1:43330"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:41:31.822887591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2076698043972355,
+				"StableID":   "nYdzpVLYDH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1946e977609333d4c16166ba0691e1f7eb14a518f8bd5976660919d7b75c569",
+				"KeyExpiry":  "2026-10-26T10:41:32Z",
+				"DiscoKey":   "discokey:a1ce915620701d095a0295d7aa92c83eefe3d411f60a54a21884caddf42f794a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:47630", "10.65.0.27:47630", "172.17.0.1:47630"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:41:32.357373593Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8526217598177442,
+				"StableID":   "nXqSV9HYa921CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:72bf4397b09cb51a207b6c82248aeb269962a8bb9b902fffd0a726ad02ffb740",
+				"KeyExpiry":  "2026-10-26T10:41:32Z",
+				"DiscoKey":   "discokey:9cf45968469ef62c0e9d376a460499cb5a6f0b84cd024307cd3156a9194d9f47",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53951", "10.65.0.27:53951", "172.17.0.1:53951"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:41:32.885083862Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8654059984069183,
+				"StableID":   "nWceMuUSaA21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c7cbe03e07a1c7031b86080bc341380681b0f7093870793b0a559512bc7ec28",
+				"KeyExpiry":  "2026-10-26T10:41:33Z",
+				"DiscoKey":   "discokey:00883b9ddacb614b2b0ab83c11238be8eb1e94b397cc3313a3e2c30e0baf5c4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52924", "10.65.0.27:52924", "172.17.0.1:52924"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:41:33.414079737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1164851287676903": {
+				"ID":          1164851287676903,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2076698043972355,
+				"StableID":   "nYdzpVLYDH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1946e977609333d4c16166ba0691e1f7eb14a518f8bd5976660919d7b75c569",
+				"KeyExpiry":  "2026-10-26T10:41:32Z",
+				"DiscoKey":   "discokey:a1ce915620701d095a0295d7aa92c83eefe3d411f60a54a21884caddf42f794a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:47630", "10.65.0.27:47630", "172.17.0.1:47630"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:41:32.357373593Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b1946e977609333d4c16166ba0691e1f7eb14a518f8bd5976660919d7b75c569",
+			"MachineKey": "mkey:4cd429f72d20c787f290a1703500007c7a03b1af7a3503a9f5dd1adde8806762",
+			"Peers": [{
+				"ID":         1164851287676903,
+				"StableID":   "n6vsSkfZ6A11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9a102d548cd95bcab5c9240466f98fff2c0f15e85fd942757c6c23440318830",
+				"DiscoKey":   "discokey:5422f9bf5c8f5e0ca7ed4ba1b169f927ea37a33e6bed803849ca5ecfcdab1d19",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:36724", "10.65.0.27:36724", "172.17.0.1:36724"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:41:29.663738156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4581455073616816,
+				"StableID":   "nKUBQF4xmc11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:279d08d331623930fd54516b7070af939bd4508393113e6925a6e9cde5d89366",
+				"DiscoKey":   "discokey:af0f5d540ba81838e3e55206a76bf8c8ceabe85ccc4d4b4de056abed6c0efd22",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:53679", "10.65.0.27:53679", "172.17.0.1:53679"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:41:30.224583256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8414384166007848,
+				"StableID":   "nq5d32cth821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55d723b81a40b5a04cdb6f3ea539fea8c244c7b29f27e2fc844305f0d2021b4c",
+				"DiscoKey":   "discokey:d751795579eae1c3f3a13b55d95956e5e92f2871b867de5fcc0b795928fa6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37239", "10.65.0.27:37239", "172.17.0.1:37239"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:41:30.725555302Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5880529504649908,
+				"StableID":   "nF68QEYJvn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:761b3d6016c76ff48631554e5ee9ada10999646d887640ecc1885f4a2409f745",
+				"DiscoKey":   "discokey:cd2ec87b615a1a80ddfd6509f29d30ef69e5a1de58660fd37cd60d3063b43c15",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59011", "10.65.0.27:59011", "172.17.0.1:59011"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:41:31.267544095Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4774901373693190,
+				"StableID":   "nsHgWcZZHe11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8cb378dcdd3755a0d4ae49124e0b0bfe7a60a774a35614173b73a308fcc0d428",
+				"DiscoKey":   "discokey:c25053eb1334fb8282271b328e2b10ee084dfd1d143e3883a9250d158ff4ca4f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:43330", "10.65.0.27:43330", "172.17.0.1:43330"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:41:31.822887591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8526217598177442,
+				"StableID":   "nXqSV9HYa921CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:72bf4397b09cb51a207b6c82248aeb269962a8bb9b902fffd0a726ad02ffb740",
+				"KeyExpiry":  "2026-10-26T10:41:32Z",
+				"DiscoKey":   "discokey:9cf45968469ef62c0e9d376a460499cb5a6f0b84cd024307cd3156a9194d9f47",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53951", "10.65.0.27:53951", "172.17.0.1:53951"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:41:32.885083862Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8654059984069183,
+				"StableID":   "nWceMuUSaA21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c7cbe03e07a1c7031b86080bc341380681b0f7093870793b0a559512bc7ec28",
+				"KeyExpiry":  "2026-10-26T10:41:33Z",
+				"DiscoKey":   "discokey:00883b9ddacb614b2b0ab83c11238be8eb1e94b397cc3313a3e2c30e0baf5c4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52924", "10.65.0.27:52924", "172.17.0.1:52924"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:41:33.414079737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5880529504649908,
+				"StableID":   "nF68QEYJvn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       5880529504649908,
+				"Key":        "nodekey:761b3d6016c76ff48631554e5ee9ada10999646d887640ecc1885f4a2409f745",
+				"DiscoKey":   "discokey:cd2ec87b615a1a80ddfd6509f29d30ef69e5a1de58660fd37cd60d3063b43c15",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59011", "10.65.0.27:59011", "172.17.0.1:59011"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:41:31.267544095Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:761b3d6016c76ff48631554e5ee9ada10999646d887640ecc1885f4a2409f745",
+			"MachineKey": "mkey:39e026342e2dc659173727ff649aea2540fe4e1d2dcfb9fb5738681370aea323",
+			"Peers": [{
+				"ID":         1164851287676903,
+				"StableID":   "n6vsSkfZ6A11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9a102d548cd95bcab5c9240466f98fff2c0f15e85fd942757c6c23440318830",
+				"DiscoKey":   "discokey:5422f9bf5c8f5e0ca7ed4ba1b169f927ea37a33e6bed803849ca5ecfcdab1d19",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:36724", "10.65.0.27:36724", "172.17.0.1:36724"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:41:29.663738156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4581455073616816,
+				"StableID":   "nKUBQF4xmc11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:279d08d331623930fd54516b7070af939bd4508393113e6925a6e9cde5d89366",
+				"DiscoKey":   "discokey:af0f5d540ba81838e3e55206a76bf8c8ceabe85ccc4d4b4de056abed6c0efd22",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:53679", "10.65.0.27:53679", "172.17.0.1:53679"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:41:30.224583256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8414384166007848,
+				"StableID":   "nq5d32cth821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55d723b81a40b5a04cdb6f3ea539fea8c244c7b29f27e2fc844305f0d2021b4c",
+				"DiscoKey":   "discokey:d751795579eae1c3f3a13b55d95956e5e92f2871b867de5fcc0b795928fa6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37239", "10.65.0.27:37239", "172.17.0.1:37239"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:41:30.725555302Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4774901373693190,
+				"StableID":   "nsHgWcZZHe11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8cb378dcdd3755a0d4ae49124e0b0bfe7a60a774a35614173b73a308fcc0d428",
+				"DiscoKey":   "discokey:c25053eb1334fb8282271b328e2b10ee084dfd1d143e3883a9250d158ff4ca4f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:43330", "10.65.0.27:43330", "172.17.0.1:43330"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:41:31.822887591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2076698043972355,
+				"StableID":   "nYdzpVLYDH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1946e977609333d4c16166ba0691e1f7eb14a518f8bd5976660919d7b75c569",
+				"KeyExpiry":  "2026-10-26T10:41:32Z",
+				"DiscoKey":   "discokey:a1ce915620701d095a0295d7aa92c83eefe3d411f60a54a21884caddf42f794a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:47630", "10.65.0.27:47630", "172.17.0.1:47630"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:41:32.357373593Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8526217598177442,
+				"StableID":   "nXqSV9HYa921CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:72bf4397b09cb51a207b6c82248aeb269962a8bb9b902fffd0a726ad02ffb740",
+				"KeyExpiry":  "2026-10-26T10:41:32Z",
+				"DiscoKey":   "discokey:9cf45968469ef62c0e9d376a460499cb5a6f0b84cd024307cd3156a9194d9f47",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53951", "10.65.0.27:53951", "172.17.0.1:53951"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:41:32.885083862Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8654059984069183,
+				"StableID":   "nWceMuUSaA21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c7cbe03e07a1c7031b86080bc341380681b0f7093870793b0a559512bc7ec28",
+				"KeyExpiry":  "2026-10-26T10:41:33Z",
+				"DiscoKey":   "discokey:00883b9ddacb614b2b0ab83c11238be8eb1e94b397cc3313a3e2c30e0baf5c4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52924", "10.65.0.27:52924", "172.17.0.1:52924"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:41:33.414079737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5880529504649908": {
+				"ID":          5880529504649908,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4581455073616816,
+				"StableID":   "nKUBQF4xmc11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       4581455073616816,
+				"Key":        "nodekey:279d08d331623930fd54516b7070af939bd4508393113e6925a6e9cde5d89366",
+				"DiscoKey":   "discokey:af0f5d540ba81838e3e55206a76bf8c8ceabe85ccc4d4b4de056abed6c0efd22",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:53679", "10.65.0.27:53679", "172.17.0.1:53679"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:41:30.224583256Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:279d08d331623930fd54516b7070af939bd4508393113e6925a6e9cde5d89366",
+			"MachineKey": "mkey:9d381a3928eb315e96231b0dc7933131488fe14fd22e9ae548ad35b3eb15a668",
+			"Peers": [{
+				"ID":         1164851287676903,
+				"StableID":   "n6vsSkfZ6A11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9a102d548cd95bcab5c9240466f98fff2c0f15e85fd942757c6c23440318830",
+				"DiscoKey":   "discokey:5422f9bf5c8f5e0ca7ed4ba1b169f927ea37a33e6bed803849ca5ecfcdab1d19",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:36724", "10.65.0.27:36724", "172.17.0.1:36724"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:41:29.663738156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8414384166007848,
+				"StableID":   "nq5d32cth821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55d723b81a40b5a04cdb6f3ea539fea8c244c7b29f27e2fc844305f0d2021b4c",
+				"DiscoKey":   "discokey:d751795579eae1c3f3a13b55d95956e5e92f2871b867de5fcc0b795928fa6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37239", "10.65.0.27:37239", "172.17.0.1:37239"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:41:30.725555302Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5880529504649908,
+				"StableID":   "nF68QEYJvn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:761b3d6016c76ff48631554e5ee9ada10999646d887640ecc1885f4a2409f745",
+				"DiscoKey":   "discokey:cd2ec87b615a1a80ddfd6509f29d30ef69e5a1de58660fd37cd60d3063b43c15",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59011", "10.65.0.27:59011", "172.17.0.1:59011"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:41:31.267544095Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4774901373693190,
+				"StableID":   "nsHgWcZZHe11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8cb378dcdd3755a0d4ae49124e0b0bfe7a60a774a35614173b73a308fcc0d428",
+				"DiscoKey":   "discokey:c25053eb1334fb8282271b328e2b10ee084dfd1d143e3883a9250d158ff4ca4f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:43330", "10.65.0.27:43330", "172.17.0.1:43330"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:41:31.822887591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2076698043972355,
+				"StableID":   "nYdzpVLYDH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1946e977609333d4c16166ba0691e1f7eb14a518f8bd5976660919d7b75c569",
+				"KeyExpiry":  "2026-10-26T10:41:32Z",
+				"DiscoKey":   "discokey:a1ce915620701d095a0295d7aa92c83eefe3d411f60a54a21884caddf42f794a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:47630", "10.65.0.27:47630", "172.17.0.1:47630"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:41:32.357373593Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8526217598177442,
+				"StableID":   "nXqSV9HYa921CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:72bf4397b09cb51a207b6c82248aeb269962a8bb9b902fffd0a726ad02ffb740",
+				"KeyExpiry":  "2026-10-26T10:41:32Z",
+				"DiscoKey":   "discokey:9cf45968469ef62c0e9d376a460499cb5a6f0b84cd024307cd3156a9194d9f47",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53951", "10.65.0.27:53951", "172.17.0.1:53951"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:41:32.885083862Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8654059984069183,
+				"StableID":   "nWceMuUSaA21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c7cbe03e07a1c7031b86080bc341380681b0f7093870793b0a559512bc7ec28",
+				"KeyExpiry":  "2026-10-26T10:41:33Z",
+				"DiscoKey":   "discokey:00883b9ddacb614b2b0ab83c11238be8eb1e94b397cc3313a3e2c30e0baf5c4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52924", "10.65.0.27:52924", "172.17.0.1:52924"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:41:33.414079737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4581455073616816": {
+				"ID":          4581455073616816,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8526217598177442,
+				"StableID":   "nXqSV9HYa921CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:72bf4397b09cb51a207b6c82248aeb269962a8bb9b902fffd0a726ad02ffb740",
+				"KeyExpiry":  "2026-10-26T10:41:32Z",
+				"DiscoKey":   "discokey:9cf45968469ef62c0e9d376a460499cb5a6f0b84cd024307cd3156a9194d9f47",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53951", "10.65.0.27:53951", "172.17.0.1:53951"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:41:32.885083862Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:72bf4397b09cb51a207b6c82248aeb269962a8bb9b902fffd0a726ad02ffb740",
+			"MachineKey": "mkey:cc328d2661f9b1cdfd04fda69108dfa175bacf7173269956ccf4ba962824ae08",
+			"Peers": [{
+				"ID":         1164851287676903,
+				"StableID":   "n6vsSkfZ6A11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9a102d548cd95bcab5c9240466f98fff2c0f15e85fd942757c6c23440318830",
+				"DiscoKey":   "discokey:5422f9bf5c8f5e0ca7ed4ba1b169f927ea37a33e6bed803849ca5ecfcdab1d19",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:36724", "10.65.0.27:36724", "172.17.0.1:36724"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:41:29.663738156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4581455073616816,
+				"StableID":   "nKUBQF4xmc11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:279d08d331623930fd54516b7070af939bd4508393113e6925a6e9cde5d89366",
+				"DiscoKey":   "discokey:af0f5d540ba81838e3e55206a76bf8c8ceabe85ccc4d4b4de056abed6c0efd22",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:53679", "10.65.0.27:53679", "172.17.0.1:53679"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:41:30.224583256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8414384166007848,
+				"StableID":   "nq5d32cth821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55d723b81a40b5a04cdb6f3ea539fea8c244c7b29f27e2fc844305f0d2021b4c",
+				"DiscoKey":   "discokey:d751795579eae1c3f3a13b55d95956e5e92f2871b867de5fcc0b795928fa6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37239", "10.65.0.27:37239", "172.17.0.1:37239"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:41:30.725555302Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5880529504649908,
+				"StableID":   "nF68QEYJvn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:761b3d6016c76ff48631554e5ee9ada10999646d887640ecc1885f4a2409f745",
+				"DiscoKey":   "discokey:cd2ec87b615a1a80ddfd6509f29d30ef69e5a1de58660fd37cd60d3063b43c15",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59011", "10.65.0.27:59011", "172.17.0.1:59011"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:41:31.267544095Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4774901373693190,
+				"StableID":   "nsHgWcZZHe11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8cb378dcdd3755a0d4ae49124e0b0bfe7a60a774a35614173b73a308fcc0d428",
+				"DiscoKey":   "discokey:c25053eb1334fb8282271b328e2b10ee084dfd1d143e3883a9250d158ff4ca4f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:43330", "10.65.0.27:43330", "172.17.0.1:43330"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:41:31.822887591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2076698043972355,
+				"StableID":   "nYdzpVLYDH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1946e977609333d4c16166ba0691e1f7eb14a518f8bd5976660919d7b75c569",
+				"KeyExpiry":  "2026-10-26T10:41:32Z",
+				"DiscoKey":   "discokey:a1ce915620701d095a0295d7aa92c83eefe3d411f60a54a21884caddf42f794a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:47630", "10.65.0.27:47630", "172.17.0.1:47630"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:41:32.357373593Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8654059984069183,
+				"StableID":   "nWceMuUSaA21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c7cbe03e07a1c7031b86080bc341380681b0f7093870793b0a559512bc7ec28",
+				"KeyExpiry":  "2026-10-26T10:41:33Z",
+				"DiscoKey":   "discokey:00883b9ddacb614b2b0ab83c11238be8eb1e94b397cc3313a3e2c30e0baf5c4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52924", "10.65.0.27:52924", "172.17.0.1:52924"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:41:33.414079737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8414384166007848,
+				"StableID":   "nq5d32cth821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       8414384166007848,
+				"Key":        "nodekey:55d723b81a40b5a04cdb6f3ea539fea8c244c7b29f27e2fc844305f0d2021b4c",
+				"DiscoKey":   "discokey:d751795579eae1c3f3a13b55d95956e5e92f2871b867de5fcc0b795928fa6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37239", "10.65.0.27:37239", "172.17.0.1:37239"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:41:30.725555302Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:55d723b81a40b5a04cdb6f3ea539fea8c244c7b29f27e2fc844305f0d2021b4c",
+			"MachineKey": "mkey:adaadb68a779195acbe174fe5a57d0242e54d51897929607ab52332b80f38e14",
+			"Peers": [{
+				"ID":         1164851287676903,
+				"StableID":   "n6vsSkfZ6A11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9a102d548cd95bcab5c9240466f98fff2c0f15e85fd942757c6c23440318830",
+				"DiscoKey":   "discokey:5422f9bf5c8f5e0ca7ed4ba1b169f927ea37a33e6bed803849ca5ecfcdab1d19",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:36724", "10.65.0.27:36724", "172.17.0.1:36724"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:41:29.663738156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4581455073616816,
+				"StableID":   "nKUBQF4xmc11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:279d08d331623930fd54516b7070af939bd4508393113e6925a6e9cde5d89366",
+				"DiscoKey":   "discokey:af0f5d540ba81838e3e55206a76bf8c8ceabe85ccc4d4b4de056abed6c0efd22",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:53679", "10.65.0.27:53679", "172.17.0.1:53679"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:41:30.224583256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5880529504649908,
+				"StableID":   "nF68QEYJvn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:761b3d6016c76ff48631554e5ee9ada10999646d887640ecc1885f4a2409f745",
+				"DiscoKey":   "discokey:cd2ec87b615a1a80ddfd6509f29d30ef69e5a1de58660fd37cd60d3063b43c15",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59011", "10.65.0.27:59011", "172.17.0.1:59011"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:41:31.267544095Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4774901373693190,
+				"StableID":   "nsHgWcZZHe11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8cb378dcdd3755a0d4ae49124e0b0bfe7a60a774a35614173b73a308fcc0d428",
+				"DiscoKey":   "discokey:c25053eb1334fb8282271b328e2b10ee084dfd1d143e3883a9250d158ff4ca4f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:43330", "10.65.0.27:43330", "172.17.0.1:43330"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:41:31.822887591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2076698043972355,
+				"StableID":   "nYdzpVLYDH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1946e977609333d4c16166ba0691e1f7eb14a518f8bd5976660919d7b75c569",
+				"KeyExpiry":  "2026-10-26T10:41:32Z",
+				"DiscoKey":   "discokey:a1ce915620701d095a0295d7aa92c83eefe3d411f60a54a21884caddf42f794a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:47630", "10.65.0.27:47630", "172.17.0.1:47630"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:41:32.357373593Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8526217598177442,
+				"StableID":   "nXqSV9HYa921CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:72bf4397b09cb51a207b6c82248aeb269962a8bb9b902fffd0a726ad02ffb740",
+				"KeyExpiry":  "2026-10-26T10:41:32Z",
+				"DiscoKey":   "discokey:9cf45968469ef62c0e9d376a460499cb5a6f0b84cd024307cd3156a9194d9f47",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53951", "10.65.0.27:53951", "172.17.0.1:53951"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:41:32.885083862Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8654059984069183,
+				"StableID":   "nWceMuUSaA21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c7cbe03e07a1c7031b86080bc341380681b0f7093870793b0a559512bc7ec28",
+				"KeyExpiry":  "2026-10-26T10:41:33Z",
+				"DiscoKey":   "discokey:00883b9ddacb614b2b0ab83c11238be8eb1e94b397cc3313a3e2c30e0baf5c4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52924", "10.65.0.27:52924", "172.17.0.1:52924"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:41:33.414079737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8414384166007848": {
+				"ID":          8414384166007848,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-allpass-acls-and-grants-mixed.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-allpass-acls-and-grants-mixed.hujson
@@ -1,0 +1,7317 @@
+// policytest-allpass-acls-and-grants-mixed
+//
+// tests block all-pass: acls and grants mixed in one policy
+//
+// Nodes with filter rules: 1 of 8
+// Captured at:    2026-04-29T10:41:55Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-allpass-acls-and-grants-mixed",
+	"description":    "tests block all-pass: acls and grants mixed in one policy",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:41:55.127200563Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                           \n  \n                                                                \n                                                                     \n                                        \n{\n\t\"id\":          \"policytest-allpass-acls-and-grants-mixed\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block all-pass: acls and grants mixed in one policy\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"odin@example.com\"], \"dst\": [\"tag:server:22\"]}\n\t\t],\n\t\t\"grants\": [\n\t\t\t{\"src\": [\"tag:client\"], \"dst\": [\"webserver\"], \"ip\": [\"tcp:80\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"odin@example.com\", \"accept\": [\"tag:server:22\"]},\n\t\t\t{\"src\": \"tag:client\", \"accept\": [\"webserver:80\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-allpass-acls-and-grants-mixed.hujson",
+		"full_policy": {
+			"acls": [{
+				"action": "accept",
+				"dst":    ["tag:server:22"],
+				"src":    ["odin@example.com"]
+			}],
+			"grants": [{"dst": ["webserver"], "ip": ["tcp:80"], "src": ["tag:client"]}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [
+				{"accept": ["tag:server:22"], "src": "odin@example.com"},
+				{"accept": ["webserver:80"], "src": "tag:client"}
+			]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {"packet_filter_rules": [{
+		"SrcIPs":   ["100.64.0.14", "fd7a:115c:a1e0::e"],
+		"DstPorts": [{"IP": "100.64.0.16", "Ports": {"First": 80, "Last": 80}}],
+		"IPProto":  [6]
+	}, {"SrcIPs": ["100.64.0.19", "fd7a:115c:a1e0::13"], "DstPorts": [
+		{"IP": "100.64.0.16", "Ports": {"First": 22, "Last": 22}},
+		{"IP": "fd7a:115c:a1e0::10", "Ports": {"First": 22, "Last": 22}}
+	]}], "packet_filter_matches": [{
+		"IPProto": [6],
+		"Srcs":    ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+		"SrcCaps": null,
+		"Dsts":    [{"Net": "100.64.0.16/32", "Ports": {"First": 80, "Last": 80}}],
+		"Caps":    []
+	}, {
+		"IPProto": [6, 17, 1, 58],
+		"Srcs":    ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+		"SrcCaps": null,
+		"Dsts": [
+			{"Net": "100.64.0.16/32", "Ports": {"First": 22, "Last": 22}},
+			{"Net": "fd7a:115c:a1e0::10/128", "Ports": {"First": 22, "Last": 22}}
+		],
+		"Caps": []
+	}], "netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1326423528169737,
+			"StableID":   "nJ7W42ujMB11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       1326423528169737,
+			"Key":        "nodekey:9af9e07f331cdda7e1e9f2b3ce5033ee9fe3ea4317bb982bccacc56b0b726321",
+			"DiscoKey":   "discokey:189808f5fff93d7f1822e1aefbb3d0e59a4234f3d1f0388e96492a83dec75869",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints":  ["77.164.248.136:47628", "10.65.0.27:47628", "172.17.0.1:47628"],
+			"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:41:58.734496814Z",
+			"Tags":              ["tag:server"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:9af9e07f331cdda7e1e9f2b3ce5033ee9fe3ea4317bb982bccacc56b0b726321",
+		"MachineKey": "mkey:372c885e2a2d7e2f37912e6ca2dcb1f0e23fd5cdfcfff857d062c506b496b54e",
+		"Peers": [{
+			"ID":         6123833227974073,
+			"StableID":   "nNwuGTiVpp11CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:5008e0d244cc1e9147b3f706056675e12f65b7fee3b3cee7ef4fc6005604da59",
+			"DiscoKey":   "discokey:86b35cc2a02397a89338e6f9ba16635fc51dc614689dac2babf96cb745709218",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints":  ["77.164.248.136:42072", "10.65.0.27:42072", "172.17.0.1:42072"],
+			"HomeDERP":   26,
+			"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957}
+			]},
+			"Created":              "2026-04-29T10:41:57.615669945Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:client"],
+			"Online":               true,
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		}, {
+			"ID":         7475615564789547,
+			"StableID":   "nGoDRBkiN121CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:b79992a1928110bf061d9cb65ed774cfa5e2a54acd4486298ed99761e229973a",
+			"KeyExpiry":  "2026-10-26T10:42:00Z",
+			"DiscoKey":   "discokey:5a1bde77595eaf270f4e62119ce66230a4ccb13a6d8776e422225e0e2f46e87d",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints":  ["77.164.248.136:34573", "10.65.0.27:34573", "172.17.0.1:34573"],
+			"HomeDERP":   14,
+			"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156}
+			]},
+			"Created":              "2026-04-29T10:42:00.324919323Z",
+			"Cap":                  131,
+			"Online":               true,
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		}],
+		"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter": [{
+			"IPProto": [6],
+			"Srcs":    ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"SrcCaps": null,
+			"Dsts":    [{"Net": "100.64.0.16/32", "Ports": {"First": 80, "Last": 80}}],
+			"Caps":    []
+		}, {
+			"IPProto": [6, 17, 1, 58],
+			"Srcs":    ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"SrcCaps": null,
+			"Dsts": [
+				{"Net": "100.64.0.16/32", "Ports": {"First": 22, "Last": 22}},
+				{"Net": "fd7a:115c:a1e0::10/128", "Ports": {"First": 22, "Last": 22}}
+			],
+			"Caps": []
+		}],
+		"PacketFilterRules": [{
+			"SrcIPs":   ["100.64.0.14", "fd7a:115c:a1e0::e"],
+			"DstPorts": [{"IP": "100.64.0.16", "Ports": {"First": 80, "Last": 80}}],
+			"IPProto":  [6]
+		}, {"SrcIPs": ["100.64.0.19", "fd7a:115c:a1e0::13"], "DstPorts": [
+			{"IP": "100.64.0.16", "Ports": {"First": 22, "Last": 22}},
+			{"IP": "fd7a:115c:a1e0::10", "Ports": {"First": 22, "Last": 22}}
+		]}],
+		"SSHPolicy":       {"rules": []},
+		"CollectServices": false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "1326423528169737": {
+			"ID":          1326423528169737,
+			"LoginName":   "beedrill.tail78f774.ts.net",
+			"DisplayName": "beedrill"
+		}, "4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}}
+	}}, "bulbasaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7475615564789547,
+			"StableID":   "nGoDRBkiN121CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:b79992a1928110bf061d9cb65ed774cfa5e2a54acd4486298ed99761e229973a",
+			"KeyExpiry":  "2026-10-26T10:42:00Z",
+			"DiscoKey":   "discokey:5a1bde77595eaf270f4e62119ce66230a4ccb13a6d8776e422225e0e2f46e87d",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints":  ["77.164.248.136:34573", "10.65.0.27:34573", "172.17.0.1:34573"],
+			"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:42:00.324919323Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:b79992a1928110bf061d9cb65ed774cfa5e2a54acd4486298ed99761e229973a",
+		"MachineKey": "mkey:00285bb41faafa135410868adab32559d044a676be3c0f1c7ce2b14c72636c0b",
+		"Peers": [{
+			"ID":         1326423528169737,
+			"StableID":   "nJ7W42ujMB11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:9af9e07f331cdda7e1e9f2b3ce5033ee9fe3ea4317bb982bccacc56b0b726321",
+			"DiscoKey":   "discokey:189808f5fff93d7f1822e1aefbb3d0e59a4234f3d1f0388e96492a83dec75869",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints":  ["77.164.248.136:47628", "10.65.0.27:47628", "172.17.0.1:47628"],
+			"HomeDERP":   14,
+			"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358}
+			]},
+			"Created":              "2026-04-29T10:41:58.734496814Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:server"],
+			"Online":               true,
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}}
+	}}, "charmander": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2338917222658736,
+			"StableID":   "nX6oiaPJGK11CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       2338917222658736,
+			"Key":        "nodekey:9608c016339a8b0312c529559dcf63b487c5dbaef40c29a60843c4adc8e0f85d",
+			"DiscoKey":   "discokey:2359cd69113ba487ab570f821563a570737ff673fa7bc345efb3720e4df86625",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"Endpoints":  ["77.164.248.136:58174", "10.65.0.27:58174", "172.17.0.1:58174"],
+			"Hostinfo": {
+				"Hostname":    "charmander",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T10:41:56.568087219Z",
+			"Tags":              ["tag:exit"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:9608c016339a8b0312c529559dcf63b487c5dbaef40c29a60843c4adc8e0f85d",
+		"MachineKey":        "mkey:bb35e4a9a8fa4b52739922548fd29a9ff1d4f868254334b326223fbb95a7a81b",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"2338917222658736": {
+			"ID":          2338917222658736,
+			"LoginName":   "charmander.tail78f774.ts.net",
+			"DisplayName": "charmander"
+		}}
+	}}, "ivysaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4649030528769780,
+			"StableID":   "nmwGyc9ZJd11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:192e314e216fc59ff36e30678fb498e1e9e89b1b27e828c58f5c85f18f073742",
+			"KeyExpiry":  "2026-10-26T10:41:59Z",
+			"DiscoKey":   "discokey:69fea4e3d57457589cef56d3bcc873c3cb36d53eb50a50dd4f0a8d4ca2bde917",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints":  ["77.164.248.136:44550", "10.65.0.27:44550", "172.17.0.1:44550"],
+			"Hostinfo": {"Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:41:59.242876585Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:192e314e216fc59ff36e30678fb498e1e9e89b1b27e828c58f5c85f18f073742",
+		"MachineKey":        "mkey:1d72a07dbd173ed96aa4f567ee1bf5ab875c02ab2326a458b2ea5e2714059259",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}}
+	}}, "kakuna": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1745377287434865,
+			"StableID":   "nGrM8u6VdE11CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       1745377287434865,
+			"Key":        "nodekey:41a77cddc1c2c23754f599e2476b6054b7157f9c0a316ffa98bc9aecbb6c1d7a",
+			"DiscoKey":   "discokey:a5d6e02919efcf6f7980b71810b88f8ddf6479fcc3d8108ec31aa8b673d01f57",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints":  ["77.164.248.136:38130", "10.65.0.27:38130", "172.17.0.1:38130"],
+			"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:41:58.190697912Z",
+			"Tags":              ["tag:prod"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:41a77cddc1c2c23754f599e2476b6054b7157f9c0a316ffa98bc9aecbb6c1d7a",
+		"MachineKey":        "mkey:cf6f3a4dd332753660ffcf1bbdb3e3820f8398874be6807b0d1de29600891c61",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1745377287434865": {
+			"ID":          1745377287434865,
+			"LoginName":   "kakuna.tail78f774.ts.net",
+			"DisplayName": "kakuna"
+		}}
+	}}, "squirtle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7292727586188908,
+			"StableID":   "nRK725btwy11CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       7292727586188908,
+			"Key":        "nodekey:a31112e0405454bc5ea4ae118573504a3617404f26d2f69ea73e1743c0c24872",
+			"DiscoKey":   "discokey:472ed1f0f78f040a8433eb8f2d4c8d382ee3b43fed4df81b2e49f61262871a55",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"Endpoints":  ["77.164.248.136:43979", "10.65.0.27:43979", "172.17.0.1:43979"],
+			"Hostinfo": {
+				"Hostname":    "squirtle",
+				"RoutableIPs": ["10.33.0.0/16"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T10:41:57.06748997Z",
+			"Tags":              ["tag:router"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:a31112e0405454bc5ea4ae118573504a3617404f26d2f69ea73e1743c0c24872",
+		"MachineKey":        "mkey:c320d87f8b040bdf6347336fc768d8ea583a6feef4dc3fe38a96edb8d3ecbf4d",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"7292727586188908": {
+			"ID":          7292727586188908,
+			"LoginName":   "squirtle.tail78f774.ts.net",
+			"DisplayName": "squirtle"
+		}}
+	}}, "venusaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5847261510094306,
+			"StableID":   "ndEAePeEfn11CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:e7f6ad6caa048cb31ebe89bb4bdf40d08aedfd10dd1b2f3fe194f1874741605a",
+			"KeyExpiry":  "2026-10-26T10:41:59Z",
+			"DiscoKey":   "discokey:f5e33b7ddf0584ebc46a5806c2a258a64fa51520db305063db58b069ae01f578",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints":  ["77.164.248.136:44821", "10.65.0.27:44821", "172.17.0.1:44821"],
+			"Hostinfo": {"Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:41:59.808439516Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:e7f6ad6caa048cb31ebe89bb4bdf40d08aedfd10dd1b2f3fe194f1874741605a",
+		"MachineKey":        "mkey:e80ad55cc543a27b9332c93e98f33c8724c376c1f4c7e1b552430d3d67dafb58",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}}
+	}}, "weedle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         6123833227974073,
+			"StableID":   "nNwuGTiVpp11CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       6123833227974073,
+			"Key":        "nodekey:5008e0d244cc1e9147b3f706056675e12f65b7fee3b3cee7ef4fc6005604da59",
+			"DiscoKey":   "discokey:86b35cc2a02397a89338e6f9ba16635fc51dc614689dac2babf96cb745709218",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints":  ["77.164.248.136:42072", "10.65.0.27:42072", "172.17.0.1:42072"],
+			"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:41:57.615669945Z",
+			"Tags":              ["tag:client"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:5008e0d244cc1e9147b3f706056675e12f65b7fee3b3cee7ef4fc6005604da59",
+		"MachineKey": "mkey:bd2df2ef8f2f66891e9d941ce36e8d18735ff9b3de4d4c4c22d1c07651397c10",
+		"Peers": [{
+			"ID":         1326423528169737,
+			"StableID":   "nJ7W42ujMB11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:9af9e07f331cdda7e1e9f2b3ce5033ee9fe3ea4317bb982bccacc56b0b726321",
+			"DiscoKey":   "discokey:189808f5fff93d7f1822e1aefbb3d0e59a4234f3d1f0388e96492a83dec75869",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints":  ["77.164.248.136:47628", "10.65.0.27:47628", "172.17.0.1:47628"],
+			"HomeDERP":   14,
+			"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358}
+			]},
+			"Created":              "2026-04-29T10:41:58.734496814Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:server"],
+			"Online":               true,
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "6123833227974073": {
+			"ID":          6123833227974073,
+			"LoginName":   "weedle.tail78f774.ts.net",
+			"DisplayName": "weedle"
+		}}
+	}}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-allpass-acls-group-src-host-dst.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-allpass-acls-group-src-host-dst.hujson
@@ -1,0 +1,7289 @@
+// policytest-allpass-acls-group-src-host-dst
+//
+// tests block all-pass: group src to host alias on tcp:22
+//
+// Nodes with filter rules: 1 of 8
+// Captured at:    2026-04-29T10:42:31Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-allpass-acls-group-src-host-dst",
+	"description":    "tests block all-pass: group src to host alias on tcp:22",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:42:31.182899882Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                             \n  \n                                                                       \n                           \n{\n\t\"id\":          \"policytest-allpass-acls-group-src-host-dst\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block all-pass: group src to host alias on tcp:22\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"group:developers\"], \"dst\": [\"webserver:22\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"group:developers\", \"accept\": [\"webserver:22\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-allpass-acls-group-src-host-dst.hujson",
+		"full_policy": {"acls": [
+			{"action": "accept", "dst": ["webserver:22"], "src": ["group:developers"]}
+		], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [{"accept": ["webserver:22"], "src": "group:developers"}]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {"packet_filter_rules": [{
+		"SrcIPs":   ["100.64.0.17", "100.64.0.19", "fd7a:115c:a1e0::11", "fd7a:115c:a1e0::13"],
+		"DstPorts": [{"IP": "100.64.0.16", "Ports": {"First": 22, "Last": 22}}]
+	}], "packet_filter_matches": [{
+		"IPProto": [6, 17, 1, 58],
+		"Srcs": [
+			"100.64.0.17/32",
+			"100.64.0.19/32",
+			"fd7a:115c:a1e0::11/128",
+			"fd7a:115c:a1e0::13/128"
+		],
+		"SrcCaps": null,
+		"Dsts":    [{"Net": "100.64.0.16/32", "Ports": {"First": 22, "Last": 22}}],
+		"Caps":    []
+	}], "netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         791806517701836,
+			"StableID":   "ndwCZ3RcB711CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       791806517701836,
+			"Key":        "nodekey:e0b24ab893a75fd56e0f4c4b588208cdc12db28741ad09d1747411d2f6ef6529",
+			"DiscoKey":   "discokey:4a4c878e628db9853d9243c0e3ef595b1426b2b1fbb7e4f024d6c59e866f217c",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints":  ["77.164.248.136:57680", "10.65.0.27:57680", "172.17.0.1:57680"],
+			"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:42:34.893353415Z",
+			"Tags":              ["tag:server"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:e0b24ab893a75fd56e0f4c4b588208cdc12db28741ad09d1747411d2f6ef6529",
+		"MachineKey": "mkey:14d5a07b029964386a5ce998cc76c0339c30f4502ed64b52de3457480e484e35",
+		"Peers": [{
+			"ID":         1529766981595,
+			"StableID":   "n8MeGhBh1111CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:e53cd25296af6806cce8714d3575ea597bbe107547c93d4169722bcd009f2112",
+			"KeyExpiry":  "2026-10-26T10:42:35Z",
+			"DiscoKey":   "discokey:89124ea162513f3e75512f88e0ffab0462f70272abf63d342dfa2c59eb22ac32",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints":  ["77.164.248.136:45813", "10.65.0.27:45813", "172.17.0.1:45813"],
+			"HomeDERP":   14,
+			"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496}
+			]},
+			"Created":              "2026-04-29T10:42:35.449274092Z",
+			"Cap":                  131,
+			"Online":               true,
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		}, {
+			"ID":         597957933528770,
+			"StableID":   "nVYZymLpf511CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:a6d7198a7da238b47cc53719ade52d29f1a2f8fd6f7840c2a794b5daed2fda5e",
+			"KeyExpiry":  "2026-10-26T10:42:36Z",
+			"DiscoKey":   "discokey:5fd30c76e33ebd788eacc5bd3c60c83b9bf2c1bc998f3c601cacc25eafd5b16d",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints":  ["77.164.248.136:47032", "10.65.0.27:47032", "172.17.0.1:47032"],
+			"HomeDERP":   14,
+			"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156}
+			]},
+			"Created":              "2026-04-29T10:42:36.524901527Z",
+			"Cap":                  131,
+			"Online":               true,
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		}],
+		"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter": [{
+			"IPProto": [6, 17, 1, 58],
+			"Srcs": [
+				"100.64.0.17/32",
+				"100.64.0.19/32",
+				"fd7a:115c:a1e0::11/128",
+				"fd7a:115c:a1e0::13/128"
+			],
+			"SrcCaps": null,
+			"Dsts":    [{"Net": "100.64.0.16/32", "Ports": {"First": 22, "Last": 22}}],
+			"Caps":    []
+		}],
+		"PacketFilterRules": [{
+			"SrcIPs":   ["100.64.0.17", "100.64.0.19", "fd7a:115c:a1e0::11", "fd7a:115c:a1e0::13"],
+			"DstPorts": [{"IP": "100.64.0.16", "Ports": {"First": 22, "Last": 22}}]
+		}],
+		"SSHPolicy":       {"rules": []},
+		"CollectServices": false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}, "4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}, "791806517701836": {
+			"ID":          791806517701836,
+			"LoginName":   "beedrill.tail78f774.ts.net",
+			"DisplayName": "beedrill"
+		}}
+	}}, "bulbasaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         597957933528770,
+			"StableID":   "nVYZymLpf511CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:a6d7198a7da238b47cc53719ade52d29f1a2f8fd6f7840c2a794b5daed2fda5e",
+			"KeyExpiry":  "2026-10-26T10:42:36Z",
+			"DiscoKey":   "discokey:5fd30c76e33ebd788eacc5bd3c60c83b9bf2c1bc998f3c601cacc25eafd5b16d",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints":  ["77.164.248.136:47032", "10.65.0.27:47032", "172.17.0.1:47032"],
+			"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:42:36.524901527Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:a6d7198a7da238b47cc53719ade52d29f1a2f8fd6f7840c2a794b5daed2fda5e",
+		"MachineKey": "mkey:b6039a0b056da3ae307c3122cca07b30f8f3e644b284da90b1d8cc5885a30d3c",
+		"Peers": [{
+			"ID":         791806517701836,
+			"StableID":   "ndwCZ3RcB711CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:e0b24ab893a75fd56e0f4c4b588208cdc12db28741ad09d1747411d2f6ef6529",
+			"DiscoKey":   "discokey:4a4c878e628db9853d9243c0e3ef595b1426b2b1fbb7e4f024d6c59e866f217c",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints":  ["77.164.248.136:57680", "10.65.0.27:57680", "172.17.0.1:57680"],
+			"HomeDERP":   14,
+			"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358}
+			]},
+			"Created":              "2026-04-29T10:42:34.893353415Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:server"],
+			"Online":               true,
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}}
+	}}, "charmander": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7245779449651478,
+			"StableID":   "njFfxgLday11CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       7245779449651478,
+			"Key":        "nodekey:5e6910a5ea7483f6d901be727edb36c6fa684ad876385e0edf860ec9bb18dc57",
+			"DiscoKey":   "discokey:262c7f5ac5d4a2e40c4c355ec83c18d6050dc3760f322523577c430d5141b922",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"Endpoints":  ["77.164.248.136:47050", "10.65.0.27:47050", "172.17.0.1:47050"],
+			"Hostinfo": {
+				"Hostname":    "charmander",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T10:42:32.744175374Z",
+			"Tags":              ["tag:exit"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:5e6910a5ea7483f6d901be727edb36c6fa684ad876385e0edf860ec9bb18dc57",
+		"MachineKey":        "mkey:4a38fc77ef3b625622becda73b53623ab4a4b3550b2e9d442e2492464a457168",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"7245779449651478": {
+			"ID":          7245779449651478,
+			"LoginName":   "charmander.tail78f774.ts.net",
+			"DisplayName": "charmander"
+		}}
+	}}, "ivysaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1529766981595,
+			"StableID":   "n8MeGhBh1111CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:e53cd25296af6806cce8714d3575ea597bbe107547c93d4169722bcd009f2112",
+			"KeyExpiry":  "2026-10-26T10:42:35Z",
+			"DiscoKey":   "discokey:89124ea162513f3e75512f88e0ffab0462f70272abf63d342dfa2c59eb22ac32",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints":  ["77.164.248.136:45813", "10.65.0.27:45813", "172.17.0.1:45813"],
+			"Hostinfo": {"Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:42:35.449274092Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:e53cd25296af6806cce8714d3575ea597bbe107547c93d4169722bcd009f2112",
+		"MachineKey": "mkey:383c76501d8d727632aa7f73da177107e0df8f0dd76a14f27f12feac2019223e",
+		"Peers": [{
+			"ID":         791806517701836,
+			"StableID":   "ndwCZ3RcB711CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:e0b24ab893a75fd56e0f4c4b588208cdc12db28741ad09d1747411d2f6ef6529",
+			"DiscoKey":   "discokey:4a4c878e628db9853d9243c0e3ef595b1426b2b1fbb7e4f024d6c59e866f217c",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints":  ["77.164.248.136:57680", "10.65.0.27:57680", "172.17.0.1:57680"],
+			"HomeDERP":   14,
+			"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358}
+			]},
+			"Created":              "2026-04-29T10:42:34.893353415Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:server"],
+			"Online":               true,
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}}
+	}}, "kakuna": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4194926203460666,
+			"StableID":   "n7fVkgbtkZ11CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       4194926203460666,
+			"Key":        "nodekey:1e5d342f84dad82e072004ca69afbaadc7c0c9404177dbc7f80196d0e1b76554",
+			"DiscoKey":   "discokey:3c3ee1db489761624f93b90f509c134eb4f710505b7c5b65fc56ae6d0fc74b36",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints":  ["77.164.248.136:39631", "10.65.0.27:39631", "172.17.0.1:39631"],
+			"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:42:34.426236312Z",
+			"Tags":              ["tag:prod"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:1e5d342f84dad82e072004ca69afbaadc7c0c9404177dbc7f80196d0e1b76554",
+		"MachineKey":        "mkey:f44a1298e17e663d6c9648d848ba5eb9fd4bdfe1ed18cf9dfec2f2f1d415d31f",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4194926203460666": {
+			"ID":          4194926203460666,
+			"LoginName":   "kakuna.tail78f774.ts.net",
+			"DisplayName": "kakuna"
+		}}
+	}}, "squirtle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         950578355611099,
+			"StableID":   "npbbBj5XR811CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       950578355611099,
+			"Key":        "nodekey:883eb6d91de8690c2070133f0c8b95f003464c9161eeb26427cbc64649e3192d",
+			"DiscoKey":   "discokey:b0b9172584fa8631680fdbf19f04a4d59d80d5a408977e55a93263d7a309976a",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"Endpoints":  ["77.164.248.136:43223", "10.65.0.27:43223", "172.17.0.1:43223"],
+			"Hostinfo": {
+				"Hostname":    "squirtle",
+				"RoutableIPs": ["10.33.0.0/16"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T10:42:33.30147098Z",
+			"Tags":              ["tag:router"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:883eb6d91de8690c2070133f0c8b95f003464c9161eeb26427cbc64649e3192d",
+		"MachineKey":        "mkey:3bcc8b4ba5637d47879593330cd1aa5526249103fbc3477eb1a6adfa8a3f913c",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"950578355611099": {
+			"ID":          950578355611099,
+			"LoginName":   "squirtle.tail78f774.ts.net",
+			"DisplayName": "squirtle"
+		}}
+	}}, "venusaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2321679539194840,
+			"StableID":   "nq9KfuaV8K11CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:66d56535478bff383da297a53065101d89de533a30976adcf87d55b88f22f668",
+			"KeyExpiry":  "2026-10-26T10:42:36Z",
+			"DiscoKey":   "discokey:6b24a10d6d3358f87ea381d89401a42ad5a6ebf7de6e042143e2472bf2118265",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints":  ["77.164.248.136:59655", "10.65.0.27:59655", "172.17.0.1:59655"],
+			"Hostinfo": {"Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:42:36.002427676Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:66d56535478bff383da297a53065101d89de533a30976adcf87d55b88f22f668",
+		"MachineKey":        "mkey:e172e377c9c9c5564521237240f4c2aeda9b3f593d70a92166f31ad89ba0a205",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}}
+	}}, "weedle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         288654018169325,
+			"StableID":   "nWmu8CTjF311CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       288654018169325,
+			"Key":        "nodekey:47cb7b60cb7eef6c3b0400da0d124bd1d32c2d4ed3709bc81098c0937af4163f",
+			"DiscoKey":   "discokey:12c288154922bc24046189ecdb3056dde2000303faa13d206cdeb15603d3e744",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints":  ["77.164.248.136:35834", "10.65.0.27:35834", "172.17.0.1:35834"],
+			"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:42:33.809985154Z",
+			"Tags":              ["tag:client"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:47cb7b60cb7eef6c3b0400da0d124bd1d32c2d4ed3709bc81098c0937af4163f",
+		"MachineKey":        "mkey:b83d7695c50c0d7d202d08127bf59be032db983f64dc4b02cdc18c4abf71d011",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"288654018169325": {
+			"ID":          288654018169325,
+			"LoginName":   "weedle.tail78f774.ts.net",
+			"DisplayName": "weedle"
+		}}
+	}}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-allpass-acls-user-src-tag-dst.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-allpass-acls-user-src-tag-dst.hujson
@@ -1,0 +1,7241 @@
+// policytest-allpass-acls-user-src-tag-dst
+//
+// tests block all-pass: user-email src to tag dst on port 22
+//
+// Nodes with filter rules: 1 of 8
+// Captured at:    2026-04-29T10:43:07Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-allpass-acls-user-src-tag-dst",
+	"description":    "tests block all-pass: user-email src to tag dst on port 22",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:43:07.427788929Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                           \n  \n                                                                      \n                                                                  \n{\n\t\"id\":          \"policytest-allpass-acls-user-src-tag-dst\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block all-pass: user-email src to tag dst on port 22\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"odin@example.com\"], \"dst\": [\"tag:server:22\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"odin@example.com\", \"accept\": [\"tag:server:22\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-allpass-acls-user-src-tag-dst.hujson",
+		"full_policy": {"acls": [{
+			"action": "accept",
+			"dst":    ["tag:server:22"],
+			"src":    ["odin@example.com"]
+		}], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [{"accept": ["tag:server:22"], "src": "odin@example.com"}]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": ["100.64.0.19", "fd7a:115c:a1e0::13"], "DstPorts": [
+			{"IP": "100.64.0.16", "Ports": {"First": 22, "Last": 22}},
+			{"IP": "fd7a:115c:a1e0::10", "Ports": {"First": 22, "Last": 22}}
+		]}],
+		"packet_filter_matches": [{
+			"IPProto": [6, 17, 1, 58],
+			"Srcs":    ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"SrcCaps": null,
+			"Dsts": [
+				{"Net": "100.64.0.16/32", "Ports": {"First": 22, "Last": 22}},
+				{"Net": "fd7a:115c:a1e0::10/128", "Ports": {"First": 22, "Last": 22}}
+			],
+			"Caps": []
+		}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7140284701305751,
+				"StableID":   "nguHJwArkx11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       7140284701305751,
+				"Key":        "nodekey:478f76ec99e1a634190abba945f661449554e619b6e7aa3ed771e3710db20900",
+				"DiscoKey":   "discokey:4d84b9dedc8b17df38a90785760fda4421e672d6a69958b44ba2a89658a5c57b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40503", "10.65.0.27:40503", "172.17.0.1:40503"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:43:11.251042984Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:478f76ec99e1a634190abba945f661449554e619b6e7aa3ed771e3710db20900",
+			"MachineKey": "mkey:19b22528dfb2db77e1e6e3017a4800191e10afd8397eb338e8b46ecac822323d",
+			"Peers": [{
+				"ID":         5172665022611838,
+				"StableID":   "n7PA649iPh11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:248bac1a350ad2f02687a802630b6fe8c8e6a1ff9bdd9315ef67aa00b9fb8a6e",
+				"KeyExpiry":  "2026-10-26T10:43:12Z",
+				"DiscoKey":   "discokey:888370485211a587025ea098c8adf6e9a740c2cf3dae70ca70da0c4899e18d52",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:57919", "10.65.0.27:57919", "172.17.0.1:57919"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:43:12.848808309Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{
+				"IPProto": [6, 17, 1, 58],
+				"Srcs":    ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"SrcCaps": null,
+				"Dsts": [
+					{"Net": "100.64.0.16/32", "Ports": {"First": 22, "Last": 22}},
+					{"Net": "fd7a:115c:a1e0::10/128", "Ports": {"First": 22, "Last": 22}}
+				],
+				"Caps": []
+			}],
+			"PacketFilterRules": [{"SrcIPs": ["100.64.0.19", "fd7a:115c:a1e0::13"], "DstPorts": [
+				{"IP": "100.64.0.16", "Ports": {"First": 22, "Last": 22}},
+				{"IP": "fd7a:115c:a1e0::10", "Ports": {"First": 22, "Last": 22}}
+			]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "7140284701305751": {
+				"ID":          7140284701305751,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5172665022611838,
+			"StableID":   "n7PA649iPh11CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:248bac1a350ad2f02687a802630b6fe8c8e6a1ff9bdd9315ef67aa00b9fb8a6e",
+			"KeyExpiry":  "2026-10-26T10:43:12Z",
+			"DiscoKey":   "discokey:888370485211a587025ea098c8adf6e9a740c2cf3dae70ca70da0c4899e18d52",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints":  ["77.164.248.136:57919", "10.65.0.27:57919", "172.17.0.1:57919"],
+			"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:43:12.848808309Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:248bac1a350ad2f02687a802630b6fe8c8e6a1ff9bdd9315ef67aa00b9fb8a6e",
+		"MachineKey": "mkey:d84b3332341c7f48415ad5e03e0357361dfb68df2b58b69202212bef6952737a",
+		"Peers": [{
+			"ID":         7140284701305751,
+			"StableID":   "nguHJwArkx11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:478f76ec99e1a634190abba945f661449554e619b6e7aa3ed771e3710db20900",
+			"DiscoKey":   "discokey:4d84b9dedc8b17df38a90785760fda4421e672d6a69958b44ba2a89658a5c57b",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints":  ["77.164.248.136:40503", "10.65.0.27:40503", "172.17.0.1:40503"],
+			"HomeDERP":   14,
+			"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358}
+			]},
+			"Created":              "2026-04-29T10:43:11.251042984Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:server"],
+			"Online":               true,
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}}
+	}}, "charmander": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7829235338567774,
+			"StableID":   "n1Avuhjs8421CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       7829235338567774,
+			"Key":        "nodekey:06a2eeb7e2445717986b4d04ec741e988252c18bf63d83d53b703ddaa4f6c832",
+			"DiscoKey":   "discokey:ab3ef2fe26a74d2ef7bda9da190778bb439e9e3e518f3840f796e6883f838268",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"Endpoints":  ["77.164.248.136:50260", "10.65.0.27:50260", "172.17.0.1:50260"],
+			"Hostinfo": {
+				"Hostname":    "charmander",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T10:43:09.110117389Z",
+			"Tags":              ["tag:exit"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:06a2eeb7e2445717986b4d04ec741e988252c18bf63d83d53b703ddaa4f6c832",
+		"MachineKey":        "mkey:3716fb4cd57bd3ccbc2deca1c0105dab2348d0b14632816735bd444d9d890218",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"7829235338567774": {
+			"ID":          7829235338567774,
+			"LoginName":   "charmander.tail78f774.ts.net",
+			"DisplayName": "charmander"
+		}}
+	}}, "ivysaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5408574741666956,
+			"StableID":   "nHHN846ZEj11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:b4426deca70bbea73b7a7b5f1a8c64928f2a78dc92e6b070357856d283104256",
+			"KeyExpiry":  "2026-10-26T10:43:11Z",
+			"DiscoKey":   "discokey:1d093f6003eb7059d0458eab1579dc937f10f1d4c4724f2427cac4190c3c8177",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints":  ["77.164.248.136:48307", "10.65.0.27:48307", "172.17.0.1:48307"],
+			"Hostinfo": {"Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:43:11.799652674Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:b4426deca70bbea73b7a7b5f1a8c64928f2a78dc92e6b070357856d283104256",
+		"MachineKey":        "mkey:0cdc8aff6abbffe481558b84857e72096252c0849b98a60e0c34934401b4080a",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}}
+	}}, "kakuna": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4076632402283312,
+			"StableID":   "nqmqcnDKqY11CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       4076632402283312,
+			"Key":        "nodekey:b603b841dcf838406e0dca6e54e843e8dabed80ce594be42ceb5eb3f7d080006",
+			"DiscoKey":   "discokey:2cc52a79f3751ee066e020d77461988e343693b9b92f5cc781d3914f2a4c6637",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints":  ["77.164.248.136:47501", "10.65.0.27:47501", "172.17.0.1:47501"],
+			"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:43:10.687874358Z",
+			"Tags":              ["tag:prod"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:b603b841dcf838406e0dca6e54e843e8dabed80ce594be42ceb5eb3f7d080006",
+		"MachineKey":        "mkey:fc95c6a3a527f6c09ce306e1ba912ed44e2ceeb65ad11c4a514679050c92657c",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4076632402283312": {
+			"ID":          4076632402283312,
+			"LoginName":   "kakuna.tail78f774.ts.net",
+			"DisplayName": "kakuna"
+		}}
+	}}, "squirtle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         81145542165442,
+			"StableID":   "nyY6hEZkd111CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       81145542165442,
+			"Key":        "nodekey:6e349ec07834d5c3bc23638864bc7e024d7bc4a78fa36b447cb8105f33d2b14d",
+			"DiscoKey":   "discokey:69360d498e2b1d352e40869925390b058f9edd94f8e5b8b06b9094878f8fcc7f",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"Endpoints":  ["77.164.248.136:33326", "10.65.0.27:33326", "172.17.0.1:33326"],
+			"Hostinfo": {
+				"Hostname":    "squirtle",
+				"RoutableIPs": ["10.33.0.0/16"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T10:43:09.603442092Z",
+			"Tags":              ["tag:router"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:6e349ec07834d5c3bc23638864bc7e024d7bc4a78fa36b447cb8105f33d2b14d",
+		"MachineKey":        "mkey:ed466800563cb12391a14c49216c06c35ae4389ad4593967f9f5f9b771e36207",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"81145542165442": {
+			"ID":          81145542165442,
+			"LoginName":   "squirtle.tail78f774.ts.net",
+			"DisplayName": "squirtle"
+		}}
+	}}, "venusaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2394441553228690,
+			"StableID":   "n5vNgKvShK11CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:e4c22f3298ba5a9880c6a5e7da52cbdf0e0fb16650e006ec90d50ada807a8635",
+			"KeyExpiry":  "2026-10-26T10:43:12Z",
+			"DiscoKey":   "discokey:61d8c89b5bf7ff23ed0558989efea14d2519444061d85304725b6d7eaa88f562",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints":  ["77.164.248.136:54438", "10.65.0.27:54438", "172.17.0.1:54438"],
+			"Hostinfo": {"Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:43:12.291246713Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:e4c22f3298ba5a9880c6a5e7da52cbdf0e0fb16650e006ec90d50ada807a8635",
+		"MachineKey":        "mkey:cdfca354c31e08b44e3e6a55e668bdb40dde709efe2abab914883d9a0a8a9317",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}}
+	}}, "weedle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5299323541090243,
+			"StableID":   "ncVRe7F5Pi11CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       5299323541090243,
+			"Key":        "nodekey:58502ca467024a3856bfa82397951e0d8fa2cf07f4aebefda07e5a54f9ae410b",
+			"DiscoKey":   "discokey:c90c55cc0d485db0750a106cfc3819cb7b889480564486ade6bdf9ccd62e5e4d",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints":  ["77.164.248.136:45277", "10.65.0.27:45277", "172.17.0.1:45277"],
+			"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:43:10.138821092Z",
+			"Tags":              ["tag:client"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:58502ca467024a3856bfa82397951e0d8fa2cf07f4aebefda07e5a54f9ae410b",
+		"MachineKey":        "mkey:3340dbb04f46bd19dd3b42d610ce7998b3bcf4aecccf81ad1073f2a3b35db668",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"5299323541090243": {
+			"ID":          5299323541090243,
+			"LoginName":   "weedle.tail78f774.ts.net",
+			"DisplayName": "weedle"
+		}}
+	}}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-allpass-grants-only-tag-src-cidr-dst.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-allpass-grants-only-tag-src-cidr-dst.hujson
@@ -1,0 +1,8843 @@
+// policytest-allpass-grants-only-tag-src-cidr-dst
+//
+// tests block all-pass: tag src to cidr dst, grants only, tcp
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:43:43Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-allpass-grants-only-tag-src-cidr-dst",
+	"description":    "tests block all-pass: tag src to cidr dst, grants only, tcp",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:43:43.658780853Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                  \n  \n                                                                       \n                                                                     \n                                        \n{\n\t\"id\":          \"policytest-allpass-grants-only-tag-src-cidr-dst\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block all-pass: tag src to cidr dst, grants only, tcp\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"grants\": [\n\t\t\t{\"src\": [\"tag:client\"], \"dst\": [\"10.0.0.0/8\"], \"ip\": [\"tcp:22\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"tag:client\", \"accept\": [\"10.0.0.0/8:22\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-allpass-grants-only-tag-src-cidr-dst.hujson",
+		"full_policy": {
+			"grants": [{"dst": ["10.0.0.0/8"], "ip": ["tcp:22"], "src": ["tag:client"]}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["10.0.0.0/8:22"], "src": "tag:client"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         624684407717733,
+				"StableID":   "nYYmyCQvs511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       624684407717733,
+				"Key":        "nodekey:4abd8c6e8117a613d3eb4df78021ae0f3406d10925574255f6a3491154482c7f",
+				"DiscoKey":   "discokey:a6e909ab8a5a9af4c42ae93eb649911f91e99431775c4fdfebbcb64adfdc4035",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36423", "10.65.0.27:36423", "172.17.0.1:36423"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:43:47.321616474Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4abd8c6e8117a613d3eb4df78021ae0f3406d10925574255f6a3491154482c7f",
+			"MachineKey": "mkey:776f5ff1f8a308857f7040f197140f13e35b6c4f563be8d50f001dd56380a040",
+			"Peers": [{
+				"ID":         767842026245996,
+				"StableID":   "nyTTWfukz611CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aa16e7437037ab8e5d58bb73f81bacafbc53227b2774050dade7aea84612959",
+				"DiscoKey":   "discokey:36b2c890d7a1806ba26d76dcd22841d82907795599e421a6cdc45469aadc8e34",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41278", "10.65.0.27:41278", "172.17.0.1:41278"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:43:45.173122416Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1806022443739163,
+				"StableID":   "npbMvX9x6F11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e3e915cc385b6058c25d636562da1e7479be400860c4fcb8d3ae8238491b303",
+				"DiscoKey":   "discokey:6cf56b6d72ec4ea9bbf19fba9432669bf62d2d4a2becf676954c7ee5e078c835",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:40148", "10.65.0.27:40148", "172.17.0.1:40148"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:43:45.686739257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7745127178510831,
+				"StableID":   "n4XjpjMnU321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3b474e0b2de97b89ca01c25669bb5e7dcaa2ee6fd400bd1057e69dbecdf3718",
+				"DiscoKey":   "discokey:1178eaf052798a38dac1a10be631a1a03e0322f0c12719828ded59e1202ead02",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:45646", "10.65.0.27:45646", "172.17.0.1:45646"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:43:46.253803586Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5186798971470242,
+				"StableID":   "nsbWkzQ7Wh11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:301c862a5d4bfa8d4a73f34a25b68040de1f036ba2e962b476ede552bea75c33",
+				"DiscoKey":   "discokey:d3ea3efe130ab7afb75d129b6ad4f27d790760f41dca9af4fcf10cfdf65dba78",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41039", "10.65.0.27:41039", "172.17.0.1:41039"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:43:46.782141487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2860439699917347,
+				"StableID":   "nvpdAEuVLP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ebf14a8a86134c38deb13d51101af7ba42e4d1cdb04d2547cff22883322ca363",
+				"KeyExpiry":  "2026-10-26T10:43:47Z",
+				"DiscoKey":   "discokey:973e9cd0281d9a4003095ff2f629d562f2d31e189ea484a83df793e6872ff270",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:47820", "10.65.0.27:47820", "172.17.0.1:47820"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:43:47.843298513Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8349456121928427,
+				"StableID":   "nkMH894VC821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:847c8ad09d811593dc6a62c3dd586cbbb3cc1491cc28184994a68eb5a808aa15",
+				"KeyExpiry":  "2026-10-26T10:43:48Z",
+				"DiscoKey":   "discokey:202b9b905521e235b7b22755d76d32e79a7ced0b07325557e4815ec849ab4f15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43467", "10.65.0.27:43467", "172.17.0.1:43467"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:43:48.412446532Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         295406210098733,
+				"StableID":   "ngYVDapnJ311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29642e0e9676988578577e1236ab3217f46c4bc9817a0407562a262cce41567a",
+				"KeyExpiry":  "2026-10-26T10:43:48Z",
+				"DiscoKey":   "discokey:37f2413da0e11306cf6a97b80d2d01e200cf55f23a97226015970e5ae4c65b65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39985", "10.65.0.27:39985", "172.17.0.1:39985"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:43:48.932268868Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "624684407717733": {
+				"ID":          624684407717733,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         295406210098733,
+				"StableID":   "ngYVDapnJ311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29642e0e9676988578577e1236ab3217f46c4bc9817a0407562a262cce41567a",
+				"KeyExpiry":  "2026-10-26T10:43:48Z",
+				"DiscoKey":   "discokey:37f2413da0e11306cf6a97b80d2d01e200cf55f23a97226015970e5ae4c65b65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39985", "10.65.0.27:39985", "172.17.0.1:39985"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:43:48.932268868Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:29642e0e9676988578577e1236ab3217f46c4bc9817a0407562a262cce41567a",
+			"MachineKey": "mkey:d57ec97966f08d794d14326c948f44955a742d146acaf1c11cba056c110b455d",
+			"Peers": [{
+				"ID":         767842026245996,
+				"StableID":   "nyTTWfukz611CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aa16e7437037ab8e5d58bb73f81bacafbc53227b2774050dade7aea84612959",
+				"DiscoKey":   "discokey:36b2c890d7a1806ba26d76dcd22841d82907795599e421a6cdc45469aadc8e34",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41278", "10.65.0.27:41278", "172.17.0.1:41278"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:43:45.173122416Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1806022443739163,
+				"StableID":   "npbMvX9x6F11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e3e915cc385b6058c25d636562da1e7479be400860c4fcb8d3ae8238491b303",
+				"DiscoKey":   "discokey:6cf56b6d72ec4ea9bbf19fba9432669bf62d2d4a2becf676954c7ee5e078c835",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:40148", "10.65.0.27:40148", "172.17.0.1:40148"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:43:45.686739257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7745127178510831,
+				"StableID":   "n4XjpjMnU321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3b474e0b2de97b89ca01c25669bb5e7dcaa2ee6fd400bd1057e69dbecdf3718",
+				"DiscoKey":   "discokey:1178eaf052798a38dac1a10be631a1a03e0322f0c12719828ded59e1202ead02",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:45646", "10.65.0.27:45646", "172.17.0.1:45646"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:43:46.253803586Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5186798971470242,
+				"StableID":   "nsbWkzQ7Wh11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:301c862a5d4bfa8d4a73f34a25b68040de1f036ba2e962b476ede552bea75c33",
+				"DiscoKey":   "discokey:d3ea3efe130ab7afb75d129b6ad4f27d790760f41dca9af4fcf10cfdf65dba78",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41039", "10.65.0.27:41039", "172.17.0.1:41039"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:43:46.782141487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         624684407717733,
+				"StableID":   "nYYmyCQvs511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4abd8c6e8117a613d3eb4df78021ae0f3406d10925574255f6a3491154482c7f",
+				"DiscoKey":   "discokey:a6e909ab8a5a9af4c42ae93eb649911f91e99431775c4fdfebbcb64adfdc4035",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36423", "10.65.0.27:36423", "172.17.0.1:36423"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:43:47.321616474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2860439699917347,
+				"StableID":   "nvpdAEuVLP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ebf14a8a86134c38deb13d51101af7ba42e4d1cdb04d2547cff22883322ca363",
+				"KeyExpiry":  "2026-10-26T10:43:47Z",
+				"DiscoKey":   "discokey:973e9cd0281d9a4003095ff2f629d562f2d31e189ea484a83df793e6872ff270",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:47820", "10.65.0.27:47820", "172.17.0.1:47820"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:43:47.843298513Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8349456121928427,
+				"StableID":   "nkMH894VC821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:847c8ad09d811593dc6a62c3dd586cbbb3cc1491cc28184994a68eb5a808aa15",
+				"KeyExpiry":  "2026-10-26T10:43:48Z",
+				"DiscoKey":   "discokey:202b9b905521e235b7b22755d76d32e79a7ced0b07325557e4815ec849ab4f15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43467", "10.65.0.27:43467", "172.17.0.1:43467"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:43:48.412446532Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         767842026245996,
+				"StableID":   "nyTTWfukz611CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       767842026245996,
+				"Key":        "nodekey:5aa16e7437037ab8e5d58bb73f81bacafbc53227b2774050dade7aea84612959",
+				"DiscoKey":   "discokey:36b2c890d7a1806ba26d76dcd22841d82907795599e421a6cdc45469aadc8e34",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41278", "10.65.0.27:41278", "172.17.0.1:41278"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:43:45.173122416Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5aa16e7437037ab8e5d58bb73f81bacafbc53227b2774050dade7aea84612959",
+			"MachineKey": "mkey:4f746eda580cba74175e26fbfd62a89b260155f0bbd6715bf1481060b3f93c39",
+			"Peers": [{
+				"ID":         1806022443739163,
+				"StableID":   "npbMvX9x6F11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e3e915cc385b6058c25d636562da1e7479be400860c4fcb8d3ae8238491b303",
+				"DiscoKey":   "discokey:6cf56b6d72ec4ea9bbf19fba9432669bf62d2d4a2becf676954c7ee5e078c835",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:40148", "10.65.0.27:40148", "172.17.0.1:40148"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:43:45.686739257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7745127178510831,
+				"StableID":   "n4XjpjMnU321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3b474e0b2de97b89ca01c25669bb5e7dcaa2ee6fd400bd1057e69dbecdf3718",
+				"DiscoKey":   "discokey:1178eaf052798a38dac1a10be631a1a03e0322f0c12719828ded59e1202ead02",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:45646", "10.65.0.27:45646", "172.17.0.1:45646"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:43:46.253803586Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5186798971470242,
+				"StableID":   "nsbWkzQ7Wh11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:301c862a5d4bfa8d4a73f34a25b68040de1f036ba2e962b476ede552bea75c33",
+				"DiscoKey":   "discokey:d3ea3efe130ab7afb75d129b6ad4f27d790760f41dca9af4fcf10cfdf65dba78",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41039", "10.65.0.27:41039", "172.17.0.1:41039"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:43:46.782141487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         624684407717733,
+				"StableID":   "nYYmyCQvs511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4abd8c6e8117a613d3eb4df78021ae0f3406d10925574255f6a3491154482c7f",
+				"DiscoKey":   "discokey:a6e909ab8a5a9af4c42ae93eb649911f91e99431775c4fdfebbcb64adfdc4035",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36423", "10.65.0.27:36423", "172.17.0.1:36423"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:43:47.321616474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2860439699917347,
+				"StableID":   "nvpdAEuVLP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ebf14a8a86134c38deb13d51101af7ba42e4d1cdb04d2547cff22883322ca363",
+				"KeyExpiry":  "2026-10-26T10:43:47Z",
+				"DiscoKey":   "discokey:973e9cd0281d9a4003095ff2f629d562f2d31e189ea484a83df793e6872ff270",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:47820", "10.65.0.27:47820", "172.17.0.1:47820"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:43:47.843298513Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8349456121928427,
+				"StableID":   "nkMH894VC821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:847c8ad09d811593dc6a62c3dd586cbbb3cc1491cc28184994a68eb5a808aa15",
+				"KeyExpiry":  "2026-10-26T10:43:48Z",
+				"DiscoKey":   "discokey:202b9b905521e235b7b22755d76d32e79a7ced0b07325557e4815ec849ab4f15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43467", "10.65.0.27:43467", "172.17.0.1:43467"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:43:48.412446532Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         295406210098733,
+				"StableID":   "ngYVDapnJ311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29642e0e9676988578577e1236ab3217f46c4bc9817a0407562a262cce41567a",
+				"KeyExpiry":  "2026-10-26T10:43:48Z",
+				"DiscoKey":   "discokey:37f2413da0e11306cf6a97b80d2d01e200cf55f23a97226015970e5ae4c65b65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39985", "10.65.0.27:39985", "172.17.0.1:39985"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:43:48.932268868Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "767842026245996": {
+				"ID":          767842026245996,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2860439699917347,
+				"StableID":   "nvpdAEuVLP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ebf14a8a86134c38deb13d51101af7ba42e4d1cdb04d2547cff22883322ca363",
+				"KeyExpiry":  "2026-10-26T10:43:47Z",
+				"DiscoKey":   "discokey:973e9cd0281d9a4003095ff2f629d562f2d31e189ea484a83df793e6872ff270",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:47820", "10.65.0.27:47820", "172.17.0.1:47820"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:43:47.843298513Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ebf14a8a86134c38deb13d51101af7ba42e4d1cdb04d2547cff22883322ca363",
+			"MachineKey": "mkey:c2cde5ae2d8c44d1fd598b74805b6e70021cb7fba6a74b13a54a195a008e3f3c",
+			"Peers": [{
+				"ID":         767842026245996,
+				"StableID":   "nyTTWfukz611CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aa16e7437037ab8e5d58bb73f81bacafbc53227b2774050dade7aea84612959",
+				"DiscoKey":   "discokey:36b2c890d7a1806ba26d76dcd22841d82907795599e421a6cdc45469aadc8e34",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41278", "10.65.0.27:41278", "172.17.0.1:41278"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:43:45.173122416Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1806022443739163,
+				"StableID":   "npbMvX9x6F11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e3e915cc385b6058c25d636562da1e7479be400860c4fcb8d3ae8238491b303",
+				"DiscoKey":   "discokey:6cf56b6d72ec4ea9bbf19fba9432669bf62d2d4a2becf676954c7ee5e078c835",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:40148", "10.65.0.27:40148", "172.17.0.1:40148"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:43:45.686739257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7745127178510831,
+				"StableID":   "n4XjpjMnU321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3b474e0b2de97b89ca01c25669bb5e7dcaa2ee6fd400bd1057e69dbecdf3718",
+				"DiscoKey":   "discokey:1178eaf052798a38dac1a10be631a1a03e0322f0c12719828ded59e1202ead02",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:45646", "10.65.0.27:45646", "172.17.0.1:45646"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:43:46.253803586Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5186798971470242,
+				"StableID":   "nsbWkzQ7Wh11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:301c862a5d4bfa8d4a73f34a25b68040de1f036ba2e962b476ede552bea75c33",
+				"DiscoKey":   "discokey:d3ea3efe130ab7afb75d129b6ad4f27d790760f41dca9af4fcf10cfdf65dba78",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41039", "10.65.0.27:41039", "172.17.0.1:41039"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:43:46.782141487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         624684407717733,
+				"StableID":   "nYYmyCQvs511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4abd8c6e8117a613d3eb4df78021ae0f3406d10925574255f6a3491154482c7f",
+				"DiscoKey":   "discokey:a6e909ab8a5a9af4c42ae93eb649911f91e99431775c4fdfebbcb64adfdc4035",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36423", "10.65.0.27:36423", "172.17.0.1:36423"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:43:47.321616474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8349456121928427,
+				"StableID":   "nkMH894VC821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:847c8ad09d811593dc6a62c3dd586cbbb3cc1491cc28184994a68eb5a808aa15",
+				"KeyExpiry":  "2026-10-26T10:43:48Z",
+				"DiscoKey":   "discokey:202b9b905521e235b7b22755d76d32e79a7ced0b07325557e4815ec849ab4f15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43467", "10.65.0.27:43467", "172.17.0.1:43467"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:43:48.412446532Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         295406210098733,
+				"StableID":   "ngYVDapnJ311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29642e0e9676988578577e1236ab3217f46c4bc9817a0407562a262cce41567a",
+				"KeyExpiry":  "2026-10-26T10:43:48Z",
+				"DiscoKey":   "discokey:37f2413da0e11306cf6a97b80d2d01e200cf55f23a97226015970e5ae4c65b65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39985", "10.65.0.27:39985", "172.17.0.1:39985"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:43:48.932268868Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5186798971470242,
+				"StableID":   "nsbWkzQ7Wh11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       5186798971470242,
+				"Key":        "nodekey:301c862a5d4bfa8d4a73f34a25b68040de1f036ba2e962b476ede552bea75c33",
+				"DiscoKey":   "discokey:d3ea3efe130ab7afb75d129b6ad4f27d790760f41dca9af4fcf10cfdf65dba78",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41039", "10.65.0.27:41039", "172.17.0.1:41039"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:43:46.782141487Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:301c862a5d4bfa8d4a73f34a25b68040de1f036ba2e962b476ede552bea75c33",
+			"MachineKey": "mkey:779df964e7ed14b92523d160559e6c45e4d5d61a2260ceed4f88efdc4d2df46d",
+			"Peers": [{
+				"ID":         767842026245996,
+				"StableID":   "nyTTWfukz611CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aa16e7437037ab8e5d58bb73f81bacafbc53227b2774050dade7aea84612959",
+				"DiscoKey":   "discokey:36b2c890d7a1806ba26d76dcd22841d82907795599e421a6cdc45469aadc8e34",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41278", "10.65.0.27:41278", "172.17.0.1:41278"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:43:45.173122416Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1806022443739163,
+				"StableID":   "npbMvX9x6F11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e3e915cc385b6058c25d636562da1e7479be400860c4fcb8d3ae8238491b303",
+				"DiscoKey":   "discokey:6cf56b6d72ec4ea9bbf19fba9432669bf62d2d4a2becf676954c7ee5e078c835",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:40148", "10.65.0.27:40148", "172.17.0.1:40148"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:43:45.686739257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7745127178510831,
+				"StableID":   "n4XjpjMnU321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3b474e0b2de97b89ca01c25669bb5e7dcaa2ee6fd400bd1057e69dbecdf3718",
+				"DiscoKey":   "discokey:1178eaf052798a38dac1a10be631a1a03e0322f0c12719828ded59e1202ead02",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:45646", "10.65.0.27:45646", "172.17.0.1:45646"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:43:46.253803586Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         624684407717733,
+				"StableID":   "nYYmyCQvs511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4abd8c6e8117a613d3eb4df78021ae0f3406d10925574255f6a3491154482c7f",
+				"DiscoKey":   "discokey:a6e909ab8a5a9af4c42ae93eb649911f91e99431775c4fdfebbcb64adfdc4035",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36423", "10.65.0.27:36423", "172.17.0.1:36423"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:43:47.321616474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2860439699917347,
+				"StableID":   "nvpdAEuVLP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ebf14a8a86134c38deb13d51101af7ba42e4d1cdb04d2547cff22883322ca363",
+				"KeyExpiry":  "2026-10-26T10:43:47Z",
+				"DiscoKey":   "discokey:973e9cd0281d9a4003095ff2f629d562f2d31e189ea484a83df793e6872ff270",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:47820", "10.65.0.27:47820", "172.17.0.1:47820"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:43:47.843298513Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8349456121928427,
+				"StableID":   "nkMH894VC821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:847c8ad09d811593dc6a62c3dd586cbbb3cc1491cc28184994a68eb5a808aa15",
+				"KeyExpiry":  "2026-10-26T10:43:48Z",
+				"DiscoKey":   "discokey:202b9b905521e235b7b22755d76d32e79a7ced0b07325557e4815ec849ab4f15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43467", "10.65.0.27:43467", "172.17.0.1:43467"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:43:48.412446532Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         295406210098733,
+				"StableID":   "ngYVDapnJ311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29642e0e9676988578577e1236ab3217f46c4bc9817a0407562a262cce41567a",
+				"KeyExpiry":  "2026-10-26T10:43:48Z",
+				"DiscoKey":   "discokey:37f2413da0e11306cf6a97b80d2d01e200cf55f23a97226015970e5ae4c65b65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39985", "10.65.0.27:39985", "172.17.0.1:39985"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:43:48.932268868Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5186798971470242": {
+				"ID":          5186798971470242,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1806022443739163,
+				"StableID":   "npbMvX9x6F11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1806022443739163,
+				"Key":        "nodekey:0e3e915cc385b6058c25d636562da1e7479be400860c4fcb8d3ae8238491b303",
+				"DiscoKey":   "discokey:6cf56b6d72ec4ea9bbf19fba9432669bf62d2d4a2becf676954c7ee5e078c835",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:40148", "10.65.0.27:40148", "172.17.0.1:40148"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:43:45.686739257Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0e3e915cc385b6058c25d636562da1e7479be400860c4fcb8d3ae8238491b303",
+			"MachineKey": "mkey:18aadc6bd02ccaba50a79034919fd36abf7d8ef47b1d21d787647f6541726e74",
+			"Peers": [{
+				"ID":         767842026245996,
+				"StableID":   "nyTTWfukz611CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aa16e7437037ab8e5d58bb73f81bacafbc53227b2774050dade7aea84612959",
+				"DiscoKey":   "discokey:36b2c890d7a1806ba26d76dcd22841d82907795599e421a6cdc45469aadc8e34",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41278", "10.65.0.27:41278", "172.17.0.1:41278"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:43:45.173122416Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7745127178510831,
+				"StableID":   "n4XjpjMnU321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3b474e0b2de97b89ca01c25669bb5e7dcaa2ee6fd400bd1057e69dbecdf3718",
+				"DiscoKey":   "discokey:1178eaf052798a38dac1a10be631a1a03e0322f0c12719828ded59e1202ead02",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:45646", "10.65.0.27:45646", "172.17.0.1:45646"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:43:46.253803586Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5186798971470242,
+				"StableID":   "nsbWkzQ7Wh11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:301c862a5d4bfa8d4a73f34a25b68040de1f036ba2e962b476ede552bea75c33",
+				"DiscoKey":   "discokey:d3ea3efe130ab7afb75d129b6ad4f27d790760f41dca9af4fcf10cfdf65dba78",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41039", "10.65.0.27:41039", "172.17.0.1:41039"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:43:46.782141487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         624684407717733,
+				"StableID":   "nYYmyCQvs511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4abd8c6e8117a613d3eb4df78021ae0f3406d10925574255f6a3491154482c7f",
+				"DiscoKey":   "discokey:a6e909ab8a5a9af4c42ae93eb649911f91e99431775c4fdfebbcb64adfdc4035",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36423", "10.65.0.27:36423", "172.17.0.1:36423"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:43:47.321616474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2860439699917347,
+				"StableID":   "nvpdAEuVLP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ebf14a8a86134c38deb13d51101af7ba42e4d1cdb04d2547cff22883322ca363",
+				"KeyExpiry":  "2026-10-26T10:43:47Z",
+				"DiscoKey":   "discokey:973e9cd0281d9a4003095ff2f629d562f2d31e189ea484a83df793e6872ff270",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:47820", "10.65.0.27:47820", "172.17.0.1:47820"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:43:47.843298513Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8349456121928427,
+				"StableID":   "nkMH894VC821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:847c8ad09d811593dc6a62c3dd586cbbb3cc1491cc28184994a68eb5a808aa15",
+				"KeyExpiry":  "2026-10-26T10:43:48Z",
+				"DiscoKey":   "discokey:202b9b905521e235b7b22755d76d32e79a7ced0b07325557e4815ec849ab4f15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43467", "10.65.0.27:43467", "172.17.0.1:43467"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:43:48.412446532Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         295406210098733,
+				"StableID":   "ngYVDapnJ311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29642e0e9676988578577e1236ab3217f46c4bc9817a0407562a262cce41567a",
+				"KeyExpiry":  "2026-10-26T10:43:48Z",
+				"DiscoKey":   "discokey:37f2413da0e11306cf6a97b80d2d01e200cf55f23a97226015970e5ae4c65b65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39985", "10.65.0.27:39985", "172.17.0.1:39985"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:43:48.932268868Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1806022443739163": {
+				"ID":          1806022443739163,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8349456121928427,
+				"StableID":   "nkMH894VC821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:847c8ad09d811593dc6a62c3dd586cbbb3cc1491cc28184994a68eb5a808aa15",
+				"KeyExpiry":  "2026-10-26T10:43:48Z",
+				"DiscoKey":   "discokey:202b9b905521e235b7b22755d76d32e79a7ced0b07325557e4815ec849ab4f15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43467", "10.65.0.27:43467", "172.17.0.1:43467"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:43:48.412446532Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:847c8ad09d811593dc6a62c3dd586cbbb3cc1491cc28184994a68eb5a808aa15",
+			"MachineKey": "mkey:0761751ed1434902d18f722986c647511cec8639aac48b922a52a091fe057458",
+			"Peers": [{
+				"ID":         767842026245996,
+				"StableID":   "nyTTWfukz611CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aa16e7437037ab8e5d58bb73f81bacafbc53227b2774050dade7aea84612959",
+				"DiscoKey":   "discokey:36b2c890d7a1806ba26d76dcd22841d82907795599e421a6cdc45469aadc8e34",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41278", "10.65.0.27:41278", "172.17.0.1:41278"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:43:45.173122416Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1806022443739163,
+				"StableID":   "npbMvX9x6F11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e3e915cc385b6058c25d636562da1e7479be400860c4fcb8d3ae8238491b303",
+				"DiscoKey":   "discokey:6cf56b6d72ec4ea9bbf19fba9432669bf62d2d4a2becf676954c7ee5e078c835",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:40148", "10.65.0.27:40148", "172.17.0.1:40148"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:43:45.686739257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7745127178510831,
+				"StableID":   "n4XjpjMnU321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3b474e0b2de97b89ca01c25669bb5e7dcaa2ee6fd400bd1057e69dbecdf3718",
+				"DiscoKey":   "discokey:1178eaf052798a38dac1a10be631a1a03e0322f0c12719828ded59e1202ead02",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:45646", "10.65.0.27:45646", "172.17.0.1:45646"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:43:46.253803586Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5186798971470242,
+				"StableID":   "nsbWkzQ7Wh11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:301c862a5d4bfa8d4a73f34a25b68040de1f036ba2e962b476ede552bea75c33",
+				"DiscoKey":   "discokey:d3ea3efe130ab7afb75d129b6ad4f27d790760f41dca9af4fcf10cfdf65dba78",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41039", "10.65.0.27:41039", "172.17.0.1:41039"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:43:46.782141487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         624684407717733,
+				"StableID":   "nYYmyCQvs511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4abd8c6e8117a613d3eb4df78021ae0f3406d10925574255f6a3491154482c7f",
+				"DiscoKey":   "discokey:a6e909ab8a5a9af4c42ae93eb649911f91e99431775c4fdfebbcb64adfdc4035",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36423", "10.65.0.27:36423", "172.17.0.1:36423"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:43:47.321616474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2860439699917347,
+				"StableID":   "nvpdAEuVLP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ebf14a8a86134c38deb13d51101af7ba42e4d1cdb04d2547cff22883322ca363",
+				"KeyExpiry":  "2026-10-26T10:43:47Z",
+				"DiscoKey":   "discokey:973e9cd0281d9a4003095ff2f629d562f2d31e189ea484a83df793e6872ff270",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:47820", "10.65.0.27:47820", "172.17.0.1:47820"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:43:47.843298513Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         295406210098733,
+				"StableID":   "ngYVDapnJ311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29642e0e9676988578577e1236ab3217f46c4bc9817a0407562a262cce41567a",
+				"KeyExpiry":  "2026-10-26T10:43:48Z",
+				"DiscoKey":   "discokey:37f2413da0e11306cf6a97b80d2d01e200cf55f23a97226015970e5ae4c65b65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39985", "10.65.0.27:39985", "172.17.0.1:39985"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:43:48.932268868Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7745127178510831,
+				"StableID":   "n4XjpjMnU321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       7745127178510831,
+				"Key":        "nodekey:b3b474e0b2de97b89ca01c25669bb5e7dcaa2ee6fd400bd1057e69dbecdf3718",
+				"DiscoKey":   "discokey:1178eaf052798a38dac1a10be631a1a03e0322f0c12719828ded59e1202ead02",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:45646", "10.65.0.27:45646", "172.17.0.1:45646"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:43:46.253803586Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b3b474e0b2de97b89ca01c25669bb5e7dcaa2ee6fd400bd1057e69dbecdf3718",
+			"MachineKey": "mkey:47cacef09ca431e6757d2f518c40010d688f63e4d69a2ca00217195399aaa023",
+			"Peers": [{
+				"ID":         767842026245996,
+				"StableID":   "nyTTWfukz611CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aa16e7437037ab8e5d58bb73f81bacafbc53227b2774050dade7aea84612959",
+				"DiscoKey":   "discokey:36b2c890d7a1806ba26d76dcd22841d82907795599e421a6cdc45469aadc8e34",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41278", "10.65.0.27:41278", "172.17.0.1:41278"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:43:45.173122416Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1806022443739163,
+				"StableID":   "npbMvX9x6F11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e3e915cc385b6058c25d636562da1e7479be400860c4fcb8d3ae8238491b303",
+				"DiscoKey":   "discokey:6cf56b6d72ec4ea9bbf19fba9432669bf62d2d4a2becf676954c7ee5e078c835",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:40148", "10.65.0.27:40148", "172.17.0.1:40148"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:43:45.686739257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5186798971470242,
+				"StableID":   "nsbWkzQ7Wh11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:301c862a5d4bfa8d4a73f34a25b68040de1f036ba2e962b476ede552bea75c33",
+				"DiscoKey":   "discokey:d3ea3efe130ab7afb75d129b6ad4f27d790760f41dca9af4fcf10cfdf65dba78",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41039", "10.65.0.27:41039", "172.17.0.1:41039"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:43:46.782141487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         624684407717733,
+				"StableID":   "nYYmyCQvs511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4abd8c6e8117a613d3eb4df78021ae0f3406d10925574255f6a3491154482c7f",
+				"DiscoKey":   "discokey:a6e909ab8a5a9af4c42ae93eb649911f91e99431775c4fdfebbcb64adfdc4035",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36423", "10.65.0.27:36423", "172.17.0.1:36423"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:43:47.321616474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2860439699917347,
+				"StableID":   "nvpdAEuVLP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ebf14a8a86134c38deb13d51101af7ba42e4d1cdb04d2547cff22883322ca363",
+				"KeyExpiry":  "2026-10-26T10:43:47Z",
+				"DiscoKey":   "discokey:973e9cd0281d9a4003095ff2f629d562f2d31e189ea484a83df793e6872ff270",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:47820", "10.65.0.27:47820", "172.17.0.1:47820"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:43:47.843298513Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8349456121928427,
+				"StableID":   "nkMH894VC821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:847c8ad09d811593dc6a62c3dd586cbbb3cc1491cc28184994a68eb5a808aa15",
+				"KeyExpiry":  "2026-10-26T10:43:48Z",
+				"DiscoKey":   "discokey:202b9b905521e235b7b22755d76d32e79a7ced0b07325557e4815ec849ab4f15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43467", "10.65.0.27:43467", "172.17.0.1:43467"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:43:48.412446532Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         295406210098733,
+				"StableID":   "ngYVDapnJ311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29642e0e9676988578577e1236ab3217f46c4bc9817a0407562a262cce41567a",
+				"KeyExpiry":  "2026-10-26T10:43:48Z",
+				"DiscoKey":   "discokey:37f2413da0e11306cf6a97b80d2d01e200cf55f23a97226015970e5ae4c65b65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39985", "10.65.0.27:39985", "172.17.0.1:39985"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:43:48.932268868Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7745127178510831": {
+				"ID":          7745127178510831,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-allpass-grants-only-tag-src-host-alias-cidr-dst.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-allpass-grants-only-tag-src-host-alias-cidr-dst.hujson
@@ -1,0 +1,8205 @@
+// policytest-allpass-grants-only-tag-src-host-alias-cidr-dst
+//
+// tests block all-pass: tag src to host-alias-CIDR dst, grants only, tcp
+//
+// Nodes with filter rules: 7 of 7
+// Captured at:    2026-04-29T13:23:48Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-allpass-grants-only-tag-src-host-alias-cidr-dst",
+	"description":    "tests block all-pass: tag src to host-alias-CIDR dst, grants only, tcp",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T13:23:48.570400492Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                             \n  \n                                                                  \n                                                                     \n                                                \n                               \n  \n                                          \n                                                                 \n                                                                     \n                                                                      \n                                           \n                                                                          \n                                                                     \n                                                                      \n                           \n  \n                                                                     \n                              \n{\n\t\"id\":          \"policytest-allpass-grants-only-tag-src-host-alias-cidr-dst\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block all-pass: tag src to host-alias-CIDR dst, grants only, tcp\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"grants\": [\n\t\t\t{\"src\": [\"tag:client\"], \"dst\": [\"internal\"], \"ip\": [\"tcp:22\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"tag:client\", \"accept\": [\"internal:22\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-allpass-grants-only-tag-src-host-alias-cidr-dst.hujson",
+		"full_policy": {
+			"grants": [{"dst": ["internal"], "ip": ["tcp:22"], "src": ["tag:client"]}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["internal:22"], "src": "tag:client"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8763758784003192,
+				"StableID":   "nPCJfn58SB21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       8763758784003192,
+				"Key":        "nodekey:ec90473fa63c8df15d699be22067ff59e3c907df73195b1b901328b31b3dfe29",
+				"DiscoKey":   "discokey:be54d91345499bac18eaf0c802b76bb38780b7f8761279fb38fa36937341157c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56561",
+					"10.65.0.27:56561",
+					"172.17.0.1:56561",
+					"172.18.0.1:56561",
+					"172.19.0.1:56561",
+					"172.20.0.1:56561",
+					"172.21.0.1:56561"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T13:23:56.51906349Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ec90473fa63c8df15d699be22067ff59e3c907df73195b1b901328b31b3dfe29",
+			"MachineKey": "mkey:c37308ce85677646d7b00cdaffab8d06ec40dff363e082200d5ba5e4f95e2531",
+			"Peers": [{
+				"ID":         1658264361576696,
+				"StableID":   "ndy2Bzn2xD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c76c351aae7b6a8c0fc8b25a8ae62fca35acd204ee7541cf1f8d7554beb91673",
+				"DiscoKey":   "discokey:dcbd9850257038e504b6645a17d1571fcd5d69c17d8d5620c67567b9ec7bc504",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41648",
+					"10.65.0.27:41648",
+					"172.17.0.1:41648",
+					"172.18.0.1:41648",
+					"172.19.0.1:41648",
+					"172.20.0.1:41648",
+					"172.21.0.1:41648"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T13:23:53.994127006Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6570685786201527,
+				"StableID":   "nrcsfsmsJt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb38e5a6a44a2dde8a8061885c3dc154f057c14c67545d42f332e19806e15c42",
+				"DiscoKey":   "discokey:e87015294515acc3a86d768061b467d7a791c5b3cf081eb1f363b21248e7a562",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35471",
+					"10.65.0.27:35471",
+					"172.17.0.1:35471",
+					"172.18.0.1:35471",
+					"172.19.0.1:35471",
+					"172.20.0.1:35471",
+					"172.21.0.1:35471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T13:23:54.50610025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7342653510776860,
+				"StableID":   "nyDg1J4WLz11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c75ecd0f4ad102b17e501e55934feb12bcac1a9a6526933630ae771fcbf267",
+				"DiscoKey":   "discokey:1b0ac5a509eda8231833c0f68ed6ada1981a737207d91e29e06195bf7c619860",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38338",
+					"10.65.0.27:38338",
+					"172.17.0.1:38338",
+					"172.18.0.1:38338",
+					"172.19.0.1:38338",
+					"172.20.0.1:38338",
+					"172.21.0.1:38338"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T13:23:55.029549639Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3313057563901890,
+				"StableID":   "nVratSQVsS11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6cba84fbd809d08fc4b20d2e9de9f681e2cbcead13b14f2d29802191d2f7952",
+				"DiscoKey":   "discokey:3a7f920c5d8ad40e4ff33f9cb4d187ef0e98d3868afa7fb44ac8ef49e983432a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41487",
+					"10.65.0.27:41487",
+					"172.17.0.1:41487",
+					"172.18.0.1:41487",
+					"172.19.0.1:41487",
+					"172.20.0.1:41487",
+					"172.21.0.1:41487"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T13:23:55.993232503Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         800342630989507,
+				"StableID":   "nSe3fLeUF711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a870ecc3d85187fc24cc51674baaae6816874db6ebb31141135c4de4ad4dda5e",
+				"KeyExpiry":  "2026-10-26T13:23:57Z",
+				"DiscoKey":   "discokey:779717f384c9b71071b1b2e9b5fad06d76bb9d1212f0c1576624b0a882e13f57",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46494",
+					"10.65.0.27:46494",
+					"172.17.0.1:46494",
+					"172.18.0.1:46494",
+					"172.19.0.1:46494",
+					"172.20.0.1:46494",
+					"172.21.0.1:46494"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T13:23:57.068518103Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         224877126030096,
+				"StableID":   "n7LAaA9rk211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:079e831be9bc7110cb798a0a9332a1a6c58887fd28792bf8e3df305f1e4cea62",
+				"KeyExpiry":  "2026-10-26T13:23:57Z",
+				"DiscoKey":   "discokey:3aca6f2ceffa3fedf9451aeb9edd3de39a80267c2fd148995478fcb64c2fb14b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:43035",
+					"10.65.0.27:43035",
+					"172.17.0.1:43035",
+					"172.18.0.1:43035",
+					"172.19.0.1:43035",
+					"172.20.0.1:43035",
+					"172.21.0.1:43035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T13:23:57.688541413Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         991115548764406,
+				"StableID":   "nhUT8evsj811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fa2a15489baf3af226ade00801da4902a5eec1378a75f01c5fea32ce165eab0c",
+				"KeyExpiry":  "2026-10-26T13:23:58Z",
+				"DiscoKey":   "discokey:930b2720a2afe63f7c46bca55b55f194f688dcd4741a3a775332d3306c24416b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60913",
+					"10.65.0.27:60913",
+					"172.17.0.1:60913",
+					"172.18.0.1:60913",
+					"172.19.0.1:60913",
+					"172.20.0.1:60913",
+					"172.21.0.1:60913"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T13:23:58.242890963Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8763758784003192": {
+				"ID":          8763758784003192,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         991115548764406,
+				"StableID":   "nhUT8evsj811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fa2a15489baf3af226ade00801da4902a5eec1378a75f01c5fea32ce165eab0c",
+				"KeyExpiry":  "2026-10-26T13:23:58Z",
+				"DiscoKey":   "discokey:930b2720a2afe63f7c46bca55b55f194f688dcd4741a3a775332d3306c24416b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60913",
+					"10.65.0.27:60913",
+					"172.17.0.1:60913",
+					"172.18.0.1:60913",
+					"172.19.0.1:60913",
+					"172.20.0.1:60913",
+					"172.21.0.1:60913"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T13:23:58.242890963Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fa2a15489baf3af226ade00801da4902a5eec1378a75f01c5fea32ce165eab0c",
+			"MachineKey": "mkey:658d3cace493f9865ce671c96ad94530008062612754be1f1e05ba220506465f",
+			"Peers": [{
+				"ID":         1658264361576696,
+				"StableID":   "ndy2Bzn2xD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c76c351aae7b6a8c0fc8b25a8ae62fca35acd204ee7541cf1f8d7554beb91673",
+				"DiscoKey":   "discokey:dcbd9850257038e504b6645a17d1571fcd5d69c17d8d5620c67567b9ec7bc504",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41648",
+					"10.65.0.27:41648",
+					"172.17.0.1:41648",
+					"172.18.0.1:41648",
+					"172.19.0.1:41648",
+					"172.20.0.1:41648",
+					"172.21.0.1:41648"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T13:23:53.994127006Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6570685786201527,
+				"StableID":   "nrcsfsmsJt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb38e5a6a44a2dde8a8061885c3dc154f057c14c67545d42f332e19806e15c42",
+				"DiscoKey":   "discokey:e87015294515acc3a86d768061b467d7a791c5b3cf081eb1f363b21248e7a562",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35471",
+					"10.65.0.27:35471",
+					"172.17.0.1:35471",
+					"172.18.0.1:35471",
+					"172.19.0.1:35471",
+					"172.20.0.1:35471",
+					"172.21.0.1:35471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T13:23:54.50610025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7342653510776860,
+				"StableID":   "nyDg1J4WLz11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c75ecd0f4ad102b17e501e55934feb12bcac1a9a6526933630ae771fcbf267",
+				"DiscoKey":   "discokey:1b0ac5a509eda8231833c0f68ed6ada1981a737207d91e29e06195bf7c619860",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38338",
+					"10.65.0.27:38338",
+					"172.17.0.1:38338",
+					"172.18.0.1:38338",
+					"172.19.0.1:38338",
+					"172.20.0.1:38338",
+					"172.21.0.1:38338"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T13:23:55.029549639Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3313057563901890,
+				"StableID":   "nVratSQVsS11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6cba84fbd809d08fc4b20d2e9de9f681e2cbcead13b14f2d29802191d2f7952",
+				"DiscoKey":   "discokey:3a7f920c5d8ad40e4ff33f9cb4d187ef0e98d3868afa7fb44ac8ef49e983432a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41487",
+					"10.65.0.27:41487",
+					"172.17.0.1:41487",
+					"172.18.0.1:41487",
+					"172.19.0.1:41487",
+					"172.20.0.1:41487",
+					"172.21.0.1:41487"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T13:23:55.993232503Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8763758784003192,
+				"StableID":   "nPCJfn58SB21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec90473fa63c8df15d699be22067ff59e3c907df73195b1b901328b31b3dfe29",
+				"DiscoKey":   "discokey:be54d91345499bac18eaf0c802b76bb38780b7f8761279fb38fa36937341157c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56561",
+					"10.65.0.27:56561",
+					"172.17.0.1:56561",
+					"172.18.0.1:56561",
+					"172.19.0.1:56561",
+					"172.20.0.1:56561",
+					"172.21.0.1:56561"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T13:23:56.51906349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         800342630989507,
+				"StableID":   "nSe3fLeUF711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a870ecc3d85187fc24cc51674baaae6816874db6ebb31141135c4de4ad4dda5e",
+				"KeyExpiry":  "2026-10-26T13:23:57Z",
+				"DiscoKey":   "discokey:779717f384c9b71071b1b2e9b5fad06d76bb9d1212f0c1576624b0a882e13f57",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46494",
+					"10.65.0.27:46494",
+					"172.17.0.1:46494",
+					"172.18.0.1:46494",
+					"172.19.0.1:46494",
+					"172.20.0.1:46494",
+					"172.21.0.1:46494"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T13:23:57.068518103Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         224877126030096,
+				"StableID":   "n7LAaA9rk211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:079e831be9bc7110cb798a0a9332a1a6c58887fd28792bf8e3df305f1e4cea62",
+				"KeyExpiry":  "2026-10-26T13:23:57Z",
+				"DiscoKey":   "discokey:3aca6f2ceffa3fedf9451aeb9edd3de39a80267c2fd148995478fcb64c2fb14b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:43035",
+					"10.65.0.27:43035",
+					"172.17.0.1:43035",
+					"172.18.0.1:43035",
+					"172.19.0.1:43035",
+					"172.20.0.1:43035",
+					"172.21.0.1:43035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T13:23:57.688541413Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1658264361576696,
+				"StableID":   "ndy2Bzn2xD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1658264361576696,
+				"Key":        "nodekey:c76c351aae7b6a8c0fc8b25a8ae62fca35acd204ee7541cf1f8d7554beb91673",
+				"DiscoKey":   "discokey:dcbd9850257038e504b6645a17d1571fcd5d69c17d8d5620c67567b9ec7bc504",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41648",
+					"10.65.0.27:41648",
+					"172.17.0.1:41648",
+					"172.18.0.1:41648",
+					"172.19.0.1:41648",
+					"172.20.0.1:41648",
+					"172.21.0.1:41648"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T13:23:53.994127006Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c76c351aae7b6a8c0fc8b25a8ae62fca35acd204ee7541cf1f8d7554beb91673",
+			"MachineKey": "mkey:b4da22f080c473ef5f8001bbfb8b66c541dbf77ee774de8dcdf38c844b90a43b",
+			"Peers": [{
+				"ID":         6570685786201527,
+				"StableID":   "nrcsfsmsJt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb38e5a6a44a2dde8a8061885c3dc154f057c14c67545d42f332e19806e15c42",
+				"DiscoKey":   "discokey:e87015294515acc3a86d768061b467d7a791c5b3cf081eb1f363b21248e7a562",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35471",
+					"10.65.0.27:35471",
+					"172.17.0.1:35471",
+					"172.18.0.1:35471",
+					"172.19.0.1:35471",
+					"172.20.0.1:35471",
+					"172.21.0.1:35471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T13:23:54.50610025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7342653510776860,
+				"StableID":   "nyDg1J4WLz11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c75ecd0f4ad102b17e501e55934feb12bcac1a9a6526933630ae771fcbf267",
+				"DiscoKey":   "discokey:1b0ac5a509eda8231833c0f68ed6ada1981a737207d91e29e06195bf7c619860",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38338",
+					"10.65.0.27:38338",
+					"172.17.0.1:38338",
+					"172.18.0.1:38338",
+					"172.19.0.1:38338",
+					"172.20.0.1:38338",
+					"172.21.0.1:38338"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T13:23:55.029549639Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3313057563901890,
+				"StableID":   "nVratSQVsS11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6cba84fbd809d08fc4b20d2e9de9f681e2cbcead13b14f2d29802191d2f7952",
+				"DiscoKey":   "discokey:3a7f920c5d8ad40e4ff33f9cb4d187ef0e98d3868afa7fb44ac8ef49e983432a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41487",
+					"10.65.0.27:41487",
+					"172.17.0.1:41487",
+					"172.18.0.1:41487",
+					"172.19.0.1:41487",
+					"172.20.0.1:41487",
+					"172.21.0.1:41487"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T13:23:55.993232503Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8763758784003192,
+				"StableID":   "nPCJfn58SB21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec90473fa63c8df15d699be22067ff59e3c907df73195b1b901328b31b3dfe29",
+				"DiscoKey":   "discokey:be54d91345499bac18eaf0c802b76bb38780b7f8761279fb38fa36937341157c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56561",
+					"10.65.0.27:56561",
+					"172.17.0.1:56561",
+					"172.18.0.1:56561",
+					"172.19.0.1:56561",
+					"172.20.0.1:56561",
+					"172.21.0.1:56561"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T13:23:56.51906349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         800342630989507,
+				"StableID":   "nSe3fLeUF711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a870ecc3d85187fc24cc51674baaae6816874db6ebb31141135c4de4ad4dda5e",
+				"KeyExpiry":  "2026-10-26T13:23:57Z",
+				"DiscoKey":   "discokey:779717f384c9b71071b1b2e9b5fad06d76bb9d1212f0c1576624b0a882e13f57",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46494",
+					"10.65.0.27:46494",
+					"172.17.0.1:46494",
+					"172.18.0.1:46494",
+					"172.19.0.1:46494",
+					"172.20.0.1:46494",
+					"172.21.0.1:46494"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T13:23:57.068518103Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         224877126030096,
+				"StableID":   "n7LAaA9rk211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:079e831be9bc7110cb798a0a9332a1a6c58887fd28792bf8e3df305f1e4cea62",
+				"KeyExpiry":  "2026-10-26T13:23:57Z",
+				"DiscoKey":   "discokey:3aca6f2ceffa3fedf9451aeb9edd3de39a80267c2fd148995478fcb64c2fb14b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:43035",
+					"10.65.0.27:43035",
+					"172.17.0.1:43035",
+					"172.18.0.1:43035",
+					"172.19.0.1:43035",
+					"172.20.0.1:43035",
+					"172.21.0.1:43035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T13:23:57.688541413Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         991115548764406,
+				"StableID":   "nhUT8evsj811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fa2a15489baf3af226ade00801da4902a5eec1378a75f01c5fea32ce165eab0c",
+				"KeyExpiry":  "2026-10-26T13:23:58Z",
+				"DiscoKey":   "discokey:930b2720a2afe63f7c46bca55b55f194f688dcd4741a3a775332d3306c24416b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60913",
+					"10.65.0.27:60913",
+					"172.17.0.1:60913",
+					"172.18.0.1:60913",
+					"172.19.0.1:60913",
+					"172.20.0.1:60913",
+					"172.21.0.1:60913"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T13:23:58.242890963Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1658264361576696": {
+				"ID":          1658264361576696,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         800342630989507,
+				"StableID":   "nSe3fLeUF711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a870ecc3d85187fc24cc51674baaae6816874db6ebb31141135c4de4ad4dda5e",
+				"KeyExpiry":  "2026-10-26T13:23:57Z",
+				"DiscoKey":   "discokey:779717f384c9b71071b1b2e9b5fad06d76bb9d1212f0c1576624b0a882e13f57",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46494",
+					"10.65.0.27:46494",
+					"172.17.0.1:46494",
+					"172.18.0.1:46494",
+					"172.19.0.1:46494",
+					"172.20.0.1:46494",
+					"172.21.0.1:46494"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T13:23:57.068518103Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a870ecc3d85187fc24cc51674baaae6816874db6ebb31141135c4de4ad4dda5e",
+			"MachineKey": "mkey:6a340dd080eb8310b5a97d42f2b77ade555e95dbb681fff7cf83ea810a7e766a",
+			"Peers": [{
+				"ID":         1658264361576696,
+				"StableID":   "ndy2Bzn2xD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c76c351aae7b6a8c0fc8b25a8ae62fca35acd204ee7541cf1f8d7554beb91673",
+				"DiscoKey":   "discokey:dcbd9850257038e504b6645a17d1571fcd5d69c17d8d5620c67567b9ec7bc504",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41648",
+					"10.65.0.27:41648",
+					"172.17.0.1:41648",
+					"172.18.0.1:41648",
+					"172.19.0.1:41648",
+					"172.20.0.1:41648",
+					"172.21.0.1:41648"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T13:23:53.994127006Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6570685786201527,
+				"StableID":   "nrcsfsmsJt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb38e5a6a44a2dde8a8061885c3dc154f057c14c67545d42f332e19806e15c42",
+				"DiscoKey":   "discokey:e87015294515acc3a86d768061b467d7a791c5b3cf081eb1f363b21248e7a562",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35471",
+					"10.65.0.27:35471",
+					"172.17.0.1:35471",
+					"172.18.0.1:35471",
+					"172.19.0.1:35471",
+					"172.20.0.1:35471",
+					"172.21.0.1:35471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T13:23:54.50610025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7342653510776860,
+				"StableID":   "nyDg1J4WLz11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c75ecd0f4ad102b17e501e55934feb12bcac1a9a6526933630ae771fcbf267",
+				"DiscoKey":   "discokey:1b0ac5a509eda8231833c0f68ed6ada1981a737207d91e29e06195bf7c619860",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38338",
+					"10.65.0.27:38338",
+					"172.17.0.1:38338",
+					"172.18.0.1:38338",
+					"172.19.0.1:38338",
+					"172.20.0.1:38338",
+					"172.21.0.1:38338"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T13:23:55.029549639Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3313057563901890,
+				"StableID":   "nVratSQVsS11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6cba84fbd809d08fc4b20d2e9de9f681e2cbcead13b14f2d29802191d2f7952",
+				"DiscoKey":   "discokey:3a7f920c5d8ad40e4ff33f9cb4d187ef0e98d3868afa7fb44ac8ef49e983432a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41487",
+					"10.65.0.27:41487",
+					"172.17.0.1:41487",
+					"172.18.0.1:41487",
+					"172.19.0.1:41487",
+					"172.20.0.1:41487",
+					"172.21.0.1:41487"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T13:23:55.993232503Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8763758784003192,
+				"StableID":   "nPCJfn58SB21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec90473fa63c8df15d699be22067ff59e3c907df73195b1b901328b31b3dfe29",
+				"DiscoKey":   "discokey:be54d91345499bac18eaf0c802b76bb38780b7f8761279fb38fa36937341157c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56561",
+					"10.65.0.27:56561",
+					"172.17.0.1:56561",
+					"172.18.0.1:56561",
+					"172.19.0.1:56561",
+					"172.20.0.1:56561",
+					"172.21.0.1:56561"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T13:23:56.51906349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         224877126030096,
+				"StableID":   "n7LAaA9rk211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:079e831be9bc7110cb798a0a9332a1a6c58887fd28792bf8e3df305f1e4cea62",
+				"KeyExpiry":  "2026-10-26T13:23:57Z",
+				"DiscoKey":   "discokey:3aca6f2ceffa3fedf9451aeb9edd3de39a80267c2fd148995478fcb64c2fb14b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:43035",
+					"10.65.0.27:43035",
+					"172.17.0.1:43035",
+					"172.18.0.1:43035",
+					"172.19.0.1:43035",
+					"172.20.0.1:43035",
+					"172.21.0.1:43035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T13:23:57.688541413Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         991115548764406,
+				"StableID":   "nhUT8evsj811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fa2a15489baf3af226ade00801da4902a5eec1378a75f01c5fea32ce165eab0c",
+				"KeyExpiry":  "2026-10-26T13:23:58Z",
+				"DiscoKey":   "discokey:930b2720a2afe63f7c46bca55b55f194f688dcd4741a3a775332d3306c24416b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60913",
+					"10.65.0.27:60913",
+					"172.17.0.1:60913",
+					"172.18.0.1:60913",
+					"172.19.0.1:60913",
+					"172.20.0.1:60913",
+					"172.21.0.1:60913"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T13:23:58.242890963Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3313057563901890,
+				"StableID":   "nVratSQVsS11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       3313057563901890,
+				"Key":        "nodekey:c6cba84fbd809d08fc4b20d2e9de9f681e2cbcead13b14f2d29802191d2f7952",
+				"DiscoKey":   "discokey:3a7f920c5d8ad40e4ff33f9cb4d187ef0e98d3868afa7fb44ac8ef49e983432a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41487",
+					"10.65.0.27:41487",
+					"172.17.0.1:41487",
+					"172.18.0.1:41487",
+					"172.19.0.1:41487",
+					"172.20.0.1:41487",
+					"172.21.0.1:41487"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T13:23:55.993232503Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c6cba84fbd809d08fc4b20d2e9de9f681e2cbcead13b14f2d29802191d2f7952",
+			"MachineKey": "mkey:a2505cf474f9c2bcd423ccf7fa3d3e63c51bb585904b386bd95dadc4cf180f06",
+			"Peers": [{
+				"ID":         1658264361576696,
+				"StableID":   "ndy2Bzn2xD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c76c351aae7b6a8c0fc8b25a8ae62fca35acd204ee7541cf1f8d7554beb91673",
+				"DiscoKey":   "discokey:dcbd9850257038e504b6645a17d1571fcd5d69c17d8d5620c67567b9ec7bc504",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41648",
+					"10.65.0.27:41648",
+					"172.17.0.1:41648",
+					"172.18.0.1:41648",
+					"172.19.0.1:41648",
+					"172.20.0.1:41648",
+					"172.21.0.1:41648"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T13:23:53.994127006Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6570685786201527,
+				"StableID":   "nrcsfsmsJt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb38e5a6a44a2dde8a8061885c3dc154f057c14c67545d42f332e19806e15c42",
+				"DiscoKey":   "discokey:e87015294515acc3a86d768061b467d7a791c5b3cf081eb1f363b21248e7a562",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35471",
+					"10.65.0.27:35471",
+					"172.17.0.1:35471",
+					"172.18.0.1:35471",
+					"172.19.0.1:35471",
+					"172.20.0.1:35471",
+					"172.21.0.1:35471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T13:23:54.50610025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7342653510776860,
+				"StableID":   "nyDg1J4WLz11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c75ecd0f4ad102b17e501e55934feb12bcac1a9a6526933630ae771fcbf267",
+				"DiscoKey":   "discokey:1b0ac5a509eda8231833c0f68ed6ada1981a737207d91e29e06195bf7c619860",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38338",
+					"10.65.0.27:38338",
+					"172.17.0.1:38338",
+					"172.18.0.1:38338",
+					"172.19.0.1:38338",
+					"172.20.0.1:38338",
+					"172.21.0.1:38338"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T13:23:55.029549639Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8763758784003192,
+				"StableID":   "nPCJfn58SB21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec90473fa63c8df15d699be22067ff59e3c907df73195b1b901328b31b3dfe29",
+				"DiscoKey":   "discokey:be54d91345499bac18eaf0c802b76bb38780b7f8761279fb38fa36937341157c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56561",
+					"10.65.0.27:56561",
+					"172.17.0.1:56561",
+					"172.18.0.1:56561",
+					"172.19.0.1:56561",
+					"172.20.0.1:56561",
+					"172.21.0.1:56561"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T13:23:56.51906349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         800342630989507,
+				"StableID":   "nSe3fLeUF711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a870ecc3d85187fc24cc51674baaae6816874db6ebb31141135c4de4ad4dda5e",
+				"KeyExpiry":  "2026-10-26T13:23:57Z",
+				"DiscoKey":   "discokey:779717f384c9b71071b1b2e9b5fad06d76bb9d1212f0c1576624b0a882e13f57",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46494",
+					"10.65.0.27:46494",
+					"172.17.0.1:46494",
+					"172.18.0.1:46494",
+					"172.19.0.1:46494",
+					"172.20.0.1:46494",
+					"172.21.0.1:46494"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T13:23:57.068518103Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         224877126030096,
+				"StableID":   "n7LAaA9rk211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:079e831be9bc7110cb798a0a9332a1a6c58887fd28792bf8e3df305f1e4cea62",
+				"KeyExpiry":  "2026-10-26T13:23:57Z",
+				"DiscoKey":   "discokey:3aca6f2ceffa3fedf9451aeb9edd3de39a80267c2fd148995478fcb64c2fb14b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:43035",
+					"10.65.0.27:43035",
+					"172.17.0.1:43035",
+					"172.18.0.1:43035",
+					"172.19.0.1:43035",
+					"172.20.0.1:43035",
+					"172.21.0.1:43035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T13:23:57.688541413Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         991115548764406,
+				"StableID":   "nhUT8evsj811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fa2a15489baf3af226ade00801da4902a5eec1378a75f01c5fea32ce165eab0c",
+				"KeyExpiry":  "2026-10-26T13:23:58Z",
+				"DiscoKey":   "discokey:930b2720a2afe63f7c46bca55b55f194f688dcd4741a3a775332d3306c24416b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60913",
+					"10.65.0.27:60913",
+					"172.17.0.1:60913",
+					"172.18.0.1:60913",
+					"172.19.0.1:60913",
+					"172.20.0.1:60913",
+					"172.21.0.1:60913"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T13:23:58.242890963Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3313057563901890": {
+				"ID":          3313057563901890,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6570685786201527,
+				"StableID":   "nrcsfsmsJt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       6570685786201527,
+				"Key":        "nodekey:cb38e5a6a44a2dde8a8061885c3dc154f057c14c67545d42f332e19806e15c42",
+				"DiscoKey":   "discokey:e87015294515acc3a86d768061b467d7a791c5b3cf081eb1f363b21248e7a562",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35471",
+					"10.65.0.27:35471",
+					"172.17.0.1:35471",
+					"172.18.0.1:35471",
+					"172.19.0.1:35471",
+					"172.20.0.1:35471",
+					"172.21.0.1:35471"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T13:23:54.50610025Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cb38e5a6a44a2dde8a8061885c3dc154f057c14c67545d42f332e19806e15c42",
+			"MachineKey": "mkey:086a6808f56a09780f6e37d44382d129e68a334292daaad8d87ea861e02fcd7b",
+			"Peers": [{
+				"ID":         1658264361576696,
+				"StableID":   "ndy2Bzn2xD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c76c351aae7b6a8c0fc8b25a8ae62fca35acd204ee7541cf1f8d7554beb91673",
+				"DiscoKey":   "discokey:dcbd9850257038e504b6645a17d1571fcd5d69c17d8d5620c67567b9ec7bc504",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41648",
+					"10.65.0.27:41648",
+					"172.17.0.1:41648",
+					"172.18.0.1:41648",
+					"172.19.0.1:41648",
+					"172.20.0.1:41648",
+					"172.21.0.1:41648"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T13:23:53.994127006Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7342653510776860,
+				"StableID":   "nyDg1J4WLz11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c75ecd0f4ad102b17e501e55934feb12bcac1a9a6526933630ae771fcbf267",
+				"DiscoKey":   "discokey:1b0ac5a509eda8231833c0f68ed6ada1981a737207d91e29e06195bf7c619860",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38338",
+					"10.65.0.27:38338",
+					"172.17.0.1:38338",
+					"172.18.0.1:38338",
+					"172.19.0.1:38338",
+					"172.20.0.1:38338",
+					"172.21.0.1:38338"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T13:23:55.029549639Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3313057563901890,
+				"StableID":   "nVratSQVsS11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6cba84fbd809d08fc4b20d2e9de9f681e2cbcead13b14f2d29802191d2f7952",
+				"DiscoKey":   "discokey:3a7f920c5d8ad40e4ff33f9cb4d187ef0e98d3868afa7fb44ac8ef49e983432a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41487",
+					"10.65.0.27:41487",
+					"172.17.0.1:41487",
+					"172.18.0.1:41487",
+					"172.19.0.1:41487",
+					"172.20.0.1:41487",
+					"172.21.0.1:41487"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T13:23:55.993232503Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8763758784003192,
+				"StableID":   "nPCJfn58SB21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec90473fa63c8df15d699be22067ff59e3c907df73195b1b901328b31b3dfe29",
+				"DiscoKey":   "discokey:be54d91345499bac18eaf0c802b76bb38780b7f8761279fb38fa36937341157c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56561",
+					"10.65.0.27:56561",
+					"172.17.0.1:56561",
+					"172.18.0.1:56561",
+					"172.19.0.1:56561",
+					"172.20.0.1:56561",
+					"172.21.0.1:56561"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T13:23:56.51906349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         800342630989507,
+				"StableID":   "nSe3fLeUF711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a870ecc3d85187fc24cc51674baaae6816874db6ebb31141135c4de4ad4dda5e",
+				"KeyExpiry":  "2026-10-26T13:23:57Z",
+				"DiscoKey":   "discokey:779717f384c9b71071b1b2e9b5fad06d76bb9d1212f0c1576624b0a882e13f57",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46494",
+					"10.65.0.27:46494",
+					"172.17.0.1:46494",
+					"172.18.0.1:46494",
+					"172.19.0.1:46494",
+					"172.20.0.1:46494",
+					"172.21.0.1:46494"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T13:23:57.068518103Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         224877126030096,
+				"StableID":   "n7LAaA9rk211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:079e831be9bc7110cb798a0a9332a1a6c58887fd28792bf8e3df305f1e4cea62",
+				"KeyExpiry":  "2026-10-26T13:23:57Z",
+				"DiscoKey":   "discokey:3aca6f2ceffa3fedf9451aeb9edd3de39a80267c2fd148995478fcb64c2fb14b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:43035",
+					"10.65.0.27:43035",
+					"172.17.0.1:43035",
+					"172.18.0.1:43035",
+					"172.19.0.1:43035",
+					"172.20.0.1:43035",
+					"172.21.0.1:43035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T13:23:57.688541413Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         991115548764406,
+				"StableID":   "nhUT8evsj811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fa2a15489baf3af226ade00801da4902a5eec1378a75f01c5fea32ce165eab0c",
+				"KeyExpiry":  "2026-10-26T13:23:58Z",
+				"DiscoKey":   "discokey:930b2720a2afe63f7c46bca55b55f194f688dcd4741a3a775332d3306c24416b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60913",
+					"10.65.0.27:60913",
+					"172.17.0.1:60913",
+					"172.18.0.1:60913",
+					"172.19.0.1:60913",
+					"172.20.0.1:60913",
+					"172.21.0.1:60913"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T13:23:58.242890963Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6570685786201527": {
+				"ID":          6570685786201527,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7342653510776860,
+				"StableID":   "nyDg1J4WLz11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       7342653510776860,
+				"Key":        "nodekey:07c75ecd0f4ad102b17e501e55934feb12bcac1a9a6526933630ae771fcbf267",
+				"DiscoKey":   "discokey:1b0ac5a509eda8231833c0f68ed6ada1981a737207d91e29e06195bf7c619860",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38338",
+					"10.65.0.27:38338",
+					"172.17.0.1:38338",
+					"172.18.0.1:38338",
+					"172.19.0.1:38338",
+					"172.20.0.1:38338",
+					"172.21.0.1:38338"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T13:23:55.029549639Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:07c75ecd0f4ad102b17e501e55934feb12bcac1a9a6526933630ae771fcbf267",
+			"MachineKey": "mkey:30d5ad0bd989307af82a65c797b73c160f06ce3ad9efe6f176cd314f0547c66f",
+			"Peers": [{
+				"ID":         1658264361576696,
+				"StableID":   "ndy2Bzn2xD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c76c351aae7b6a8c0fc8b25a8ae62fca35acd204ee7541cf1f8d7554beb91673",
+				"DiscoKey":   "discokey:dcbd9850257038e504b6645a17d1571fcd5d69c17d8d5620c67567b9ec7bc504",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41648",
+					"10.65.0.27:41648",
+					"172.17.0.1:41648",
+					"172.18.0.1:41648",
+					"172.19.0.1:41648",
+					"172.20.0.1:41648",
+					"172.21.0.1:41648"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T13:23:53.994127006Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6570685786201527,
+				"StableID":   "nrcsfsmsJt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb38e5a6a44a2dde8a8061885c3dc154f057c14c67545d42f332e19806e15c42",
+				"DiscoKey":   "discokey:e87015294515acc3a86d768061b467d7a791c5b3cf081eb1f363b21248e7a562",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35471",
+					"10.65.0.27:35471",
+					"172.17.0.1:35471",
+					"172.18.0.1:35471",
+					"172.19.0.1:35471",
+					"172.20.0.1:35471",
+					"172.21.0.1:35471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T13:23:54.50610025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3313057563901890,
+				"StableID":   "nVratSQVsS11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6cba84fbd809d08fc4b20d2e9de9f681e2cbcead13b14f2d29802191d2f7952",
+				"DiscoKey":   "discokey:3a7f920c5d8ad40e4ff33f9cb4d187ef0e98d3868afa7fb44ac8ef49e983432a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41487",
+					"10.65.0.27:41487",
+					"172.17.0.1:41487",
+					"172.18.0.1:41487",
+					"172.19.0.1:41487",
+					"172.20.0.1:41487",
+					"172.21.0.1:41487"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T13:23:55.993232503Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8763758784003192,
+				"StableID":   "nPCJfn58SB21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec90473fa63c8df15d699be22067ff59e3c907df73195b1b901328b31b3dfe29",
+				"DiscoKey":   "discokey:be54d91345499bac18eaf0c802b76bb38780b7f8761279fb38fa36937341157c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56561",
+					"10.65.0.27:56561",
+					"172.17.0.1:56561",
+					"172.18.0.1:56561",
+					"172.19.0.1:56561",
+					"172.20.0.1:56561",
+					"172.21.0.1:56561"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T13:23:56.51906349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         800342630989507,
+				"StableID":   "nSe3fLeUF711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a870ecc3d85187fc24cc51674baaae6816874db6ebb31141135c4de4ad4dda5e",
+				"KeyExpiry":  "2026-10-26T13:23:57Z",
+				"DiscoKey":   "discokey:779717f384c9b71071b1b2e9b5fad06d76bb9d1212f0c1576624b0a882e13f57",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46494",
+					"10.65.0.27:46494",
+					"172.17.0.1:46494",
+					"172.18.0.1:46494",
+					"172.19.0.1:46494",
+					"172.20.0.1:46494",
+					"172.21.0.1:46494"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T13:23:57.068518103Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         224877126030096,
+				"StableID":   "n7LAaA9rk211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:079e831be9bc7110cb798a0a9332a1a6c58887fd28792bf8e3df305f1e4cea62",
+				"KeyExpiry":  "2026-10-26T13:23:57Z",
+				"DiscoKey":   "discokey:3aca6f2ceffa3fedf9451aeb9edd3de39a80267c2fd148995478fcb64c2fb14b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:43035",
+					"10.65.0.27:43035",
+					"172.17.0.1:43035",
+					"172.18.0.1:43035",
+					"172.19.0.1:43035",
+					"172.20.0.1:43035",
+					"172.21.0.1:43035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T13:23:57.688541413Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         991115548764406,
+				"StableID":   "nhUT8evsj811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fa2a15489baf3af226ade00801da4902a5eec1378a75f01c5fea32ce165eab0c",
+				"KeyExpiry":  "2026-10-26T13:23:58Z",
+				"DiscoKey":   "discokey:930b2720a2afe63f7c46bca55b55f194f688dcd4741a3a775332d3306c24416b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60913",
+					"10.65.0.27:60913",
+					"172.17.0.1:60913",
+					"172.18.0.1:60913",
+					"172.19.0.1:60913",
+					"172.20.0.1:60913",
+					"172.21.0.1:60913"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T13:23:58.242890963Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7342653510776860": {
+				"ID":          7342653510776860,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-allpass-grants-only-tag-src-host-alias-non-topology-dst.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-allpass-grants-only-tag-src-host-alias-non-topology-dst.hujson
@@ -1,0 +1,6383 @@
+// policytest-allpass-grants-only-tag-src-host-alias-non-topology-dst
+//
+// tests block all-pass: tag src to host-alias dst (single IP not in topology), grants only, tcp
+// Captured at:    2026-04-29T13:25:26Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-allpass-grants-only-tag-src-host-alias-non-topology-dst",
+	"description":    "tests block all-pass: tag src to host-alias dst (single IP not in topology), grants only, tcp",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T13:25:26.317084802Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"capture_error":  "stabilization: tsdaemon: WaitFilterStable: timeout after 2m0s; 7/8 nodes stable",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                                     \n  \n                                                                        \n                                                                    \n                                                       \n  \n                                                                      \n                                                                      \n                                                               \n                                                                  \n                   \n{\n\t\"id\":          \"policytest-allpass-grants-only-tag-src-host-alias-non-topology-dst\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block all-pass: tag src to host-alias dst (single IP not in topology), grants only, tcp\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"grants\": [\n\t\t\t{\"src\": [\"tag:client\"], \"dst\": [\"prodbox\"], \"ip\": [\"tcp:22\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"tag:client\", \"accept\": [\"prodbox:22\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-allpass-grants-only-tag-src-host-alias-non-topology-dst.hujson",
+		"full_policy": {
+			"grants": [{"dst": ["prodbox"], "ip": ["tcp:22"], "src": ["tag:client"]}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["prodbox:22"], "src": "tag:client"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         3871109660777278,
+			"StableID":   "nMpNjDVEEX11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       3871109660777278,
+			"Key":        "nodekey:1eb1065aed7e4dc81586b376de24cf22ed0557461641c8add2a4dee43dd8e258",
+			"DiscoKey":   "discokey:60a56cb167d6d04a1cc6db5cad480693b667e02d3811cafbd0b17b270e562b47",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints": [
+				"77.164.248.136:51784",
+				"10.65.0.27:51784",
+				"172.17.0.1:51784",
+				"172.18.0.1:51784",
+				"172.19.0.1:51784",
+				"172.20.0.1:51784",
+				"172.21.0.1:51784",
+				"172.22.0.1:51784",
+				"172.23.0.1:51784",
+				"172.24.0.1:51784",
+				"172.25.0.1:51784",
+				"172.26.0.1:51784",
+				"172.27.0.1:51784"
+			],
+			"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T13:25:34.264158842Z",
+			"Tags":              ["tag:server"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:1eb1065aed7e4dc81586b376de24cf22ed0557461641c8add2a4dee43dd8e258",
+		"MachineKey":        "mkey:6f32d1f087cd639bd48b8c100c265031dfef59c277ae3ca9774709fee7315554",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3871109660777278": {
+			"ID":          3871109660777278,
+			"LoginName":   "beedrill.tail78f774.ts.net",
+			"DisplayName": "beedrill"
+		}}
+	}}, "bulbasaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1507056346933304,
+			"StableID":   "njcyhFpYmC11CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:8965f8e187e0ef067d2060b4f76985a2b3ead21627297a2f6c54473995e4b333",
+			"KeyExpiry":  "2026-10-26T13:25:35Z",
+			"DiscoKey":   "discokey:249c116aa8304d8f44ce43badfe9bbda63db98d8c0bcf30f5030faefd649d632",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints": [
+				"77.164.248.136:56964",
+				"10.65.0.27:56964",
+				"172.17.0.1:56964",
+				"172.18.0.1:56964",
+				"172.19.0.1:56964",
+				"172.20.0.1:56964",
+				"172.21.0.1:56964",
+				"172.22.0.1:56964",
+				"172.23.0.1:56964",
+				"172.24.0.1:56964",
+				"172.25.0.1:56964",
+				"172.26.0.1:56964",
+				"172.27.0.1:56964"
+			],
+			"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T13:25:35.910650169Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:8965f8e187e0ef067d2060b4f76985a2b3ead21627297a2f6c54473995e4b333",
+		"MachineKey":        "mkey:3d2c4a43860b9764b2236062bab6e6e5425d41ccb4d7cb680699663efc045f1b",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}}
+	}}, "charmander": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         3418309898225313,
+			"StableID":   "nrwiFsCAhT11CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       3418309898225313,
+			"Key":        "nodekey:ef534c471d64b446f7f8b6f6624bd936aa6d390c418e1e7ba34e550bfab5c434",
+			"DiscoKey":   "discokey:c59f5e874b65f8ac91e986c9c992b6bb183fa30af34329cd886429bdff39d766",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"Endpoints": [
+				"77.164.248.136:40138",
+				"10.65.0.27:40138",
+				"172.17.0.1:40138",
+				"172.18.0.1:40138",
+				"172.19.0.1:40138",
+				"172.20.0.1:40138",
+				"172.21.0.1:40138",
+				"172.22.0.1:40138",
+				"172.23.0.1:40138",
+				"172.24.0.1:40138",
+				"172.25.0.1:40138",
+				"172.26.0.1:40138",
+				"172.27.0.1:40138"
+			],
+			"Hostinfo": {
+				"Hostname":    "charmander",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T13:25:32.034720128Z",
+			"Tags":              ["tag:exit"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:ef534c471d64b446f7f8b6f6624bd936aa6d390c418e1e7ba34e550bfab5c434",
+		"MachineKey":        "mkey:69b96d2c5f2ff408da60f6712cfe704eb5163003563f9b6557e703ab771c6479",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3418309898225313": {
+			"ID":          3418309898225313,
+			"LoginName":   "charmander.tail78f774.ts.net",
+			"DisplayName": "charmander"
+		}}
+	}}, "kakuna": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         496364240222816,
+			"StableID":   "nhoxBXeos411CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       496364240222816,
+			"Key":        "nodekey:28bf08fdf57044ace941127d7de73e9d585564973750c8f2bf020e9e425b963f",
+			"DiscoKey":   "discokey:a1b6d8fcf79a001c3514e0721af5517b6b012614df7e71356e0af1ed54e73573",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints": [
+				"77.164.248.136:40389",
+				"10.65.0.27:40389",
+				"172.17.0.1:40389",
+				"172.18.0.1:40389",
+				"172.19.0.1:40389",
+				"172.20.0.1:40389",
+				"172.21.0.1:40389",
+				"172.22.0.1:40389",
+				"172.23.0.1:40389",
+				"172.24.0.1:40389",
+				"172.25.0.1:40389",
+				"172.26.0.1:40389",
+				"172.27.0.1:40389"
+			],
+			"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T13:25:33.719416297Z",
+			"Tags":              ["tag:prod"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:28bf08fdf57044ace941127d7de73e9d585564973750c8f2bf020e9e425b963f",
+		"MachineKey":        "mkey:9674d4fa3e828f0b4cd306a7eac8b43c601186dc8ea3bb8eaf70e8349870a537",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"496364240222816": {
+			"ID":          496364240222816,
+			"LoginName":   "kakuna.tail78f774.ts.net",
+			"DisplayName": "kakuna"
+		}}
+	}}, "squirtle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         693291091192673,
+			"StableID":   "nkgZfiazQ611CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       693291091192673,
+			"Key":        "nodekey:e8ce3ff1693f2533db3afd1f44d95e64bc414f7f63e96632acbf0ad5ec3e827c",
+			"DiscoKey":   "discokey:5f54115d8b5659e2d16561359b2a3d1324ad4c3b505579783301f9b909e30f30",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"Endpoints": [
+				"77.164.248.136:41208",
+				"10.65.0.27:41208",
+				"172.17.0.1:41208",
+				"172.18.0.1:41208",
+				"172.19.0.1:41208",
+				"172.20.0.1:41208",
+				"172.21.0.1:41208",
+				"172.22.0.1:41208",
+				"172.23.0.1:41208",
+				"172.24.0.1:41208",
+				"172.25.0.1:41208",
+				"172.26.0.1:41208",
+				"172.27.0.1:41208"
+			],
+			"Hostinfo": {
+				"Hostname":    "squirtle",
+				"RoutableIPs": ["10.33.0.0/16"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T13:25:32.571343225Z",
+			"Tags":              ["tag:router"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:e8ce3ff1693f2533db3afd1f44d95e64bc414f7f63e96632acbf0ad5ec3e827c",
+		"MachineKey":        "mkey:8804427a9e1e5f4bfdc7d504e85464ad2020c920f6e33e50d319dc85e0cc0e46",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"693291091192673": {
+			"ID":          693291091192673,
+			"LoginName":   "squirtle.tail78f774.ts.net",
+			"DisplayName": "squirtle"
+		}}
+	}}, "venusaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         986201451918793,
+			"StableID":   "niqdDiqeh811CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:a6c41af210546d88928dbcb310011a64eab21470cf030e81778935783cc14857",
+			"KeyExpiry":  "2026-10-26T13:25:35Z",
+			"DiscoKey":   "discokey:dea74fa25374c9445e8e9f81c618387942e2df77dc81b2e0b4e976124b43e715",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints": [
+				"77.164.248.136:35632",
+				"10.65.0.27:35632",
+				"172.17.0.1:35632",
+				"172.18.0.1:35632",
+				"172.19.0.1:35632",
+				"172.20.0.1:35632",
+				"172.21.0.1:35632",
+				"172.22.0.1:35632",
+				"172.23.0.1:35632",
+				"172.24.0.1:35632",
+				"172.25.0.1:35632",
+				"172.26.0.1:35632",
+				"172.27.0.1:35632"
+			],
+			"Hostinfo": {"Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T13:25:35.337403056Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:a6c41af210546d88928dbcb310011a64eab21470cf030e81778935783cc14857",
+		"MachineKey":        "mkey:89ebebe69b71bd7eb42df75195a43a9a65e7cea5489e88e961c9e7096748662d",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}}
+	}}, "weedle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5936702509505431,
+			"StableID":   "nAYyUG7kMo11CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       5936702509505431,
+			"Key":        "nodekey:622c38eb7f7bfc118b2010e3d668bcf58632538f61595eacc19638cae1785115",
+			"DiscoKey":   "discokey:5493fbd7fa1610e56cce7cc8e1f7bcc9b277d74bd80f1cf093edaf7df553e423",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints": [
+				"77.164.248.136:38085",
+				"10.65.0.27:38085",
+				"172.17.0.1:38085",
+				"172.18.0.1:38085",
+				"172.19.0.1:38085",
+				"172.20.0.1:38085",
+				"172.21.0.1:38085",
+				"172.22.0.1:38085",
+				"172.23.0.1:38085",
+				"172.24.0.1:38085",
+				"172.25.0.1:38085",
+				"172.26.0.1:38085",
+				"172.27.0.1:38085"
+			],
+			"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T13:25:33.180384122Z",
+			"Tags":              ["tag:client"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:622c38eb7f7bfc118b2010e3d668bcf58632538f61595eacc19638cae1785115",
+		"MachineKey":        "mkey:747803dd6a244b742d7c86011267ab0ca208a9f1e42263e8e2f0d11b57ee950c",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"5936702509505431": {
+			"ID":          5936702509505431,
+			"LoginName":   "weedle.tail78f774.ts.net",
+			"DisplayName": "weedle"
+		}}
+	}}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-allpass-grants-only-tag-src-ip-literal-dst.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-allpass-grants-only-tag-src-ip-literal-dst.hujson
@@ -1,0 +1,7335 @@
+// policytest-allpass-grants-only-tag-src-ip-literal-dst
+//
+// tests block all-pass: tag src to ipv4 literal dst (real node), grants only, tcp
+//
+// Nodes with filter rules: 1 of 8
+// Captured at:    2026-04-29T13:22:06Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-allpass-grants-only-tag-src-ip-literal-dst",
+	"description":    "tests block all-pass: tag src to ipv4 literal dst (real node), grants only, tcp",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T13:22:06.889692535Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                        \n  \n                                                   \n                                                                        \n                                                                     \n                                                                  \n  \n                                                                        \n                                                                  \n                                                                     \n                                                           \n{\n\t\"id\":          \"policytest-allpass-grants-only-tag-src-ip-literal-dst\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block all-pass: tag src to ipv4 literal dst (real node), grants only, tcp\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"grants\": [\n\t\t\t{\"src\": [\"tag:client\"], \"dst\": [\"100.64.0.16\"], \"ip\": [\"tcp:22\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"tag:client\", \"accept\": [\"100.64.0.16:22\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-allpass-grants-only-tag-src-ip-literal-dst.hujson",
+		"full_policy": {
+			"grants": [{"dst": ["100.64.0.16"], "ip": ["tcp:22"], "src": ["tag:client"]}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["100.64.0.16:22"], "src": "tag:client"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {"packet_filter_rules": [{
+		"SrcIPs":   ["100.64.0.14", "fd7a:115c:a1e0::e"],
+		"DstPorts": [{"IP": "100.64.0.16", "Ports": {"First": 22, "Last": 22}}],
+		"IPProto":  [6]
+	}], "packet_filter_matches": [{
+		"IPProto": [6],
+		"Srcs":    ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+		"SrcCaps": null,
+		"Dsts":    [{"Net": "100.64.0.16/32", "Ports": {"First": 22, "Last": 22}}],
+		"Caps":    []
+	}], "netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8514013482182995,
+			"StableID":   "nphxYRh1V921CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       8514013482182995,
+			"Key":        "nodekey:3a55de28583cf0ae3cf7ffb69c4643ca65701af359dfa92955c1ccb6c5368603",
+			"DiscoKey":   "discokey:eb305ac178c98962bf8fb245ed2937dfc59d760eb08b7d3ed8941eb599fb8274",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints": [
+				"77.164.248.136:53463",
+				"10.65.0.27:53463",
+				"172.17.0.1:53463",
+				"172.18.0.1:53463",
+				"172.19.0.1:53463",
+				"172.20.0.1:53463",
+				"172.21.0.1:53463",
+				"172.22.0.1:53463",
+				"172.23.0.1:53463"
+			],
+			"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T13:22:14.517690495Z",
+			"Tags":              ["tag:server"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:3a55de28583cf0ae3cf7ffb69c4643ca65701af359dfa92955c1ccb6c5368603",
+		"MachineKey": "mkey:e143a2e5c36721eb9eede48d16d5512cba7817923c1a1057ea8414d35e6f1514",
+		"Peers": [{
+			"ID":         7382612930190540,
+			"StableID":   "nPe65wibez11CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:6563f4516a70e52cbc939c25e2c43b19572cd4389ac0184490a9ac53ccff382d",
+			"DiscoKey":   "discokey:6c67b9b0a6766e93ae2ab57a6b53b1e875bb159989ba2164e9d9872b3d4eb859",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints": [
+				"77.164.248.136:36446",
+				"10.65.0.27:36446",
+				"172.17.0.1:36446",
+				"172.18.0.1:36446",
+				"172.19.0.1:36446",
+				"172.20.0.1:36446",
+				"172.21.0.1:36446",
+				"172.22.0.1:36446",
+				"172.23.0.1:36446"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957}
+			]},
+			"Created":              "2026-04-29T13:22:13.448789016Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:client"],
+			"Online":               true,
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		}],
+		"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter": [{
+			"IPProto": [6],
+			"Srcs":    ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"SrcCaps": null,
+			"Dsts":    [{"Net": "100.64.0.16/32", "Ports": {"First": 22, "Last": 22}}],
+			"Caps":    []
+		}],
+		"PacketFilterRules": [{
+			"SrcIPs":   ["100.64.0.14", "fd7a:115c:a1e0::e"],
+			"DstPorts": [{"IP": "100.64.0.16", "Ports": {"First": 22, "Last": 22}}],
+			"IPProto":  [6]
+		}],
+		"SSHPolicy":       {"rules": []},
+		"CollectServices": false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "8514013482182995": {
+			"ID":          8514013482182995,
+			"LoginName":   "beedrill.tail78f774.ts.net",
+			"DisplayName": "beedrill"
+		}}
+	}}, "bulbasaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         3364717195681603,
+			"StableID":   "nGRge5RtGT11CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:5530d2ea129f47f2361a28fa253c02cc79e2f0cda059412e368cf7645efab41c",
+			"KeyExpiry":  "2026-10-26T13:22:16Z",
+			"DiscoKey":   "discokey:33e4637d4aaefc339a1443dc126d9f48b361fed593752b424cd04c278023c459",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints": [
+				"77.164.248.136:50957",
+				"10.65.0.27:50957",
+				"172.17.0.1:50957",
+				"172.18.0.1:50957",
+				"172.19.0.1:50957",
+				"172.20.0.1:50957",
+				"172.21.0.1:50957",
+				"172.22.0.1:50957",
+				"172.23.0.1:50957"
+			],
+			"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T13:22:16.177192796Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:5530d2ea129f47f2361a28fa253c02cc79e2f0cda059412e368cf7645efab41c",
+		"MachineKey":        "mkey:49007805f2e7862ab017a3d88d7963bdf507f7110a012b744cdeb1d12d2e2500",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}}
+	}}, "charmander": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8857962415646210,
+			"StableID":   "nfRC1qenAC21CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       8857962415646210,
+			"Key":        "nodekey:6c8f6d4cbfe6c1948daea434bd1f7454be57f0cbecacb6b2bdc2bc2ad45d966e",
+			"DiscoKey":   "discokey:66ec4ac430ffa23d771dcb859dcf9ba5acd2b1f823da893ceac637d233801064",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"Endpoints": [
+				"77.164.248.136:43327",
+				"10.65.0.27:43327",
+				"172.17.0.1:43327",
+				"172.18.0.1:43327",
+				"172.19.0.1:43327",
+				"172.20.0.1:43327",
+				"172.21.0.1:43327",
+				"172.22.0.1:43327",
+				"172.23.0.1:43327"
+			],
+			"Hostinfo": {
+				"Hostname":    "charmander",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T13:22:12.39242837Z",
+			"Tags":              ["tag:exit"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:6c8f6d4cbfe6c1948daea434bd1f7454be57f0cbecacb6b2bdc2bc2ad45d966e",
+		"MachineKey":        "mkey:b8d9901d1e55021098fc61f3a55c7729c6c48cc0baf5973e3687f585b9b4df75",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"8857962415646210": {
+			"ID":          8857962415646210,
+			"LoginName":   "charmander.tail78f774.ts.net",
+			"DisplayName": "charmander"
+		}}
+	}}, "ivysaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7316428926946088,
+			"StableID":   "nh7kLXBd8z11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:20d33eaee8cfdd2991bd84eaea7759e1c77d63cec16cddaa796d4e2fd0166f31",
+			"KeyExpiry":  "2026-10-26T13:22:15Z",
+			"DiscoKey":   "discokey:76c852b552e5cd61e11fff4d0de57bfef3abd61eb6203d258cfd3cc4ad6e235f",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints": [
+				"77.164.248.136:57620",
+				"10.65.0.27:57620",
+				"172.17.0.1:57620",
+				"172.18.0.1:57620",
+				"172.19.0.1:57620",
+				"172.20.0.1:57620",
+				"172.21.0.1:57620",
+				"172.22.0.1:57620",
+				"172.23.0.1:57620"
+			],
+			"Hostinfo": {"Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T13:22:15.079021937Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:20d33eaee8cfdd2991bd84eaea7759e1c77d63cec16cddaa796d4e2fd0166f31",
+		"MachineKey":        "mkey:0e656b46a8e523c4dba30c3d2fcb8a832fff98c484c557f54bb23c72011e9b78",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}}
+	}}, "kakuna": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7935183457570474,
+			"StableID":   "n7dQPCprx421CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       7935183457570474,
+			"Key":        "nodekey:dffab356e6d1917621e4d5f3d414673039cf32a038a5b7da656b24d703fedf77",
+			"DiscoKey":   "discokey:b513a1f0206e31915e8c955f0cedaaa336448982649e6b555883f21639272c64",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints": [
+				"77.164.248.136:47040",
+				"10.65.0.27:47040",
+				"172.17.0.1:47040",
+				"172.18.0.1:47040",
+				"172.19.0.1:47040",
+				"172.20.0.1:47040",
+				"172.21.0.1:47040",
+				"172.22.0.1:47040",
+				"172.23.0.1:47040"
+			],
+			"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T13:22:13.981140533Z",
+			"Tags":              ["tag:prod"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:dffab356e6d1917621e4d5f3d414673039cf32a038a5b7da656b24d703fedf77",
+		"MachineKey":        "mkey:60df6d8ba6f24477e090d25bae8ba07ed29615044d3243b32dc7e787372c4f78",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"7935183457570474": {
+			"ID":          7935183457570474,
+			"LoginName":   "kakuna.tail78f774.ts.net",
+			"DisplayName": "kakuna"
+		}}
+	}}, "squirtle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2744559066403374,
+			"StableID":   "nTm2Qwu1SN11CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       2744559066403374,
+			"Key":        "nodekey:f9dc1821cf97bdd3d0b09fe99981da9a99170ce83fa99bbaf1d72cd93e584d1b",
+			"DiscoKey":   "discokey:29bd825359f4b538ab50212f9a6d91beced8b59e0e1cdf3cfb68fe4a0fedf524",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"Endpoints": [
+				"77.164.248.136:43052",
+				"10.65.0.27:43052",
+				"172.17.0.1:43052",
+				"172.18.0.1:43052",
+				"172.19.0.1:43052",
+				"172.20.0.1:43052",
+				"172.21.0.1:43052",
+				"172.22.0.1:43052",
+				"172.23.0.1:43052"
+			],
+			"Hostinfo": {
+				"Hostname":    "squirtle",
+				"RoutableIPs": ["10.33.0.0/16"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T13:22:12.908722441Z",
+			"Tags":              ["tag:router"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:f9dc1821cf97bdd3d0b09fe99981da9a99170ce83fa99bbaf1d72cd93e584d1b",
+		"MachineKey":        "mkey:2b0cb803b9c8585a568c21e0e9ea95822565b4b97d1406352408b90ebd126a33",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"2744559066403374": {
+			"ID":          2744559066403374,
+			"LoginName":   "squirtle.tail78f774.ts.net",
+			"DisplayName": "squirtle"
+		}}
+	}}, "venusaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7501315608881157,
+			"StableID":   "nJ9tJnqMa121CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:b782a4c0ecbe38987f72c9df49130275d7c943a36414f025b1838405f1de4c1f",
+			"KeyExpiry":  "2026-10-26T13:22:15Z",
+			"DiscoKey":   "discokey:7bdc8ec2d7b84b4ddfe8392a3dfd1f24ccd5097261a52394dad8cd82dfe73b63",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints": [
+				"77.164.248.136:47363",
+				"10.65.0.27:47363",
+				"172.17.0.1:47363",
+				"172.18.0.1:47363",
+				"172.19.0.1:47363",
+				"172.20.0.1:47363",
+				"172.21.0.1:47363",
+				"172.22.0.1:47363",
+				"172.23.0.1:47363"
+			],
+			"Hostinfo": {"Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T13:22:15.625557174Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:b782a4c0ecbe38987f72c9df49130275d7c943a36414f025b1838405f1de4c1f",
+		"MachineKey":        "mkey:e6b039e6e3da4b8b8010a0b68e833370f13eb60459d5a346737eef0c1678d065",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}}
+	}}, "weedle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7382612930190540,
+			"StableID":   "nPe65wibez11CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       7382612930190540,
+			"Key":        "nodekey:6563f4516a70e52cbc939c25e2c43b19572cd4389ac0184490a9ac53ccff382d",
+			"DiscoKey":   "discokey:6c67b9b0a6766e93ae2ab57a6b53b1e875bb159989ba2164e9d9872b3d4eb859",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints": [
+				"77.164.248.136:36446",
+				"10.65.0.27:36446",
+				"172.17.0.1:36446",
+				"172.18.0.1:36446",
+				"172.19.0.1:36446",
+				"172.20.0.1:36446",
+				"172.21.0.1:36446",
+				"172.22.0.1:36446",
+				"172.23.0.1:36446"
+			],
+			"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T13:22:13.448789016Z",
+			"Tags":              ["tag:client"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:6563f4516a70e52cbc939c25e2c43b19572cd4389ac0184490a9ac53ccff382d",
+		"MachineKey": "mkey:9223e0d8df13699210d9086f8bff9fbabb6fb0fd5f631802858a37668c7e8d58",
+		"Peers": [{
+			"ID":         8514013482182995,
+			"StableID":   "nphxYRh1V921CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:3a55de28583cf0ae3cf7ffb69c4643ca65701af359dfa92955c1ccb6c5368603",
+			"DiscoKey":   "discokey:eb305ac178c98962bf8fb245ed2937dfc59d760eb08b7d3ed8941eb599fb8274",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints": [
+				"77.164.248.136:53463",
+				"10.65.0.27:53463",
+				"172.17.0.1:53463",
+				"172.18.0.1:53463",
+				"172.19.0.1:53463",
+				"172.20.0.1:53463",
+				"172.21.0.1:53463",
+				"172.22.0.1:53463",
+				"172.23.0.1:53463"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358}
+			]},
+			"Created":              "2026-04-29T13:22:14.517690495Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:server"],
+			"Online":               true,
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "7382612930190540": {
+			"ID":          7382612930190540,
+			"LoginName":   "weedle.tail78f774.ts.net",
+			"DisplayName": "weedle"
+		}}
+	}}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-allpass-grants-only-tag-src-ipv6-literal-dst.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-allpass-grants-only-tag-src-ipv6-literal-dst.hujson
@@ -1,0 +1,7245 @@
+// policytest-allpass-grants-only-tag-src-ipv6-literal-dst
+//
+// tests block all-pass: tag src to ipv6 literal dst (real node), grants only, tcp
+// Captured at:    2026-04-29T13:24:39Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-allpass-grants-only-tag-src-ipv6-literal-dst",
+	"description":    "tests block all-pass: tag src to ipv6 literal dst (real node), grants only, tcp",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T13:24:39.812045471Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                          \n  \n                                                                   \n                                                                     \n                                                                     \n  \n                                                                  \n                                                             \n{\n\t\"id\":          \"policytest-allpass-grants-only-tag-src-ipv6-literal-dst\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block all-pass: tag src to ipv6 literal dst (real node), grants only, tcp\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"grants\": [\n\t\t\t{\"src\": [\"tag:client\"], \"dst\": [\"fd7a:115c:a1e0::10\"], \"ip\": [\"tcp:22\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"tag:client\", \"accept\": [\"[fd7a:115c:a1e0::10]:22\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-allpass-grants-only-tag-src-ipv6-literal-dst.hujson",
+		"full_policy": {
+			"grants": [
+				{"dst": ["fd7a:115c:a1e0::10"], "ip": ["tcp:22"], "src": ["tag:client"]}
+			],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["[fd7a:115c:a1e0::10]:22"], "src": "tag:client"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2059810081576152,
+			"StableID":   "nm1QReit5H11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       2059810081576152,
+			"Key":        "nodekey:bf57408082d82a2538eb44ad81e3ade1a1f71bc590d9db42d235c40201e63f70",
+			"DiscoKey":   "discokey:df4ab79b7978f76c32ca5a3c8c5bbd2409a76cbec52689fa849b2ac72383f97c",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints": [
+				"77.164.248.136:54132",
+				"10.65.0.27:54132",
+				"172.17.0.1:54132",
+				"172.18.0.1:54132",
+				"172.19.0.1:54132",
+				"172.20.0.1:54132",
+				"172.21.0.1:54132",
+				"172.22.0.1:54132",
+				"172.23.0.1:54132"
+			],
+			"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T13:24:47.704043287Z",
+			"Tags":              ["tag:server"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:bf57408082d82a2538eb44ad81e3ade1a1f71bc590d9db42d235c40201e63f70",
+		"MachineKey":        "mkey:11e7905ec7d0580a8cbebb98eb9aa895e653de717fe3e98b4c3d6f92a907a16f",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"2059810081576152": {
+			"ID":          2059810081576152,
+			"LoginName":   "beedrill.tail78f774.ts.net",
+			"DisplayName": "beedrill"
+		}}
+	}}, "bulbasaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5687280689185440,
+			"StableID":   "nX8tKkDnQm11CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:f947684dd93a5c90ed9c3a949bbc09decf0a8c2eb27a26e7fa338450ec7dba0e",
+			"KeyExpiry":  "2026-10-26T13:24:49Z",
+			"DiscoKey":   "discokey:a906a5adb48298542cc10f171cba511f9635ee3885a37e05c623d7e8f814af2c",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints": [
+				"77.164.248.136:37670",
+				"10.65.0.27:37670",
+				"172.17.0.1:37670",
+				"172.18.0.1:37670",
+				"172.19.0.1:37670",
+				"172.20.0.1:37670",
+				"172.21.0.1:37670",
+				"172.22.0.1:37670",
+				"172.23.0.1:37670"
+			],
+			"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T13:24:49.330041232Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:f947684dd93a5c90ed9c3a949bbc09decf0a8c2eb27a26e7fa338450ec7dba0e",
+		"MachineKey":        "mkey:8010c9e51cc31fcfe63d9a3e687238a107019894608804404f62bb0d5e5ece7f",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}}
+	}}, "charmander": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         375975686131411,
+			"StableID":   "npf5v8FHw311CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       375975686131411,
+			"Key":        "nodekey:6c8726a65f99d4a751bcb234e084c9270888ccd2879825aa4341c3df0806a951",
+			"DiscoKey":   "discokey:9875565d50d61bd2bf9f8831a89244221f46dc4211d3ce2360f069723bbbf918",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"Endpoints": [
+				"77.164.248.136:53088",
+				"10.65.0.27:53088",
+				"172.17.0.1:53088",
+				"172.18.0.1:53088",
+				"172.19.0.1:53088",
+				"172.20.0.1:53088",
+				"172.21.0.1:53088",
+				"172.22.0.1:53088",
+				"172.23.0.1:53088"
+			],
+			"Hostinfo": {
+				"Hostname":    "charmander",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T13:24:45.575310185Z",
+			"Tags":              ["tag:exit"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:6c8726a65f99d4a751bcb234e084c9270888ccd2879825aa4341c3df0806a951",
+		"MachineKey":        "mkey:25177bc07f12d3d40696f22cbcf7572d0f8f2fde98edf0e06c6f663012847e09",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"375975686131411": {
+			"ID":          375975686131411,
+			"LoginName":   "charmander.tail78f774.ts.net",
+			"DisplayName": "charmander"
+		}}
+	}}, "ivysaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5301490972850955,
+			"StableID":   "nLmjALB4Qi11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:64a76fe72134ba258e8479e70b758f322e4da1333e919b91b4813f5229ca1b70",
+			"KeyExpiry":  "2026-10-26T13:24:48Z",
+			"DiscoKey":   "discokey:d33b57bb7c1970efb2169887d010185d51c48ac3534bb77cb8cc0e035c15952a",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints": [
+				"77.164.248.136:57373",
+				"10.65.0.27:57373",
+				"172.17.0.1:57373",
+				"172.18.0.1:57373",
+				"172.19.0.1:57373",
+				"172.20.0.1:57373",
+				"172.21.0.1:57373",
+				"172.22.0.1:57373",
+				"172.23.0.1:57373"
+			],
+			"Hostinfo": {"Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T13:24:48.252270384Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:64a76fe72134ba258e8479e70b758f322e4da1333e919b91b4813f5229ca1b70",
+		"MachineKey":        "mkey:dedd55f2a117f1f36909350665daa0261281f97c31ebb350b61c842c893d5d55",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}}
+	}}, "kakuna": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         478626797055194,
+			"StableID":   "n3KN5Simj411CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       478626797055194,
+			"Key":        "nodekey:9284d5793869f24579017b7b054bf681a3d0d10a0e7317359d453b7c9f4eb721",
+			"DiscoKey":   "discokey:cfc39613c1357a5e36b29d4d1ed3f2dd72a3c1041a046ff39b9067f169731e03",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints": [
+				"77.164.248.136:36000",
+				"10.65.0.27:36000",
+				"172.17.0.1:36000",
+				"172.18.0.1:36000",
+				"172.19.0.1:36000",
+				"172.20.0.1:36000",
+				"172.21.0.1:36000",
+				"172.22.0.1:36000",
+				"172.23.0.1:36000"
+			],
+			"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T13:24:47.163280594Z",
+			"Tags":              ["tag:prod"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:9284d5793869f24579017b7b054bf681a3d0d10a0e7317359d453b7c9f4eb721",
+		"MachineKey":        "mkey:1cbe07ce64a009715fd8431c3badcaf379781fe9837dc018af8dc9309fcd4143",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"478626797055194": {
+			"ID":          478626797055194,
+			"LoginName":   "kakuna.tail78f774.ts.net",
+			"DisplayName": "kakuna"
+		}}
+	}}, "squirtle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8803661211190079,
+			"StableID":   "nvAfWbFCkB21CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       8803661211190079,
+			"Key":        "nodekey:ae18698a5a9c0f02afbe9eaa95051a713530cd3044bac56ce9aa02fd95300345",
+			"DiscoKey":   "discokey:e0ad193a3b6dba7eb3b3629c5b90f9cf42a981f347e88fe6a4f986bb8c001d29",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"Endpoints": [
+				"77.164.248.136:40501",
+				"10.65.0.27:40501",
+				"172.17.0.1:40501",
+				"172.18.0.1:40501",
+				"172.19.0.1:40501",
+				"172.20.0.1:40501",
+				"172.21.0.1:40501",
+				"172.22.0.1:40501",
+				"172.23.0.1:40501"
+			],
+			"Hostinfo": {
+				"Hostname":    "squirtle",
+				"RoutableIPs": ["10.33.0.0/16"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T13:24:46.139579075Z",
+			"Tags":              ["tag:router"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:ae18698a5a9c0f02afbe9eaa95051a713530cd3044bac56ce9aa02fd95300345",
+		"MachineKey":        "mkey:2615b8e5cf69e9a5b29267ea80c2326a7a54a4f82e58b54f50e0026af828b317",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"8803661211190079": {
+			"ID":          8803661211190079,
+			"LoginName":   "squirtle.tail78f774.ts.net",
+			"DisplayName": "squirtle"
+		}}
+	}}, "venusaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1710271768236185,
+			"StableID":   "nE1JcUwaME11CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:4aacb850c6ff378f7935f142bab630de28a284c37d07f12dce92bc3351ce981c",
+			"KeyExpiry":  "2026-10-26T13:24:48Z",
+			"DiscoKey":   "discokey:e5ad58c91ed02977e274b1b2e36037520ecb4d93d3ba972a6a1dc316e3175f54",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints": [
+				"77.164.248.136:45860",
+				"10.65.0.27:45860",
+				"172.17.0.1:45860",
+				"172.18.0.1:45860",
+				"172.19.0.1:45860",
+				"172.20.0.1:45860",
+				"172.21.0.1:45860",
+				"172.22.0.1:45860",
+				"172.23.0.1:45860"
+			],
+			"Hostinfo": {"Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T13:24:48.817925706Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:4aacb850c6ff378f7935f142bab630de28a284c37d07f12dce92bc3351ce981c",
+		"MachineKey":        "mkey:3584dbf0f06ec04c1ddb751bba2398f97ca67c4041ecd7aee269df9dfb1e3553",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}}
+	}}, "weedle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         6980522722453197,
+			"StableID":   "nWokJiVVWw11CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       6980522722453197,
+			"Key":        "nodekey:e6adaf2222e413a0f0f8001f214500a6deb25081f27bdcc29a59815d16364177",
+			"DiscoKey":   "discokey:fbd829dfe548e489978426549d82407705d4dca742924fab2633a362f683a257",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints": [
+				"77.164.248.136:37970",
+				"10.65.0.27:37970",
+				"172.17.0.1:37970",
+				"172.18.0.1:37970",
+				"172.19.0.1:37970",
+				"172.20.0.1:37970",
+				"172.21.0.1:37970",
+				"172.22.0.1:37970",
+				"172.23.0.1:37970"
+			],
+			"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T13:24:46.650573287Z",
+			"Tags":              ["tag:client"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:e6adaf2222e413a0f0f8001f214500a6deb25081f27bdcc29a59815d16364177",
+		"MachineKey":        "mkey:54e28f67f43d55aba21c024d2cac734213e510dda302e0dd12c7d482396ac402",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"6980522722453197": {
+			"ID":          6980522722453197,
+			"LoginName":   "weedle.tail78f774.ts.net",
+			"DisplayName": "weedle"
+		}}
+	}}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-allpass-grants-only-tag-src-prefix32-dst.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-allpass-grants-only-tag-src-prefix32-dst.hujson
@@ -1,0 +1,9355 @@
+// policytest-allpass-grants-only-tag-src-prefix32-dst
+//
+// tests block all-pass: tag src to /32 prefix dst (real node), grants only, tcp
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T13:23:04Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-allpass-grants-only-tag-src-prefix32-dst",
+	"description":    "tests block all-pass: tag src to /32 prefix dst (real node), grants only, tcp",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T13:23:04.469073721Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                      \n  \n                                                   \n                                                                     \n                                                                      \n                                                                     \n                                                           \n  \n                                 \n                                                                     \n                                                                    \n                                                                       \n                                                         \n                                                                  \n                                                               \n{\n\t\"id\":          \"policytest-allpass-grants-only-tag-src-prefix32-dst\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block all-pass: tag src to /32 prefix dst (real node), grants only, tcp\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"grants\": [\n\t\t\t{\"src\": [\"tag:client\"], \"dst\": [\"100.64.0.16/32\"], \"ip\": [\"tcp:22\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"tag:client\", \"accept\": [\"100.64.0.16/32:22\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-allpass-grants-only-tag-src-prefix32-dst.hujson",
+		"full_policy": {
+			"grants": [{"dst": ["100.64.0.16/32"], "ip": ["tcp:22"], "src": ["tag:client"]}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["100.64.0.16/32:22"], "src": "tag:client"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1297996733480456,
+				"StableID":   "n7eHZ3Bs8B11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1297996733480456,
+				"Key":        "nodekey:0413ae110fb631cf7339adc2e31b43ce811fd6546cc995045a189c9fa6077b03",
+				"DiscoKey":   "discokey:8085b48e9f3c3bb0454d7a884643d1e02f6273fa71b3163a16bd8085484ecd31",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46504",
+					"10.65.0.27:46504",
+					"172.17.0.1:46504",
+					"172.18.0.1:46504",
+					"172.19.0.1:46504",
+					"172.20.0.1:46504",
+					"172.21.0.1:46504"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T13:23:12.246411509Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0413ae110fb631cf7339adc2e31b43ce811fd6546cc995045a189c9fa6077b03",
+			"MachineKey": "mkey:728fc1e73df51d4cce1e778670fba0039d3fb408f26e7de10db7d032e4bab87f",
+			"Peers": [{
+				"ID":         2993996623721309,
+				"StableID":   "nrPMBSDzNQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b30def7598178cda1f07976539e579db950c9bb373ae521c20e146c320a422d",
+				"DiscoKey":   "discokey:ab19894c50f48420aed8c760e609544fa453bfda6bb7a70a576a7e6acb4b383b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39098",
+					"10.65.0.27:39098",
+					"172.17.0.1:39098",
+					"172.18.0.1:39098",
+					"172.19.0.1:39098",
+					"172.20.0.1:39098",
+					"172.21.0.1:39098"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T13:23:10.007919593Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3245310561740693,
+				"StableID":   "nYSEJiooLS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3c4111111cbfb114117eedf759c3863e7d63915c36a2724bb77c3cb8cf24e30d",
+				"DiscoKey":   "discokey:c68a1d83c483fd0963a7d5c0a34766a1717af5d7575ad9878fcb93da33449a41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59765",
+					"10.65.0.27:59765",
+					"172.17.0.1:59765",
+					"172.18.0.1:59765",
+					"172.19.0.1:59765",
+					"172.20.0.1:59765",
+					"172.21.0.1:59765"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T13:23:10.57998951Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7319947075620418,
+				"StableID":   "n1YJ6ebDAz11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b32c52b9b40fca6ec37717abb59d913192e57db63a50966f40fe1a10ac654d6a",
+				"DiscoKey":   "discokey:e55d432560d4e0919c8c9585ecfff7b48e789864e2d07c6663edfcc7647ff255",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39995",
+					"10.65.0.27:39995",
+					"172.17.0.1:39995",
+					"172.18.0.1:39995",
+					"172.19.0.1:39995",
+					"172.20.0.1:39995",
+					"172.21.0.1:39995"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T13:23:11.111969309Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6144713412823430,
+				"StableID":   "nFw6ihCxyp11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49d9201f82fef80f21122a075c1e8df29e2a14d81f7faf933549d296c20f0568",
+				"DiscoKey":   "discokey:64ad24385cf7c77f654937aa8c435f656ecf879bb303ade4e6c0a00d5dd35b36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51605",
+					"10.65.0.27:51605",
+					"172.17.0.1:51605",
+					"172.18.0.1:51605",
+					"172.19.0.1:51605",
+					"172.20.0.1:51605",
+					"172.21.0.1:51605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T13:23:11.738974092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3064666804138192,
+				"StableID":   "nqDM2pbzvQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6848a62e31c1e076d68579a3a0af964a1100da79cb16f1aa83c468385c39f00d",
+				"KeyExpiry":  "2026-10-26T13:23:13Z",
+				"DiscoKey":   "discokey:43180941c7f25aa26f913f751a4634519843449994ec7a05e3f6dbff67a76e34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59012",
+					"10.65.0.27:59012",
+					"172.17.0.1:59012",
+					"172.18.0.1:59012",
+					"172.19.0.1:59012",
+					"172.20.0.1:59012",
+					"172.21.0.1:59012"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T13:23:13.184994324Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2074875462877,
+				"StableID":   "nCY6eCWw1111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:87ab8f3839dda0dbf9d8136d42adf455d99a6f2ed00bd6be3af7bf785c13bd5f",
+				"KeyExpiry":  "2026-10-26T13:23:13Z",
+				"DiscoKey":   "discokey:f15a6fb7d69950744bcec2f55717b63df2f7634c1e6d197c28a2e2ef44be7005",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48503",
+					"10.65.0.27:48503",
+					"172.17.0.1:48503",
+					"172.18.0.1:48503",
+					"172.19.0.1:48503",
+					"172.20.0.1:48503",
+					"172.21.0.1:48503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T13:23:13.696357025Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6323419955543119,
+				"StableID":   "nk3Mw8XtNr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:477b8de9219e5489c53e278ea8281cc08e10608c223e131ac10f4cbcb9c91849",
+				"KeyExpiry":  "2026-10-26T13:23:14Z",
+				"DiscoKey":   "discokey:a40528a1b1bef40036c256e7aaab502254b244c7c40e5c0820bf6df75ee29613",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57275",
+					"10.65.0.27:57275",
+					"172.17.0.1:57275",
+					"172.18.0.1:57275",
+					"172.19.0.1:57275",
+					"172.20.0.1:57275",
+					"172.21.0.1:57275"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T13:23:14.235000202Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1297996733480456": {
+				"ID":          1297996733480456,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6323419955543119,
+				"StableID":   "nk3Mw8XtNr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:477b8de9219e5489c53e278ea8281cc08e10608c223e131ac10f4cbcb9c91849",
+				"KeyExpiry":  "2026-10-26T13:23:14Z",
+				"DiscoKey":   "discokey:a40528a1b1bef40036c256e7aaab502254b244c7c40e5c0820bf6df75ee29613",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57275",
+					"10.65.0.27:57275",
+					"172.17.0.1:57275",
+					"172.18.0.1:57275",
+					"172.19.0.1:57275",
+					"172.20.0.1:57275",
+					"172.21.0.1:57275"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T13:23:14.235000202Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:477b8de9219e5489c53e278ea8281cc08e10608c223e131ac10f4cbcb9c91849",
+			"MachineKey": "mkey:f28737b254b36d8bda69cb3e39fa6015ca1ef53c735bd05d7fc06d37d90b197d",
+			"Peers": [{
+				"ID":         2993996623721309,
+				"StableID":   "nrPMBSDzNQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b30def7598178cda1f07976539e579db950c9bb373ae521c20e146c320a422d",
+				"DiscoKey":   "discokey:ab19894c50f48420aed8c760e609544fa453bfda6bb7a70a576a7e6acb4b383b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39098",
+					"10.65.0.27:39098",
+					"172.17.0.1:39098",
+					"172.18.0.1:39098",
+					"172.19.0.1:39098",
+					"172.20.0.1:39098",
+					"172.21.0.1:39098"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T13:23:10.007919593Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3245310561740693,
+				"StableID":   "nYSEJiooLS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3c4111111cbfb114117eedf759c3863e7d63915c36a2724bb77c3cb8cf24e30d",
+				"DiscoKey":   "discokey:c68a1d83c483fd0963a7d5c0a34766a1717af5d7575ad9878fcb93da33449a41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59765",
+					"10.65.0.27:59765",
+					"172.17.0.1:59765",
+					"172.18.0.1:59765",
+					"172.19.0.1:59765",
+					"172.20.0.1:59765",
+					"172.21.0.1:59765"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T13:23:10.57998951Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7319947075620418,
+				"StableID":   "n1YJ6ebDAz11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b32c52b9b40fca6ec37717abb59d913192e57db63a50966f40fe1a10ac654d6a",
+				"DiscoKey":   "discokey:e55d432560d4e0919c8c9585ecfff7b48e789864e2d07c6663edfcc7647ff255",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39995",
+					"10.65.0.27:39995",
+					"172.17.0.1:39995",
+					"172.18.0.1:39995",
+					"172.19.0.1:39995",
+					"172.20.0.1:39995",
+					"172.21.0.1:39995"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T13:23:11.111969309Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6144713412823430,
+				"StableID":   "nFw6ihCxyp11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49d9201f82fef80f21122a075c1e8df29e2a14d81f7faf933549d296c20f0568",
+				"DiscoKey":   "discokey:64ad24385cf7c77f654937aa8c435f656ecf879bb303ade4e6c0a00d5dd35b36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51605",
+					"10.65.0.27:51605",
+					"172.17.0.1:51605",
+					"172.18.0.1:51605",
+					"172.19.0.1:51605",
+					"172.20.0.1:51605",
+					"172.21.0.1:51605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T13:23:11.738974092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1297996733480456,
+				"StableID":   "n7eHZ3Bs8B11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0413ae110fb631cf7339adc2e31b43ce811fd6546cc995045a189c9fa6077b03",
+				"DiscoKey":   "discokey:8085b48e9f3c3bb0454d7a884643d1e02f6273fa71b3163a16bd8085484ecd31",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46504",
+					"10.65.0.27:46504",
+					"172.17.0.1:46504",
+					"172.18.0.1:46504",
+					"172.19.0.1:46504",
+					"172.20.0.1:46504",
+					"172.21.0.1:46504"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T13:23:12.246411509Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3064666804138192,
+				"StableID":   "nqDM2pbzvQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6848a62e31c1e076d68579a3a0af964a1100da79cb16f1aa83c468385c39f00d",
+				"KeyExpiry":  "2026-10-26T13:23:13Z",
+				"DiscoKey":   "discokey:43180941c7f25aa26f913f751a4634519843449994ec7a05e3f6dbff67a76e34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59012",
+					"10.65.0.27:59012",
+					"172.17.0.1:59012",
+					"172.18.0.1:59012",
+					"172.19.0.1:59012",
+					"172.20.0.1:59012",
+					"172.21.0.1:59012"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T13:23:13.184994324Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2074875462877,
+				"StableID":   "nCY6eCWw1111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:87ab8f3839dda0dbf9d8136d42adf455d99a6f2ed00bd6be3af7bf785c13bd5f",
+				"KeyExpiry":  "2026-10-26T13:23:13Z",
+				"DiscoKey":   "discokey:f15a6fb7d69950744bcec2f55717b63df2f7634c1e6d197c28a2e2ef44be7005",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48503",
+					"10.65.0.27:48503",
+					"172.17.0.1:48503",
+					"172.18.0.1:48503",
+					"172.19.0.1:48503",
+					"172.20.0.1:48503",
+					"172.21.0.1:48503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T13:23:13.696357025Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2993996623721309,
+				"StableID":   "nrPMBSDzNQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       2993996623721309,
+				"Key":        "nodekey:9b30def7598178cda1f07976539e579db950c9bb373ae521c20e146c320a422d",
+				"DiscoKey":   "discokey:ab19894c50f48420aed8c760e609544fa453bfda6bb7a70a576a7e6acb4b383b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39098",
+					"10.65.0.27:39098",
+					"172.17.0.1:39098",
+					"172.18.0.1:39098",
+					"172.19.0.1:39098",
+					"172.20.0.1:39098",
+					"172.21.0.1:39098"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T13:23:10.007919593Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9b30def7598178cda1f07976539e579db950c9bb373ae521c20e146c320a422d",
+			"MachineKey": "mkey:ad35609fd13da9d0d88258c17cb59f0a773303048592e8bc1d57b40febe8b84e",
+			"Peers": [{
+				"ID":         3245310561740693,
+				"StableID":   "nYSEJiooLS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3c4111111cbfb114117eedf759c3863e7d63915c36a2724bb77c3cb8cf24e30d",
+				"DiscoKey":   "discokey:c68a1d83c483fd0963a7d5c0a34766a1717af5d7575ad9878fcb93da33449a41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59765",
+					"10.65.0.27:59765",
+					"172.17.0.1:59765",
+					"172.18.0.1:59765",
+					"172.19.0.1:59765",
+					"172.20.0.1:59765",
+					"172.21.0.1:59765"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T13:23:10.57998951Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7319947075620418,
+				"StableID":   "n1YJ6ebDAz11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b32c52b9b40fca6ec37717abb59d913192e57db63a50966f40fe1a10ac654d6a",
+				"DiscoKey":   "discokey:e55d432560d4e0919c8c9585ecfff7b48e789864e2d07c6663edfcc7647ff255",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39995",
+					"10.65.0.27:39995",
+					"172.17.0.1:39995",
+					"172.18.0.1:39995",
+					"172.19.0.1:39995",
+					"172.20.0.1:39995",
+					"172.21.0.1:39995"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T13:23:11.111969309Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6144713412823430,
+				"StableID":   "nFw6ihCxyp11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49d9201f82fef80f21122a075c1e8df29e2a14d81f7faf933549d296c20f0568",
+				"DiscoKey":   "discokey:64ad24385cf7c77f654937aa8c435f656ecf879bb303ade4e6c0a00d5dd35b36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51605",
+					"10.65.0.27:51605",
+					"172.17.0.1:51605",
+					"172.18.0.1:51605",
+					"172.19.0.1:51605",
+					"172.20.0.1:51605",
+					"172.21.0.1:51605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T13:23:11.738974092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1297996733480456,
+				"StableID":   "n7eHZ3Bs8B11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0413ae110fb631cf7339adc2e31b43ce811fd6546cc995045a189c9fa6077b03",
+				"DiscoKey":   "discokey:8085b48e9f3c3bb0454d7a884643d1e02f6273fa71b3163a16bd8085484ecd31",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46504",
+					"10.65.0.27:46504",
+					"172.17.0.1:46504",
+					"172.18.0.1:46504",
+					"172.19.0.1:46504",
+					"172.20.0.1:46504",
+					"172.21.0.1:46504"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T13:23:12.246411509Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3064666804138192,
+				"StableID":   "nqDM2pbzvQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6848a62e31c1e076d68579a3a0af964a1100da79cb16f1aa83c468385c39f00d",
+				"KeyExpiry":  "2026-10-26T13:23:13Z",
+				"DiscoKey":   "discokey:43180941c7f25aa26f913f751a4634519843449994ec7a05e3f6dbff67a76e34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59012",
+					"10.65.0.27:59012",
+					"172.17.0.1:59012",
+					"172.18.0.1:59012",
+					"172.19.0.1:59012",
+					"172.20.0.1:59012",
+					"172.21.0.1:59012"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T13:23:13.184994324Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2074875462877,
+				"StableID":   "nCY6eCWw1111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:87ab8f3839dda0dbf9d8136d42adf455d99a6f2ed00bd6be3af7bf785c13bd5f",
+				"KeyExpiry":  "2026-10-26T13:23:13Z",
+				"DiscoKey":   "discokey:f15a6fb7d69950744bcec2f55717b63df2f7634c1e6d197c28a2e2ef44be7005",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48503",
+					"10.65.0.27:48503",
+					"172.17.0.1:48503",
+					"172.18.0.1:48503",
+					"172.19.0.1:48503",
+					"172.20.0.1:48503",
+					"172.21.0.1:48503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T13:23:13.696357025Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6323419955543119,
+				"StableID":   "nk3Mw8XtNr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:477b8de9219e5489c53e278ea8281cc08e10608c223e131ac10f4cbcb9c91849",
+				"KeyExpiry":  "2026-10-26T13:23:14Z",
+				"DiscoKey":   "discokey:a40528a1b1bef40036c256e7aaab502254b244c7c40e5c0820bf6df75ee29613",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57275",
+					"10.65.0.27:57275",
+					"172.17.0.1:57275",
+					"172.18.0.1:57275",
+					"172.19.0.1:57275",
+					"172.20.0.1:57275",
+					"172.21.0.1:57275"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T13:23:14.235000202Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2993996623721309": {
+				"ID":          2993996623721309,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3064666804138192,
+				"StableID":   "nqDM2pbzvQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6848a62e31c1e076d68579a3a0af964a1100da79cb16f1aa83c468385c39f00d",
+				"KeyExpiry":  "2026-10-26T13:23:13Z",
+				"DiscoKey":   "discokey:43180941c7f25aa26f913f751a4634519843449994ec7a05e3f6dbff67a76e34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59012",
+					"10.65.0.27:59012",
+					"172.17.0.1:59012",
+					"172.18.0.1:59012",
+					"172.19.0.1:59012",
+					"172.20.0.1:59012",
+					"172.21.0.1:59012"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T13:23:13.184994324Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6848a62e31c1e076d68579a3a0af964a1100da79cb16f1aa83c468385c39f00d",
+			"MachineKey": "mkey:1e70d24e7d86c0562efd3166723be646d90c6ef0596cd935f96a3453c9cf8d02",
+			"Peers": [{
+				"ID":         2993996623721309,
+				"StableID":   "nrPMBSDzNQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b30def7598178cda1f07976539e579db950c9bb373ae521c20e146c320a422d",
+				"DiscoKey":   "discokey:ab19894c50f48420aed8c760e609544fa453bfda6bb7a70a576a7e6acb4b383b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39098",
+					"10.65.0.27:39098",
+					"172.17.0.1:39098",
+					"172.18.0.1:39098",
+					"172.19.0.1:39098",
+					"172.20.0.1:39098",
+					"172.21.0.1:39098"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T13:23:10.007919593Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3245310561740693,
+				"StableID":   "nYSEJiooLS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3c4111111cbfb114117eedf759c3863e7d63915c36a2724bb77c3cb8cf24e30d",
+				"DiscoKey":   "discokey:c68a1d83c483fd0963a7d5c0a34766a1717af5d7575ad9878fcb93da33449a41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59765",
+					"10.65.0.27:59765",
+					"172.17.0.1:59765",
+					"172.18.0.1:59765",
+					"172.19.0.1:59765",
+					"172.20.0.1:59765",
+					"172.21.0.1:59765"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T13:23:10.57998951Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7319947075620418,
+				"StableID":   "n1YJ6ebDAz11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b32c52b9b40fca6ec37717abb59d913192e57db63a50966f40fe1a10ac654d6a",
+				"DiscoKey":   "discokey:e55d432560d4e0919c8c9585ecfff7b48e789864e2d07c6663edfcc7647ff255",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39995",
+					"10.65.0.27:39995",
+					"172.17.0.1:39995",
+					"172.18.0.1:39995",
+					"172.19.0.1:39995",
+					"172.20.0.1:39995",
+					"172.21.0.1:39995"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T13:23:11.111969309Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6144713412823430,
+				"StableID":   "nFw6ihCxyp11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49d9201f82fef80f21122a075c1e8df29e2a14d81f7faf933549d296c20f0568",
+				"DiscoKey":   "discokey:64ad24385cf7c77f654937aa8c435f656ecf879bb303ade4e6c0a00d5dd35b36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51605",
+					"10.65.0.27:51605",
+					"172.17.0.1:51605",
+					"172.18.0.1:51605",
+					"172.19.0.1:51605",
+					"172.20.0.1:51605",
+					"172.21.0.1:51605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T13:23:11.738974092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1297996733480456,
+				"StableID":   "n7eHZ3Bs8B11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0413ae110fb631cf7339adc2e31b43ce811fd6546cc995045a189c9fa6077b03",
+				"DiscoKey":   "discokey:8085b48e9f3c3bb0454d7a884643d1e02f6273fa71b3163a16bd8085484ecd31",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46504",
+					"10.65.0.27:46504",
+					"172.17.0.1:46504",
+					"172.18.0.1:46504",
+					"172.19.0.1:46504",
+					"172.20.0.1:46504",
+					"172.21.0.1:46504"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T13:23:12.246411509Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2074875462877,
+				"StableID":   "nCY6eCWw1111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:87ab8f3839dda0dbf9d8136d42adf455d99a6f2ed00bd6be3af7bf785c13bd5f",
+				"KeyExpiry":  "2026-10-26T13:23:13Z",
+				"DiscoKey":   "discokey:f15a6fb7d69950744bcec2f55717b63df2f7634c1e6d197c28a2e2ef44be7005",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48503",
+					"10.65.0.27:48503",
+					"172.17.0.1:48503",
+					"172.18.0.1:48503",
+					"172.19.0.1:48503",
+					"172.20.0.1:48503",
+					"172.21.0.1:48503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T13:23:13.696357025Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6323419955543119,
+				"StableID":   "nk3Mw8XtNr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:477b8de9219e5489c53e278ea8281cc08e10608c223e131ac10f4cbcb9c91849",
+				"KeyExpiry":  "2026-10-26T13:23:14Z",
+				"DiscoKey":   "discokey:a40528a1b1bef40036c256e7aaab502254b244c7c40e5c0820bf6df75ee29613",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57275",
+					"10.65.0.27:57275",
+					"172.17.0.1:57275",
+					"172.18.0.1:57275",
+					"172.19.0.1:57275",
+					"172.20.0.1:57275",
+					"172.21.0.1:57275"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T13:23:14.235000202Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6144713412823430,
+				"StableID":   "nFw6ihCxyp11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       6144713412823430,
+				"Key":        "nodekey:49d9201f82fef80f21122a075c1e8df29e2a14d81f7faf933549d296c20f0568",
+				"DiscoKey":   "discokey:64ad24385cf7c77f654937aa8c435f656ecf879bb303ade4e6c0a00d5dd35b36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51605",
+					"10.65.0.27:51605",
+					"172.17.0.1:51605",
+					"172.18.0.1:51605",
+					"172.19.0.1:51605",
+					"172.20.0.1:51605",
+					"172.21.0.1:51605"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T13:23:11.738974092Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:49d9201f82fef80f21122a075c1e8df29e2a14d81f7faf933549d296c20f0568",
+			"MachineKey": "mkey:c6acfa35726c9306bbd66bcb83a20e5b489bb4c0ff2bb781af460374a6b00d09",
+			"Peers": [{
+				"ID":         2993996623721309,
+				"StableID":   "nrPMBSDzNQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b30def7598178cda1f07976539e579db950c9bb373ae521c20e146c320a422d",
+				"DiscoKey":   "discokey:ab19894c50f48420aed8c760e609544fa453bfda6bb7a70a576a7e6acb4b383b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39098",
+					"10.65.0.27:39098",
+					"172.17.0.1:39098",
+					"172.18.0.1:39098",
+					"172.19.0.1:39098",
+					"172.20.0.1:39098",
+					"172.21.0.1:39098"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T13:23:10.007919593Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3245310561740693,
+				"StableID":   "nYSEJiooLS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3c4111111cbfb114117eedf759c3863e7d63915c36a2724bb77c3cb8cf24e30d",
+				"DiscoKey":   "discokey:c68a1d83c483fd0963a7d5c0a34766a1717af5d7575ad9878fcb93da33449a41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59765",
+					"10.65.0.27:59765",
+					"172.17.0.1:59765",
+					"172.18.0.1:59765",
+					"172.19.0.1:59765",
+					"172.20.0.1:59765",
+					"172.21.0.1:59765"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T13:23:10.57998951Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7319947075620418,
+				"StableID":   "n1YJ6ebDAz11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b32c52b9b40fca6ec37717abb59d913192e57db63a50966f40fe1a10ac654d6a",
+				"DiscoKey":   "discokey:e55d432560d4e0919c8c9585ecfff7b48e789864e2d07c6663edfcc7647ff255",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39995",
+					"10.65.0.27:39995",
+					"172.17.0.1:39995",
+					"172.18.0.1:39995",
+					"172.19.0.1:39995",
+					"172.20.0.1:39995",
+					"172.21.0.1:39995"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T13:23:11.111969309Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1297996733480456,
+				"StableID":   "n7eHZ3Bs8B11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0413ae110fb631cf7339adc2e31b43ce811fd6546cc995045a189c9fa6077b03",
+				"DiscoKey":   "discokey:8085b48e9f3c3bb0454d7a884643d1e02f6273fa71b3163a16bd8085484ecd31",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46504",
+					"10.65.0.27:46504",
+					"172.17.0.1:46504",
+					"172.18.0.1:46504",
+					"172.19.0.1:46504",
+					"172.20.0.1:46504",
+					"172.21.0.1:46504"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T13:23:12.246411509Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3064666804138192,
+				"StableID":   "nqDM2pbzvQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6848a62e31c1e076d68579a3a0af964a1100da79cb16f1aa83c468385c39f00d",
+				"KeyExpiry":  "2026-10-26T13:23:13Z",
+				"DiscoKey":   "discokey:43180941c7f25aa26f913f751a4634519843449994ec7a05e3f6dbff67a76e34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59012",
+					"10.65.0.27:59012",
+					"172.17.0.1:59012",
+					"172.18.0.1:59012",
+					"172.19.0.1:59012",
+					"172.20.0.1:59012",
+					"172.21.0.1:59012"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T13:23:13.184994324Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2074875462877,
+				"StableID":   "nCY6eCWw1111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:87ab8f3839dda0dbf9d8136d42adf455d99a6f2ed00bd6be3af7bf785c13bd5f",
+				"KeyExpiry":  "2026-10-26T13:23:13Z",
+				"DiscoKey":   "discokey:f15a6fb7d69950744bcec2f55717b63df2f7634c1e6d197c28a2e2ef44be7005",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48503",
+					"10.65.0.27:48503",
+					"172.17.0.1:48503",
+					"172.18.0.1:48503",
+					"172.19.0.1:48503",
+					"172.20.0.1:48503",
+					"172.21.0.1:48503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T13:23:13.696357025Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6323419955543119,
+				"StableID":   "nk3Mw8XtNr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:477b8de9219e5489c53e278ea8281cc08e10608c223e131ac10f4cbcb9c91849",
+				"KeyExpiry":  "2026-10-26T13:23:14Z",
+				"DiscoKey":   "discokey:a40528a1b1bef40036c256e7aaab502254b244c7c40e5c0820bf6df75ee29613",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57275",
+					"10.65.0.27:57275",
+					"172.17.0.1:57275",
+					"172.18.0.1:57275",
+					"172.19.0.1:57275",
+					"172.20.0.1:57275",
+					"172.21.0.1:57275"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T13:23:14.235000202Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6144713412823430": {
+				"ID":          6144713412823430,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3245310561740693,
+				"StableID":   "nYSEJiooLS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       3245310561740693,
+				"Key":        "nodekey:3c4111111cbfb114117eedf759c3863e7d63915c36a2724bb77c3cb8cf24e30d",
+				"DiscoKey":   "discokey:c68a1d83c483fd0963a7d5c0a34766a1717af5d7575ad9878fcb93da33449a41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59765",
+					"10.65.0.27:59765",
+					"172.17.0.1:59765",
+					"172.18.0.1:59765",
+					"172.19.0.1:59765",
+					"172.20.0.1:59765",
+					"172.21.0.1:59765"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T13:23:10.57998951Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3c4111111cbfb114117eedf759c3863e7d63915c36a2724bb77c3cb8cf24e30d",
+			"MachineKey": "mkey:eb02fd530240734bca080c92abe1da43e7474b1ecabffbf6d1c315d9b1e7b30a",
+			"Peers": [{
+				"ID":         2993996623721309,
+				"StableID":   "nrPMBSDzNQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b30def7598178cda1f07976539e579db950c9bb373ae521c20e146c320a422d",
+				"DiscoKey":   "discokey:ab19894c50f48420aed8c760e609544fa453bfda6bb7a70a576a7e6acb4b383b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39098",
+					"10.65.0.27:39098",
+					"172.17.0.1:39098",
+					"172.18.0.1:39098",
+					"172.19.0.1:39098",
+					"172.20.0.1:39098",
+					"172.21.0.1:39098"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T13:23:10.007919593Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7319947075620418,
+				"StableID":   "n1YJ6ebDAz11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b32c52b9b40fca6ec37717abb59d913192e57db63a50966f40fe1a10ac654d6a",
+				"DiscoKey":   "discokey:e55d432560d4e0919c8c9585ecfff7b48e789864e2d07c6663edfcc7647ff255",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39995",
+					"10.65.0.27:39995",
+					"172.17.0.1:39995",
+					"172.18.0.1:39995",
+					"172.19.0.1:39995",
+					"172.20.0.1:39995",
+					"172.21.0.1:39995"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T13:23:11.111969309Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6144713412823430,
+				"StableID":   "nFw6ihCxyp11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49d9201f82fef80f21122a075c1e8df29e2a14d81f7faf933549d296c20f0568",
+				"DiscoKey":   "discokey:64ad24385cf7c77f654937aa8c435f656ecf879bb303ade4e6c0a00d5dd35b36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51605",
+					"10.65.0.27:51605",
+					"172.17.0.1:51605",
+					"172.18.0.1:51605",
+					"172.19.0.1:51605",
+					"172.20.0.1:51605",
+					"172.21.0.1:51605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T13:23:11.738974092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1297996733480456,
+				"StableID":   "n7eHZ3Bs8B11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0413ae110fb631cf7339adc2e31b43ce811fd6546cc995045a189c9fa6077b03",
+				"DiscoKey":   "discokey:8085b48e9f3c3bb0454d7a884643d1e02f6273fa71b3163a16bd8085484ecd31",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46504",
+					"10.65.0.27:46504",
+					"172.17.0.1:46504",
+					"172.18.0.1:46504",
+					"172.19.0.1:46504",
+					"172.20.0.1:46504",
+					"172.21.0.1:46504"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T13:23:12.246411509Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3064666804138192,
+				"StableID":   "nqDM2pbzvQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6848a62e31c1e076d68579a3a0af964a1100da79cb16f1aa83c468385c39f00d",
+				"KeyExpiry":  "2026-10-26T13:23:13Z",
+				"DiscoKey":   "discokey:43180941c7f25aa26f913f751a4634519843449994ec7a05e3f6dbff67a76e34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59012",
+					"10.65.0.27:59012",
+					"172.17.0.1:59012",
+					"172.18.0.1:59012",
+					"172.19.0.1:59012",
+					"172.20.0.1:59012",
+					"172.21.0.1:59012"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T13:23:13.184994324Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2074875462877,
+				"StableID":   "nCY6eCWw1111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:87ab8f3839dda0dbf9d8136d42adf455d99a6f2ed00bd6be3af7bf785c13bd5f",
+				"KeyExpiry":  "2026-10-26T13:23:13Z",
+				"DiscoKey":   "discokey:f15a6fb7d69950744bcec2f55717b63df2f7634c1e6d197c28a2e2ef44be7005",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48503",
+					"10.65.0.27:48503",
+					"172.17.0.1:48503",
+					"172.18.0.1:48503",
+					"172.19.0.1:48503",
+					"172.20.0.1:48503",
+					"172.21.0.1:48503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T13:23:13.696357025Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6323419955543119,
+				"StableID":   "nk3Mw8XtNr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:477b8de9219e5489c53e278ea8281cc08e10608c223e131ac10f4cbcb9c91849",
+				"KeyExpiry":  "2026-10-26T13:23:14Z",
+				"DiscoKey":   "discokey:a40528a1b1bef40036c256e7aaab502254b244c7c40e5c0820bf6df75ee29613",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57275",
+					"10.65.0.27:57275",
+					"172.17.0.1:57275",
+					"172.18.0.1:57275",
+					"172.19.0.1:57275",
+					"172.20.0.1:57275",
+					"172.21.0.1:57275"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T13:23:14.235000202Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3245310561740693": {
+				"ID":          3245310561740693,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2074875462877,
+				"StableID":   "nCY6eCWw1111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:87ab8f3839dda0dbf9d8136d42adf455d99a6f2ed00bd6be3af7bf785c13bd5f",
+				"KeyExpiry":  "2026-10-26T13:23:13Z",
+				"DiscoKey":   "discokey:f15a6fb7d69950744bcec2f55717b63df2f7634c1e6d197c28a2e2ef44be7005",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48503",
+					"10.65.0.27:48503",
+					"172.17.0.1:48503",
+					"172.18.0.1:48503",
+					"172.19.0.1:48503",
+					"172.20.0.1:48503",
+					"172.21.0.1:48503"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T13:23:13.696357025Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:87ab8f3839dda0dbf9d8136d42adf455d99a6f2ed00bd6be3af7bf785c13bd5f",
+			"MachineKey": "mkey:c2139fe0a41cf963c38998308286861b31c301e51ab41dcdc6c70054c23ce602",
+			"Peers": [{
+				"ID":         2993996623721309,
+				"StableID":   "nrPMBSDzNQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b30def7598178cda1f07976539e579db950c9bb373ae521c20e146c320a422d",
+				"DiscoKey":   "discokey:ab19894c50f48420aed8c760e609544fa453bfda6bb7a70a576a7e6acb4b383b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39098",
+					"10.65.0.27:39098",
+					"172.17.0.1:39098",
+					"172.18.0.1:39098",
+					"172.19.0.1:39098",
+					"172.20.0.1:39098",
+					"172.21.0.1:39098"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T13:23:10.007919593Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3245310561740693,
+				"StableID":   "nYSEJiooLS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3c4111111cbfb114117eedf759c3863e7d63915c36a2724bb77c3cb8cf24e30d",
+				"DiscoKey":   "discokey:c68a1d83c483fd0963a7d5c0a34766a1717af5d7575ad9878fcb93da33449a41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59765",
+					"10.65.0.27:59765",
+					"172.17.0.1:59765",
+					"172.18.0.1:59765",
+					"172.19.0.1:59765",
+					"172.20.0.1:59765",
+					"172.21.0.1:59765"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T13:23:10.57998951Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7319947075620418,
+				"StableID":   "n1YJ6ebDAz11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b32c52b9b40fca6ec37717abb59d913192e57db63a50966f40fe1a10ac654d6a",
+				"DiscoKey":   "discokey:e55d432560d4e0919c8c9585ecfff7b48e789864e2d07c6663edfcc7647ff255",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39995",
+					"10.65.0.27:39995",
+					"172.17.0.1:39995",
+					"172.18.0.1:39995",
+					"172.19.0.1:39995",
+					"172.20.0.1:39995",
+					"172.21.0.1:39995"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T13:23:11.111969309Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6144713412823430,
+				"StableID":   "nFw6ihCxyp11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49d9201f82fef80f21122a075c1e8df29e2a14d81f7faf933549d296c20f0568",
+				"DiscoKey":   "discokey:64ad24385cf7c77f654937aa8c435f656ecf879bb303ade4e6c0a00d5dd35b36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51605",
+					"10.65.0.27:51605",
+					"172.17.0.1:51605",
+					"172.18.0.1:51605",
+					"172.19.0.1:51605",
+					"172.20.0.1:51605",
+					"172.21.0.1:51605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T13:23:11.738974092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1297996733480456,
+				"StableID":   "n7eHZ3Bs8B11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0413ae110fb631cf7339adc2e31b43ce811fd6546cc995045a189c9fa6077b03",
+				"DiscoKey":   "discokey:8085b48e9f3c3bb0454d7a884643d1e02f6273fa71b3163a16bd8085484ecd31",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46504",
+					"10.65.0.27:46504",
+					"172.17.0.1:46504",
+					"172.18.0.1:46504",
+					"172.19.0.1:46504",
+					"172.20.0.1:46504",
+					"172.21.0.1:46504"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T13:23:12.246411509Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3064666804138192,
+				"StableID":   "nqDM2pbzvQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6848a62e31c1e076d68579a3a0af964a1100da79cb16f1aa83c468385c39f00d",
+				"KeyExpiry":  "2026-10-26T13:23:13Z",
+				"DiscoKey":   "discokey:43180941c7f25aa26f913f751a4634519843449994ec7a05e3f6dbff67a76e34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59012",
+					"10.65.0.27:59012",
+					"172.17.0.1:59012",
+					"172.18.0.1:59012",
+					"172.19.0.1:59012",
+					"172.20.0.1:59012",
+					"172.21.0.1:59012"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T13:23:13.184994324Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6323419955543119,
+				"StableID":   "nk3Mw8XtNr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:477b8de9219e5489c53e278ea8281cc08e10608c223e131ac10f4cbcb9c91849",
+				"KeyExpiry":  "2026-10-26T13:23:14Z",
+				"DiscoKey":   "discokey:a40528a1b1bef40036c256e7aaab502254b244c7c40e5c0820bf6df75ee29613",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57275",
+					"10.65.0.27:57275",
+					"172.17.0.1:57275",
+					"172.18.0.1:57275",
+					"172.19.0.1:57275",
+					"172.20.0.1:57275",
+					"172.21.0.1:57275"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T13:23:14.235000202Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7319947075620418,
+				"StableID":   "n1YJ6ebDAz11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       7319947075620418,
+				"Key":        "nodekey:b32c52b9b40fca6ec37717abb59d913192e57db63a50966f40fe1a10ac654d6a",
+				"DiscoKey":   "discokey:e55d432560d4e0919c8c9585ecfff7b48e789864e2d07c6663edfcc7647ff255",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39995",
+					"10.65.0.27:39995",
+					"172.17.0.1:39995",
+					"172.18.0.1:39995",
+					"172.19.0.1:39995",
+					"172.20.0.1:39995",
+					"172.21.0.1:39995"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T13:23:11.111969309Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b32c52b9b40fca6ec37717abb59d913192e57db63a50966f40fe1a10ac654d6a",
+			"MachineKey": "mkey:6937096136f581654b7c0ff3fcd038557a67e7a8006077d013bdc3c68433b009",
+			"Peers": [{
+				"ID":         2993996623721309,
+				"StableID":   "nrPMBSDzNQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b30def7598178cda1f07976539e579db950c9bb373ae521c20e146c320a422d",
+				"DiscoKey":   "discokey:ab19894c50f48420aed8c760e609544fa453bfda6bb7a70a576a7e6acb4b383b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39098",
+					"10.65.0.27:39098",
+					"172.17.0.1:39098",
+					"172.18.0.1:39098",
+					"172.19.0.1:39098",
+					"172.20.0.1:39098",
+					"172.21.0.1:39098"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T13:23:10.007919593Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3245310561740693,
+				"StableID":   "nYSEJiooLS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3c4111111cbfb114117eedf759c3863e7d63915c36a2724bb77c3cb8cf24e30d",
+				"DiscoKey":   "discokey:c68a1d83c483fd0963a7d5c0a34766a1717af5d7575ad9878fcb93da33449a41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59765",
+					"10.65.0.27:59765",
+					"172.17.0.1:59765",
+					"172.18.0.1:59765",
+					"172.19.0.1:59765",
+					"172.20.0.1:59765",
+					"172.21.0.1:59765"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T13:23:10.57998951Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6144713412823430,
+				"StableID":   "nFw6ihCxyp11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49d9201f82fef80f21122a075c1e8df29e2a14d81f7faf933549d296c20f0568",
+				"DiscoKey":   "discokey:64ad24385cf7c77f654937aa8c435f656ecf879bb303ade4e6c0a00d5dd35b36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51605",
+					"10.65.0.27:51605",
+					"172.17.0.1:51605",
+					"172.18.0.1:51605",
+					"172.19.0.1:51605",
+					"172.20.0.1:51605",
+					"172.21.0.1:51605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T13:23:11.738974092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1297996733480456,
+				"StableID":   "n7eHZ3Bs8B11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0413ae110fb631cf7339adc2e31b43ce811fd6546cc995045a189c9fa6077b03",
+				"DiscoKey":   "discokey:8085b48e9f3c3bb0454d7a884643d1e02f6273fa71b3163a16bd8085484ecd31",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46504",
+					"10.65.0.27:46504",
+					"172.17.0.1:46504",
+					"172.18.0.1:46504",
+					"172.19.0.1:46504",
+					"172.20.0.1:46504",
+					"172.21.0.1:46504"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T13:23:12.246411509Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3064666804138192,
+				"StableID":   "nqDM2pbzvQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6848a62e31c1e076d68579a3a0af964a1100da79cb16f1aa83c468385c39f00d",
+				"KeyExpiry":  "2026-10-26T13:23:13Z",
+				"DiscoKey":   "discokey:43180941c7f25aa26f913f751a4634519843449994ec7a05e3f6dbff67a76e34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59012",
+					"10.65.0.27:59012",
+					"172.17.0.1:59012",
+					"172.18.0.1:59012",
+					"172.19.0.1:59012",
+					"172.20.0.1:59012",
+					"172.21.0.1:59012"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T13:23:13.184994324Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2074875462877,
+				"StableID":   "nCY6eCWw1111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:87ab8f3839dda0dbf9d8136d42adf455d99a6f2ed00bd6be3af7bf785c13bd5f",
+				"KeyExpiry":  "2026-10-26T13:23:13Z",
+				"DiscoKey":   "discokey:f15a6fb7d69950744bcec2f55717b63df2f7634c1e6d197c28a2e2ef44be7005",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48503",
+					"10.65.0.27:48503",
+					"172.17.0.1:48503",
+					"172.18.0.1:48503",
+					"172.19.0.1:48503",
+					"172.20.0.1:48503",
+					"172.21.0.1:48503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T13:23:13.696357025Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6323419955543119,
+				"StableID":   "nk3Mw8XtNr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:477b8de9219e5489c53e278ea8281cc08e10608c223e131ac10f4cbcb9c91849",
+				"KeyExpiry":  "2026-10-26T13:23:14Z",
+				"DiscoKey":   "discokey:a40528a1b1bef40036c256e7aaab502254b244c7c40e5c0820bf6df75ee29613",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57275",
+					"10.65.0.27:57275",
+					"172.17.0.1:57275",
+					"172.18.0.1:57275",
+					"172.19.0.1:57275",
+					"172.20.0.1:57275",
+					"172.21.0.1:57275"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T13:23:14.235000202Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7319947075620418": {
+				"ID":          7319947075620418,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-deny-fail-autogroup-internet-dst.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-deny-fail-autogroup-internet-dst.hujson
@@ -1,0 +1,8841 @@
+// policytest-deny-fail-autogroup-internet-dst
+//
+// tests block deny-fail: tag src to autogroup:internet dst, allow rule covers it
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:44:10Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-deny-fail-autogroup-internet-dst",
+	"description":    "tests block deny-fail: tag src to autogroup:internet dst, allow rule covers it",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:44:10.664654232Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                              \n  \n                                                                      \n                                                          \n{\n\t\"id\":          \"policytest-deny-fail-autogroup-internet-dst\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block deny-fail: tag src to autogroup:internet dst, allow rule covers it\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"tag:client\"], \"dst\": [\"autogroup:internet:*\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"tag:client\", \"deny\": [\"autogroup:internet:*\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-deny-fail-autogroup-internet-dst.hujson",
+		"full_policy": {"acls": [{
+			"action": "accept",
+			"dst":    ["autogroup:internet:*"],
+			"src":    ["tag:client"]
+		}], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [{"deny": ["autogroup:internet:*"], "src": "tag:client"}]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3175282898312887,
+				"StableID":   "naWkUFJ6oR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       3175282898312887,
+				"Key":        "nodekey:00e7065bc5687561874c708a625547af7053cde15e36921f6827e0553208d070",
+				"DiscoKey":   "discokey:3ab02831e9a734ca86798742f60d25d6e08f8abbc9c3533bdf50e793786ff73c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:47713", "10.65.0.27:47713", "172.17.0.1:47713"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:44:14.629128927Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:00e7065bc5687561874c708a625547af7053cde15e36921f6827e0553208d070",
+			"MachineKey": "mkey:e3abaf6cc6df822b3c9f8aaf8cb726096407ba6476c59ee6fd0b6e5a6f910571",
+			"Peers": [{
+				"ID":         1572896685685548,
+				"StableID":   "nmhyy4LNHD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fb9dd355064d6fbe7257942657633d38fc7fe4170d44265d50cb796dbbdf835",
+				"DiscoKey":   "discokey:47811b3ccdeb1ccd7fac642608ed40638ad4db7779461b13d431dbc2094e2742",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41161", "10.65.0.27:41161", "172.17.0.1:41161"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:44:12.3130416Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5371161768079166,
+				"StableID":   "nH4Rm5Kcwi11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a83e64994ca30e6ae5fe274be5747d3f11d3a4742a920a4bfc52242dadc5f72",
+				"DiscoKey":   "discokey:87cc7b33300dafe87503ae43ab9ac9266185340169332b7aaa98a33ec8f32652",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52617", "10.65.0.27:52617", "172.17.0.1:52617"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:44:13.008879023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5043988658084634,
+				"StableID":   "nPfTPg2SPg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb1f1d7430c965c0ab8555379135835b649b69f0b31b6098d6f1e8a070761317",
+				"DiscoKey":   "discokey:6e27c319cbe5262dc2457e465e45eddc672f04af05ea7b9b955f8812eba4ae45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60575", "10.65.0.27:60575", "172.17.0.1:60575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:44:13.540351589Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7285994201530088,
+				"StableID":   "nFrhsLiqty11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4fa97de79ea2d152baf08cc1d0d6e752f0f415a89ec504e75300f43cc641545c",
+				"DiscoKey":   "discokey:2575290f2a9865811b75f96d25323f0cbcb518a03c11ea5f6c312bb2d8631b7d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55268", "10.65.0.27:55268", "172.17.0.1:55268"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:44:14.099376158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4997914966865596,
+				"StableID":   "nFYq4akZ2g11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8bddde38931ddf8542fe56429aadfd2d312b390ec11992075b8790380f310f29",
+				"KeyExpiry":  "2026-10-26T10:44:15Z",
+				"DiscoKey":   "discokey:35e8e117a46acf7aa4e528f2927ec4f7040cf315c32ce00819766cd8e7ba984f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53530", "10.65.0.27:53530", "172.17.0.1:53530"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:44:15.18187105Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7913421596501316,
+				"StableID":   "njc8FfA1o421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d9903521f19d2bd30949018e45d4e32a1ec6007486a7359a8638abd0366d567f",
+				"KeyExpiry":  "2026-10-26T10:44:15Z",
+				"DiscoKey":   "discokey:04aadf1df1e66422bcab47bdc151262f8b7a927821103ddf120e33025ffe250c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:57970", "10.65.0.27:57970", "172.17.0.1:57970"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:44:15.69700287Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4810077743070462,
+				"StableID":   "nDrRpyaVZe11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c6fe1ad53db6dc4844085251ba11c4123fbd984a18d6a7165135e07f20376027",
+				"KeyExpiry":  "2026-10-26T10:44:16Z",
+				"DiscoKey":   "discokey:b1420fb98d8cf02290514ce365ea7fbc1f6ca4c2bb19f0f341b36658b1212f2e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51314", "10.65.0.27:51314", "172.17.0.1:51314"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:44:16.243607392Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3175282898312887": {
+				"ID":          3175282898312887,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4810077743070462,
+				"StableID":   "nDrRpyaVZe11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c6fe1ad53db6dc4844085251ba11c4123fbd984a18d6a7165135e07f20376027",
+				"KeyExpiry":  "2026-10-26T10:44:16Z",
+				"DiscoKey":   "discokey:b1420fb98d8cf02290514ce365ea7fbc1f6ca4c2bb19f0f341b36658b1212f2e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51314", "10.65.0.27:51314", "172.17.0.1:51314"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:44:16.243607392Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c6fe1ad53db6dc4844085251ba11c4123fbd984a18d6a7165135e07f20376027",
+			"MachineKey": "mkey:191a06c58ceb97ca56626eadf7f07f12ebb6cfbb7d46ce7c2297d26483b3870d",
+			"Peers": [{
+				"ID":         1572896685685548,
+				"StableID":   "nmhyy4LNHD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fb9dd355064d6fbe7257942657633d38fc7fe4170d44265d50cb796dbbdf835",
+				"DiscoKey":   "discokey:47811b3ccdeb1ccd7fac642608ed40638ad4db7779461b13d431dbc2094e2742",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41161", "10.65.0.27:41161", "172.17.0.1:41161"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:44:12.3130416Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5371161768079166,
+				"StableID":   "nH4Rm5Kcwi11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a83e64994ca30e6ae5fe274be5747d3f11d3a4742a920a4bfc52242dadc5f72",
+				"DiscoKey":   "discokey:87cc7b33300dafe87503ae43ab9ac9266185340169332b7aaa98a33ec8f32652",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52617", "10.65.0.27:52617", "172.17.0.1:52617"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:44:13.008879023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5043988658084634,
+				"StableID":   "nPfTPg2SPg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb1f1d7430c965c0ab8555379135835b649b69f0b31b6098d6f1e8a070761317",
+				"DiscoKey":   "discokey:6e27c319cbe5262dc2457e465e45eddc672f04af05ea7b9b955f8812eba4ae45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60575", "10.65.0.27:60575", "172.17.0.1:60575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:44:13.540351589Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7285994201530088,
+				"StableID":   "nFrhsLiqty11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4fa97de79ea2d152baf08cc1d0d6e752f0f415a89ec504e75300f43cc641545c",
+				"DiscoKey":   "discokey:2575290f2a9865811b75f96d25323f0cbcb518a03c11ea5f6c312bb2d8631b7d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55268", "10.65.0.27:55268", "172.17.0.1:55268"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:44:14.099376158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3175282898312887,
+				"StableID":   "naWkUFJ6oR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00e7065bc5687561874c708a625547af7053cde15e36921f6827e0553208d070",
+				"DiscoKey":   "discokey:3ab02831e9a734ca86798742f60d25d6e08f8abbc9c3533bdf50e793786ff73c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:47713", "10.65.0.27:47713", "172.17.0.1:47713"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:44:14.629128927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4997914966865596,
+				"StableID":   "nFYq4akZ2g11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8bddde38931ddf8542fe56429aadfd2d312b390ec11992075b8790380f310f29",
+				"KeyExpiry":  "2026-10-26T10:44:15Z",
+				"DiscoKey":   "discokey:35e8e117a46acf7aa4e528f2927ec4f7040cf315c32ce00819766cd8e7ba984f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53530", "10.65.0.27:53530", "172.17.0.1:53530"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:44:15.18187105Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7913421596501316,
+				"StableID":   "njc8FfA1o421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d9903521f19d2bd30949018e45d4e32a1ec6007486a7359a8638abd0366d567f",
+				"KeyExpiry":  "2026-10-26T10:44:15Z",
+				"DiscoKey":   "discokey:04aadf1df1e66422bcab47bdc151262f8b7a927821103ddf120e33025ffe250c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:57970", "10.65.0.27:57970", "172.17.0.1:57970"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:44:15.69700287Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1572896685685548,
+				"StableID":   "nmhyy4LNHD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1572896685685548,
+				"Key":        "nodekey:5fb9dd355064d6fbe7257942657633d38fc7fe4170d44265d50cb796dbbdf835",
+				"DiscoKey":   "discokey:47811b3ccdeb1ccd7fac642608ed40638ad4db7779461b13d431dbc2094e2742",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41161", "10.65.0.27:41161", "172.17.0.1:41161"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:44:12.3130416Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5fb9dd355064d6fbe7257942657633d38fc7fe4170d44265d50cb796dbbdf835",
+			"MachineKey": "mkey:64a5c45b18fe5dd93bf87ae007f41912c9958d41291dd77337c96414f9f44d58",
+			"Peers": [{
+				"ID":         5371161768079166,
+				"StableID":   "nH4Rm5Kcwi11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a83e64994ca30e6ae5fe274be5747d3f11d3a4742a920a4bfc52242dadc5f72",
+				"DiscoKey":   "discokey:87cc7b33300dafe87503ae43ab9ac9266185340169332b7aaa98a33ec8f32652",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52617", "10.65.0.27:52617", "172.17.0.1:52617"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:44:13.008879023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5043988658084634,
+				"StableID":   "nPfTPg2SPg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb1f1d7430c965c0ab8555379135835b649b69f0b31b6098d6f1e8a070761317",
+				"DiscoKey":   "discokey:6e27c319cbe5262dc2457e465e45eddc672f04af05ea7b9b955f8812eba4ae45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60575", "10.65.0.27:60575", "172.17.0.1:60575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:44:13.540351589Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7285994201530088,
+				"StableID":   "nFrhsLiqty11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4fa97de79ea2d152baf08cc1d0d6e752f0f415a89ec504e75300f43cc641545c",
+				"DiscoKey":   "discokey:2575290f2a9865811b75f96d25323f0cbcb518a03c11ea5f6c312bb2d8631b7d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55268", "10.65.0.27:55268", "172.17.0.1:55268"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:44:14.099376158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3175282898312887,
+				"StableID":   "naWkUFJ6oR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00e7065bc5687561874c708a625547af7053cde15e36921f6827e0553208d070",
+				"DiscoKey":   "discokey:3ab02831e9a734ca86798742f60d25d6e08f8abbc9c3533bdf50e793786ff73c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:47713", "10.65.0.27:47713", "172.17.0.1:47713"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:44:14.629128927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4997914966865596,
+				"StableID":   "nFYq4akZ2g11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8bddde38931ddf8542fe56429aadfd2d312b390ec11992075b8790380f310f29",
+				"KeyExpiry":  "2026-10-26T10:44:15Z",
+				"DiscoKey":   "discokey:35e8e117a46acf7aa4e528f2927ec4f7040cf315c32ce00819766cd8e7ba984f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53530", "10.65.0.27:53530", "172.17.0.1:53530"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:44:15.18187105Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7913421596501316,
+				"StableID":   "njc8FfA1o421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d9903521f19d2bd30949018e45d4e32a1ec6007486a7359a8638abd0366d567f",
+				"KeyExpiry":  "2026-10-26T10:44:15Z",
+				"DiscoKey":   "discokey:04aadf1df1e66422bcab47bdc151262f8b7a927821103ddf120e33025ffe250c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:57970", "10.65.0.27:57970", "172.17.0.1:57970"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:44:15.69700287Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4810077743070462,
+				"StableID":   "nDrRpyaVZe11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c6fe1ad53db6dc4844085251ba11c4123fbd984a18d6a7165135e07f20376027",
+				"KeyExpiry":  "2026-10-26T10:44:16Z",
+				"DiscoKey":   "discokey:b1420fb98d8cf02290514ce365ea7fbc1f6ca4c2bb19f0f341b36658b1212f2e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51314", "10.65.0.27:51314", "172.17.0.1:51314"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:44:16.243607392Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1572896685685548": {
+				"ID":          1572896685685548,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4997914966865596,
+				"StableID":   "nFYq4akZ2g11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8bddde38931ddf8542fe56429aadfd2d312b390ec11992075b8790380f310f29",
+				"KeyExpiry":  "2026-10-26T10:44:15Z",
+				"DiscoKey":   "discokey:35e8e117a46acf7aa4e528f2927ec4f7040cf315c32ce00819766cd8e7ba984f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53530", "10.65.0.27:53530", "172.17.0.1:53530"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:44:15.18187105Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8bddde38931ddf8542fe56429aadfd2d312b390ec11992075b8790380f310f29",
+			"MachineKey": "mkey:b953ac25ae6660194ed8608ecbad680edaf95c0c2f4b21321324fb4cc08bc965",
+			"Peers": [{
+				"ID":         1572896685685548,
+				"StableID":   "nmhyy4LNHD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fb9dd355064d6fbe7257942657633d38fc7fe4170d44265d50cb796dbbdf835",
+				"DiscoKey":   "discokey:47811b3ccdeb1ccd7fac642608ed40638ad4db7779461b13d431dbc2094e2742",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41161", "10.65.0.27:41161", "172.17.0.1:41161"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:44:12.3130416Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5371161768079166,
+				"StableID":   "nH4Rm5Kcwi11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a83e64994ca30e6ae5fe274be5747d3f11d3a4742a920a4bfc52242dadc5f72",
+				"DiscoKey":   "discokey:87cc7b33300dafe87503ae43ab9ac9266185340169332b7aaa98a33ec8f32652",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52617", "10.65.0.27:52617", "172.17.0.1:52617"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:44:13.008879023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5043988658084634,
+				"StableID":   "nPfTPg2SPg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb1f1d7430c965c0ab8555379135835b649b69f0b31b6098d6f1e8a070761317",
+				"DiscoKey":   "discokey:6e27c319cbe5262dc2457e465e45eddc672f04af05ea7b9b955f8812eba4ae45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60575", "10.65.0.27:60575", "172.17.0.1:60575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:44:13.540351589Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7285994201530088,
+				"StableID":   "nFrhsLiqty11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4fa97de79ea2d152baf08cc1d0d6e752f0f415a89ec504e75300f43cc641545c",
+				"DiscoKey":   "discokey:2575290f2a9865811b75f96d25323f0cbcb518a03c11ea5f6c312bb2d8631b7d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55268", "10.65.0.27:55268", "172.17.0.1:55268"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:44:14.099376158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3175282898312887,
+				"StableID":   "naWkUFJ6oR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00e7065bc5687561874c708a625547af7053cde15e36921f6827e0553208d070",
+				"DiscoKey":   "discokey:3ab02831e9a734ca86798742f60d25d6e08f8abbc9c3533bdf50e793786ff73c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:47713", "10.65.0.27:47713", "172.17.0.1:47713"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:44:14.629128927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7913421596501316,
+				"StableID":   "njc8FfA1o421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d9903521f19d2bd30949018e45d4e32a1ec6007486a7359a8638abd0366d567f",
+				"KeyExpiry":  "2026-10-26T10:44:15Z",
+				"DiscoKey":   "discokey:04aadf1df1e66422bcab47bdc151262f8b7a927821103ddf120e33025ffe250c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:57970", "10.65.0.27:57970", "172.17.0.1:57970"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:44:15.69700287Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4810077743070462,
+				"StableID":   "nDrRpyaVZe11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c6fe1ad53db6dc4844085251ba11c4123fbd984a18d6a7165135e07f20376027",
+				"KeyExpiry":  "2026-10-26T10:44:16Z",
+				"DiscoKey":   "discokey:b1420fb98d8cf02290514ce365ea7fbc1f6ca4c2bb19f0f341b36658b1212f2e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51314", "10.65.0.27:51314", "172.17.0.1:51314"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:44:16.243607392Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7285994201530088,
+				"StableID":   "nFrhsLiqty11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       7285994201530088,
+				"Key":        "nodekey:4fa97de79ea2d152baf08cc1d0d6e752f0f415a89ec504e75300f43cc641545c",
+				"DiscoKey":   "discokey:2575290f2a9865811b75f96d25323f0cbcb518a03c11ea5f6c312bb2d8631b7d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55268", "10.65.0.27:55268", "172.17.0.1:55268"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:44:14.099376158Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4fa97de79ea2d152baf08cc1d0d6e752f0f415a89ec504e75300f43cc641545c",
+			"MachineKey": "mkey:3396611f62e266a9156a8622324b4a1cc91ebe0d020a1aa286c2935df2a36d39",
+			"Peers": [{
+				"ID":         1572896685685548,
+				"StableID":   "nmhyy4LNHD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fb9dd355064d6fbe7257942657633d38fc7fe4170d44265d50cb796dbbdf835",
+				"DiscoKey":   "discokey:47811b3ccdeb1ccd7fac642608ed40638ad4db7779461b13d431dbc2094e2742",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41161", "10.65.0.27:41161", "172.17.0.1:41161"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:44:12.3130416Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5371161768079166,
+				"StableID":   "nH4Rm5Kcwi11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a83e64994ca30e6ae5fe274be5747d3f11d3a4742a920a4bfc52242dadc5f72",
+				"DiscoKey":   "discokey:87cc7b33300dafe87503ae43ab9ac9266185340169332b7aaa98a33ec8f32652",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52617", "10.65.0.27:52617", "172.17.0.1:52617"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:44:13.008879023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5043988658084634,
+				"StableID":   "nPfTPg2SPg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb1f1d7430c965c0ab8555379135835b649b69f0b31b6098d6f1e8a070761317",
+				"DiscoKey":   "discokey:6e27c319cbe5262dc2457e465e45eddc672f04af05ea7b9b955f8812eba4ae45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60575", "10.65.0.27:60575", "172.17.0.1:60575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:44:13.540351589Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3175282898312887,
+				"StableID":   "naWkUFJ6oR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00e7065bc5687561874c708a625547af7053cde15e36921f6827e0553208d070",
+				"DiscoKey":   "discokey:3ab02831e9a734ca86798742f60d25d6e08f8abbc9c3533bdf50e793786ff73c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:47713", "10.65.0.27:47713", "172.17.0.1:47713"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:44:14.629128927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4997914966865596,
+				"StableID":   "nFYq4akZ2g11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8bddde38931ddf8542fe56429aadfd2d312b390ec11992075b8790380f310f29",
+				"KeyExpiry":  "2026-10-26T10:44:15Z",
+				"DiscoKey":   "discokey:35e8e117a46acf7aa4e528f2927ec4f7040cf315c32ce00819766cd8e7ba984f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53530", "10.65.0.27:53530", "172.17.0.1:53530"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:44:15.18187105Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7913421596501316,
+				"StableID":   "njc8FfA1o421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d9903521f19d2bd30949018e45d4e32a1ec6007486a7359a8638abd0366d567f",
+				"KeyExpiry":  "2026-10-26T10:44:15Z",
+				"DiscoKey":   "discokey:04aadf1df1e66422bcab47bdc151262f8b7a927821103ddf120e33025ffe250c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:57970", "10.65.0.27:57970", "172.17.0.1:57970"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:44:15.69700287Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4810077743070462,
+				"StableID":   "nDrRpyaVZe11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c6fe1ad53db6dc4844085251ba11c4123fbd984a18d6a7165135e07f20376027",
+				"KeyExpiry":  "2026-10-26T10:44:16Z",
+				"DiscoKey":   "discokey:b1420fb98d8cf02290514ce365ea7fbc1f6ca4c2bb19f0f341b36658b1212f2e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51314", "10.65.0.27:51314", "172.17.0.1:51314"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:44:16.243607392Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7285994201530088": {
+				"ID":          7285994201530088,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5371161768079166,
+				"StableID":   "nH4Rm5Kcwi11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       5371161768079166,
+				"Key":        "nodekey:7a83e64994ca30e6ae5fe274be5747d3f11d3a4742a920a4bfc52242dadc5f72",
+				"DiscoKey":   "discokey:87cc7b33300dafe87503ae43ab9ac9266185340169332b7aaa98a33ec8f32652",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52617", "10.65.0.27:52617", "172.17.0.1:52617"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:44:13.008879023Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7a83e64994ca30e6ae5fe274be5747d3f11d3a4742a920a4bfc52242dadc5f72",
+			"MachineKey": "mkey:cdb4fabf15d9a983ea84dfc0ceb66d685f3184c3212adbca5b94092dcbc73733",
+			"Peers": [{
+				"ID":         1572896685685548,
+				"StableID":   "nmhyy4LNHD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fb9dd355064d6fbe7257942657633d38fc7fe4170d44265d50cb796dbbdf835",
+				"DiscoKey":   "discokey:47811b3ccdeb1ccd7fac642608ed40638ad4db7779461b13d431dbc2094e2742",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41161", "10.65.0.27:41161", "172.17.0.1:41161"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:44:12.3130416Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5043988658084634,
+				"StableID":   "nPfTPg2SPg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb1f1d7430c965c0ab8555379135835b649b69f0b31b6098d6f1e8a070761317",
+				"DiscoKey":   "discokey:6e27c319cbe5262dc2457e465e45eddc672f04af05ea7b9b955f8812eba4ae45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60575", "10.65.0.27:60575", "172.17.0.1:60575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:44:13.540351589Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7285994201530088,
+				"StableID":   "nFrhsLiqty11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4fa97de79ea2d152baf08cc1d0d6e752f0f415a89ec504e75300f43cc641545c",
+				"DiscoKey":   "discokey:2575290f2a9865811b75f96d25323f0cbcb518a03c11ea5f6c312bb2d8631b7d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55268", "10.65.0.27:55268", "172.17.0.1:55268"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:44:14.099376158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3175282898312887,
+				"StableID":   "naWkUFJ6oR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00e7065bc5687561874c708a625547af7053cde15e36921f6827e0553208d070",
+				"DiscoKey":   "discokey:3ab02831e9a734ca86798742f60d25d6e08f8abbc9c3533bdf50e793786ff73c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:47713", "10.65.0.27:47713", "172.17.0.1:47713"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:44:14.629128927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4997914966865596,
+				"StableID":   "nFYq4akZ2g11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8bddde38931ddf8542fe56429aadfd2d312b390ec11992075b8790380f310f29",
+				"KeyExpiry":  "2026-10-26T10:44:15Z",
+				"DiscoKey":   "discokey:35e8e117a46acf7aa4e528f2927ec4f7040cf315c32ce00819766cd8e7ba984f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53530", "10.65.0.27:53530", "172.17.0.1:53530"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:44:15.18187105Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7913421596501316,
+				"StableID":   "njc8FfA1o421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d9903521f19d2bd30949018e45d4e32a1ec6007486a7359a8638abd0366d567f",
+				"KeyExpiry":  "2026-10-26T10:44:15Z",
+				"DiscoKey":   "discokey:04aadf1df1e66422bcab47bdc151262f8b7a927821103ddf120e33025ffe250c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:57970", "10.65.0.27:57970", "172.17.0.1:57970"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:44:15.69700287Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4810077743070462,
+				"StableID":   "nDrRpyaVZe11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c6fe1ad53db6dc4844085251ba11c4123fbd984a18d6a7165135e07f20376027",
+				"KeyExpiry":  "2026-10-26T10:44:16Z",
+				"DiscoKey":   "discokey:b1420fb98d8cf02290514ce365ea7fbc1f6ca4c2bb19f0f341b36658b1212f2e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51314", "10.65.0.27:51314", "172.17.0.1:51314"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:44:16.243607392Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5371161768079166": {
+				"ID":          5371161768079166,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7913421596501316,
+				"StableID":   "njc8FfA1o421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d9903521f19d2bd30949018e45d4e32a1ec6007486a7359a8638abd0366d567f",
+				"KeyExpiry":  "2026-10-26T10:44:15Z",
+				"DiscoKey":   "discokey:04aadf1df1e66422bcab47bdc151262f8b7a927821103ddf120e33025ffe250c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:57970", "10.65.0.27:57970", "172.17.0.1:57970"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:44:15.69700287Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d9903521f19d2bd30949018e45d4e32a1ec6007486a7359a8638abd0366d567f",
+			"MachineKey": "mkey:8533724fa6788f9f9dd879c1d9f70a406045236214d076e145b5e0c5d3035a3d",
+			"Peers": [{
+				"ID":         1572896685685548,
+				"StableID":   "nmhyy4LNHD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fb9dd355064d6fbe7257942657633d38fc7fe4170d44265d50cb796dbbdf835",
+				"DiscoKey":   "discokey:47811b3ccdeb1ccd7fac642608ed40638ad4db7779461b13d431dbc2094e2742",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41161", "10.65.0.27:41161", "172.17.0.1:41161"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:44:12.3130416Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5371161768079166,
+				"StableID":   "nH4Rm5Kcwi11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a83e64994ca30e6ae5fe274be5747d3f11d3a4742a920a4bfc52242dadc5f72",
+				"DiscoKey":   "discokey:87cc7b33300dafe87503ae43ab9ac9266185340169332b7aaa98a33ec8f32652",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52617", "10.65.0.27:52617", "172.17.0.1:52617"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:44:13.008879023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5043988658084634,
+				"StableID":   "nPfTPg2SPg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb1f1d7430c965c0ab8555379135835b649b69f0b31b6098d6f1e8a070761317",
+				"DiscoKey":   "discokey:6e27c319cbe5262dc2457e465e45eddc672f04af05ea7b9b955f8812eba4ae45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60575", "10.65.0.27:60575", "172.17.0.1:60575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:44:13.540351589Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7285994201530088,
+				"StableID":   "nFrhsLiqty11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4fa97de79ea2d152baf08cc1d0d6e752f0f415a89ec504e75300f43cc641545c",
+				"DiscoKey":   "discokey:2575290f2a9865811b75f96d25323f0cbcb518a03c11ea5f6c312bb2d8631b7d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55268", "10.65.0.27:55268", "172.17.0.1:55268"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:44:14.099376158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3175282898312887,
+				"StableID":   "naWkUFJ6oR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00e7065bc5687561874c708a625547af7053cde15e36921f6827e0553208d070",
+				"DiscoKey":   "discokey:3ab02831e9a734ca86798742f60d25d6e08f8abbc9c3533bdf50e793786ff73c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:47713", "10.65.0.27:47713", "172.17.0.1:47713"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:44:14.629128927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4997914966865596,
+				"StableID":   "nFYq4akZ2g11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8bddde38931ddf8542fe56429aadfd2d312b390ec11992075b8790380f310f29",
+				"KeyExpiry":  "2026-10-26T10:44:15Z",
+				"DiscoKey":   "discokey:35e8e117a46acf7aa4e528f2927ec4f7040cf315c32ce00819766cd8e7ba984f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53530", "10.65.0.27:53530", "172.17.0.1:53530"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:44:15.18187105Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4810077743070462,
+				"StableID":   "nDrRpyaVZe11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c6fe1ad53db6dc4844085251ba11c4123fbd984a18d6a7165135e07f20376027",
+				"KeyExpiry":  "2026-10-26T10:44:16Z",
+				"DiscoKey":   "discokey:b1420fb98d8cf02290514ce365ea7fbc1f6ca4c2bb19f0f341b36658b1212f2e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51314", "10.65.0.27:51314", "172.17.0.1:51314"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:44:16.243607392Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5043988658084634,
+				"StableID":   "nPfTPg2SPg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       5043988658084634,
+				"Key":        "nodekey:cb1f1d7430c965c0ab8555379135835b649b69f0b31b6098d6f1e8a070761317",
+				"DiscoKey":   "discokey:6e27c319cbe5262dc2457e465e45eddc672f04af05ea7b9b955f8812eba4ae45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60575", "10.65.0.27:60575", "172.17.0.1:60575"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:44:13.540351589Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cb1f1d7430c965c0ab8555379135835b649b69f0b31b6098d6f1e8a070761317",
+			"MachineKey": "mkey:32eef691b325281b1a4cc46291c25b77e63c7097a25396efb4d6db315fd3a04e",
+			"Peers": [{
+				"ID":         1572896685685548,
+				"StableID":   "nmhyy4LNHD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fb9dd355064d6fbe7257942657633d38fc7fe4170d44265d50cb796dbbdf835",
+				"DiscoKey":   "discokey:47811b3ccdeb1ccd7fac642608ed40638ad4db7779461b13d431dbc2094e2742",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41161", "10.65.0.27:41161", "172.17.0.1:41161"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:44:12.3130416Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5371161768079166,
+				"StableID":   "nH4Rm5Kcwi11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a83e64994ca30e6ae5fe274be5747d3f11d3a4742a920a4bfc52242dadc5f72",
+				"DiscoKey":   "discokey:87cc7b33300dafe87503ae43ab9ac9266185340169332b7aaa98a33ec8f32652",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52617", "10.65.0.27:52617", "172.17.0.1:52617"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:44:13.008879023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7285994201530088,
+				"StableID":   "nFrhsLiqty11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4fa97de79ea2d152baf08cc1d0d6e752f0f415a89ec504e75300f43cc641545c",
+				"DiscoKey":   "discokey:2575290f2a9865811b75f96d25323f0cbcb518a03c11ea5f6c312bb2d8631b7d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55268", "10.65.0.27:55268", "172.17.0.1:55268"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:44:14.099376158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3175282898312887,
+				"StableID":   "naWkUFJ6oR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00e7065bc5687561874c708a625547af7053cde15e36921f6827e0553208d070",
+				"DiscoKey":   "discokey:3ab02831e9a734ca86798742f60d25d6e08f8abbc9c3533bdf50e793786ff73c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:47713", "10.65.0.27:47713", "172.17.0.1:47713"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:44:14.629128927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4997914966865596,
+				"StableID":   "nFYq4akZ2g11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8bddde38931ddf8542fe56429aadfd2d312b390ec11992075b8790380f310f29",
+				"KeyExpiry":  "2026-10-26T10:44:15Z",
+				"DiscoKey":   "discokey:35e8e117a46acf7aa4e528f2927ec4f7040cf315c32ce00819766cd8e7ba984f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53530", "10.65.0.27:53530", "172.17.0.1:53530"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:44:15.18187105Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7913421596501316,
+				"StableID":   "njc8FfA1o421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d9903521f19d2bd30949018e45d4e32a1ec6007486a7359a8638abd0366d567f",
+				"KeyExpiry":  "2026-10-26T10:44:15Z",
+				"DiscoKey":   "discokey:04aadf1df1e66422bcab47bdc151262f8b7a927821103ddf120e33025ffe250c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:57970", "10.65.0.27:57970", "172.17.0.1:57970"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:44:15.69700287Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4810077743070462,
+				"StableID":   "nDrRpyaVZe11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c6fe1ad53db6dc4844085251ba11c4123fbd984a18d6a7165135e07f20376027",
+				"KeyExpiry":  "2026-10-26T10:44:16Z",
+				"DiscoKey":   "discokey:b1420fb98d8cf02290514ce365ea7fbc1f6ca4c2bb19f0f341b36658b1212f2e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51314", "10.65.0.27:51314", "172.17.0.1:51314"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:44:16.243607392Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5043988658084634": {
+				"ID":          5043988658084634,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-deny-fail-autogroup-member-src-wildcard-dst.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-deny-fail-autogroup-member-src-wildcard-dst.hujson
@@ -1,0 +1,8843 @@
+// policytest-deny-fail-autogroup-member-src-wildcard-dst
+//
+// tests block deny-fail: autogroup:member src to wildcard dst, allow-all policy
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:44:37Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-deny-fail-autogroup-member-src-wildcard-dst",
+	"description":    "tests block deny-fail: autogroup:member src to wildcard dst, allow-all policy",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:44:37.948922728Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                         \n  \n                                                                     \n                                                   \n{\n\t\"id\":          \"policytest-deny-fail-autogroup-member-src-wildcard-dst\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block deny-fail: autogroup:member src to wildcard dst, allow-all policy\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"autogroup:member\"], \"dst\": [\"*:*\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"autogroup:member\", \"deny\": [\"*:*\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-deny-fail-autogroup-member-src-wildcard-dst.hujson",
+		"full_policy": {
+			"acls": [{"action": "accept", "dst": ["*:*"], "src": ["autogroup:member"]}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"deny": ["*:*"], "src": "autogroup:member"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3564166014540759,
+				"StableID":   "nEkvnebDqU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       3564166014540759,
+				"Key":        "nodekey:7e4e295bc79020d901f67598d90731e8607aaf34b39a9cd24a8b27aad4456308",
+				"DiscoKey":   "discokey:89a4c78ceea3766090e09d4eec7098578dfd5eb2dba557bdba24ac9ba9493007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:50820", "10.65.0.27:50820", "172.17.0.1:50820"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:44:41.581327489Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7e4e295bc79020d901f67598d90731e8607aaf34b39a9cd24a8b27aad4456308",
+			"MachineKey": "mkey:64c9681f19020d2ec7b07d1979f95152cc1c2571305655f3eeb741cd5254de59",
+			"Peers": [{
+				"ID":         2928912232867134,
+				"StableID":   "nHavRMZWsP11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a16b59205fec4ebfc2649a535c20b112607eb0a47536a4a20e19ad0a36ca3b1f",
+				"DiscoKey":   "discokey:9395332bf0d4c455a4c0348cb1405739d26c892f2cfad07dd6d4c2ba20860009",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:49490", "10.65.0.27:49490", "172.17.0.1:49490"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:44:39.460816504Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1214378484917727,
+				"StableID":   "nQyZGVfzUA11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:32d4218018e385f2d253a532d17010b29d482e717589be92fd23f5c8d9754608",
+				"DiscoKey":   "discokey:57129ee77ec0d49a8c39867b616d29c2da91071710db800891939f7e3aa35070",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47290", "10.65.0.27:47290", "172.17.0.1:47290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:44:40.005182572Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5061435419225657,
+				"StableID":   "nkrgvtKLXg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:834286553b420dead9f9f1839e73679510d5b1d903220816bcfa1193b6b47b58",
+				"DiscoKey":   "discokey:75ec547a1851cb2afc8385bb8739cdf26628e82e28af05c23e9e02586bf3f62d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49961", "10.65.0.27:49961", "172.17.0.1:49961"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:44:40.515703385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         518598010798556,
+				"StableID":   "nD3pM3hs3511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3f500b270ffe929300a84585c2a9e96d844f86622cf30ebd84285e280813d26e",
+				"DiscoKey":   "discokey:680055814c43c2b5f865dea0f61efda81285e1e9517fc4d1cfebbd0fb6172355",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47805", "10.65.0.27:47805", "172.17.0.1:47805"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:44:41.06241377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4138047431458956,
+				"StableID":   "n1DYSNV8KZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bf4d0bf9ee4a6550676ee4259f41a065f1341890c9aaaf6ad47b38044bf3e7c",
+				"KeyExpiry":  "2026-10-26T10:44:42Z",
+				"DiscoKey":   "discokey:8065236ef85c6b0fc7aaf2a9decc2b35730ad7a8801a2883ae37966b165b7a1e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49438", "10.65.0.27:49438", "172.17.0.1:49438"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:44:42.131759986Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5218714219158154,
+				"StableID":   "nmgBuqmZkh11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0a058629a12e57bc156572913479077e44a89709de5c5b847f5500a59c264e6b",
+				"KeyExpiry":  "2026-10-26T10:44:42Z",
+				"DiscoKey":   "discokey:6dc44a7bf6e3bdfff885e51474392dd9b8c526f04ca8459827a0ac611c7d080f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:51601", "10.65.0.27:51601", "172.17.0.1:51601"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:44:42.654686675Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2633744816531722,
+				"StableID":   "nyQtbb1qZM11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:81b04c4d337014a6809319f08d1637333806912bc20a13f2559c721651c30a6b",
+				"KeyExpiry":  "2026-10-26T10:44:43Z",
+				"DiscoKey":   "discokey:e00022adfefa77acef5577750e6703c5dca0e23b723a9d2ba2b6aaf1973f6f39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:44608", "10.65.0.27:44608", "172.17.0.1:44608"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:44:43.184901839Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3564166014540759": {
+				"ID":          3564166014540759,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2633744816531722,
+				"StableID":   "nyQtbb1qZM11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:81b04c4d337014a6809319f08d1637333806912bc20a13f2559c721651c30a6b",
+				"KeyExpiry":  "2026-10-26T10:44:43Z",
+				"DiscoKey":   "discokey:e00022adfefa77acef5577750e6703c5dca0e23b723a9d2ba2b6aaf1973f6f39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:44608", "10.65.0.27:44608", "172.17.0.1:44608"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:44:43.184901839Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:81b04c4d337014a6809319f08d1637333806912bc20a13f2559c721651c30a6b",
+			"MachineKey": "mkey:99752369037898cc25dd67828e8deebcb8a01f51597a812bb49cb254a34a6377",
+			"Peers": [{
+				"ID":         2928912232867134,
+				"StableID":   "nHavRMZWsP11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a16b59205fec4ebfc2649a535c20b112607eb0a47536a4a20e19ad0a36ca3b1f",
+				"DiscoKey":   "discokey:9395332bf0d4c455a4c0348cb1405739d26c892f2cfad07dd6d4c2ba20860009",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:49490", "10.65.0.27:49490", "172.17.0.1:49490"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:44:39.460816504Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1214378484917727,
+				"StableID":   "nQyZGVfzUA11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:32d4218018e385f2d253a532d17010b29d482e717589be92fd23f5c8d9754608",
+				"DiscoKey":   "discokey:57129ee77ec0d49a8c39867b616d29c2da91071710db800891939f7e3aa35070",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47290", "10.65.0.27:47290", "172.17.0.1:47290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:44:40.005182572Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5061435419225657,
+				"StableID":   "nkrgvtKLXg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:834286553b420dead9f9f1839e73679510d5b1d903220816bcfa1193b6b47b58",
+				"DiscoKey":   "discokey:75ec547a1851cb2afc8385bb8739cdf26628e82e28af05c23e9e02586bf3f62d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49961", "10.65.0.27:49961", "172.17.0.1:49961"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:44:40.515703385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         518598010798556,
+				"StableID":   "nD3pM3hs3511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3f500b270ffe929300a84585c2a9e96d844f86622cf30ebd84285e280813d26e",
+				"DiscoKey":   "discokey:680055814c43c2b5f865dea0f61efda81285e1e9517fc4d1cfebbd0fb6172355",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47805", "10.65.0.27:47805", "172.17.0.1:47805"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:44:41.06241377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3564166014540759,
+				"StableID":   "nEkvnebDqU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7e4e295bc79020d901f67598d90731e8607aaf34b39a9cd24a8b27aad4456308",
+				"DiscoKey":   "discokey:89a4c78ceea3766090e09d4eec7098578dfd5eb2dba557bdba24ac9ba9493007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:50820", "10.65.0.27:50820", "172.17.0.1:50820"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:44:41.581327489Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4138047431458956,
+				"StableID":   "n1DYSNV8KZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bf4d0bf9ee4a6550676ee4259f41a065f1341890c9aaaf6ad47b38044bf3e7c",
+				"KeyExpiry":  "2026-10-26T10:44:42Z",
+				"DiscoKey":   "discokey:8065236ef85c6b0fc7aaf2a9decc2b35730ad7a8801a2883ae37966b165b7a1e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49438", "10.65.0.27:49438", "172.17.0.1:49438"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:44:42.131759986Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5218714219158154,
+				"StableID":   "nmgBuqmZkh11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0a058629a12e57bc156572913479077e44a89709de5c5b847f5500a59c264e6b",
+				"KeyExpiry":  "2026-10-26T10:44:42Z",
+				"DiscoKey":   "discokey:6dc44a7bf6e3bdfff885e51474392dd9b8c526f04ca8459827a0ac611c7d080f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:51601", "10.65.0.27:51601", "172.17.0.1:51601"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:44:42.654686675Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2928912232867134,
+				"StableID":   "nHavRMZWsP11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       2928912232867134,
+				"Key":        "nodekey:a16b59205fec4ebfc2649a535c20b112607eb0a47536a4a20e19ad0a36ca3b1f",
+				"DiscoKey":   "discokey:9395332bf0d4c455a4c0348cb1405739d26c892f2cfad07dd6d4c2ba20860009",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:49490", "10.65.0.27:49490", "172.17.0.1:49490"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:44:39.460816504Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a16b59205fec4ebfc2649a535c20b112607eb0a47536a4a20e19ad0a36ca3b1f",
+			"MachineKey": "mkey:b7b92dd43defdee60c29aa602fabb44f883bf33cf38477f54942d1cff276862f",
+			"Peers": [{
+				"ID":         1214378484917727,
+				"StableID":   "nQyZGVfzUA11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:32d4218018e385f2d253a532d17010b29d482e717589be92fd23f5c8d9754608",
+				"DiscoKey":   "discokey:57129ee77ec0d49a8c39867b616d29c2da91071710db800891939f7e3aa35070",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47290", "10.65.0.27:47290", "172.17.0.1:47290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:44:40.005182572Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5061435419225657,
+				"StableID":   "nkrgvtKLXg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:834286553b420dead9f9f1839e73679510d5b1d903220816bcfa1193b6b47b58",
+				"DiscoKey":   "discokey:75ec547a1851cb2afc8385bb8739cdf26628e82e28af05c23e9e02586bf3f62d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49961", "10.65.0.27:49961", "172.17.0.1:49961"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:44:40.515703385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         518598010798556,
+				"StableID":   "nD3pM3hs3511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3f500b270ffe929300a84585c2a9e96d844f86622cf30ebd84285e280813d26e",
+				"DiscoKey":   "discokey:680055814c43c2b5f865dea0f61efda81285e1e9517fc4d1cfebbd0fb6172355",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47805", "10.65.0.27:47805", "172.17.0.1:47805"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:44:41.06241377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3564166014540759,
+				"StableID":   "nEkvnebDqU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7e4e295bc79020d901f67598d90731e8607aaf34b39a9cd24a8b27aad4456308",
+				"DiscoKey":   "discokey:89a4c78ceea3766090e09d4eec7098578dfd5eb2dba557bdba24ac9ba9493007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:50820", "10.65.0.27:50820", "172.17.0.1:50820"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:44:41.581327489Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4138047431458956,
+				"StableID":   "n1DYSNV8KZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bf4d0bf9ee4a6550676ee4259f41a065f1341890c9aaaf6ad47b38044bf3e7c",
+				"KeyExpiry":  "2026-10-26T10:44:42Z",
+				"DiscoKey":   "discokey:8065236ef85c6b0fc7aaf2a9decc2b35730ad7a8801a2883ae37966b165b7a1e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49438", "10.65.0.27:49438", "172.17.0.1:49438"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:44:42.131759986Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5218714219158154,
+				"StableID":   "nmgBuqmZkh11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0a058629a12e57bc156572913479077e44a89709de5c5b847f5500a59c264e6b",
+				"KeyExpiry":  "2026-10-26T10:44:42Z",
+				"DiscoKey":   "discokey:6dc44a7bf6e3bdfff885e51474392dd9b8c526f04ca8459827a0ac611c7d080f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:51601", "10.65.0.27:51601", "172.17.0.1:51601"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:44:42.654686675Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2633744816531722,
+				"StableID":   "nyQtbb1qZM11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:81b04c4d337014a6809319f08d1637333806912bc20a13f2559c721651c30a6b",
+				"KeyExpiry":  "2026-10-26T10:44:43Z",
+				"DiscoKey":   "discokey:e00022adfefa77acef5577750e6703c5dca0e23b723a9d2ba2b6aaf1973f6f39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:44608", "10.65.0.27:44608", "172.17.0.1:44608"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:44:43.184901839Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2928912232867134": {
+				"ID":          2928912232867134,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4138047431458956,
+				"StableID":   "n1DYSNV8KZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bf4d0bf9ee4a6550676ee4259f41a065f1341890c9aaaf6ad47b38044bf3e7c",
+				"KeyExpiry":  "2026-10-26T10:44:42Z",
+				"DiscoKey":   "discokey:8065236ef85c6b0fc7aaf2a9decc2b35730ad7a8801a2883ae37966b165b7a1e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49438", "10.65.0.27:49438", "172.17.0.1:49438"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:44:42.131759986Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6bf4d0bf9ee4a6550676ee4259f41a065f1341890c9aaaf6ad47b38044bf3e7c",
+			"MachineKey": "mkey:e5b368ea8b165e1a5d250774fb5b00c54f099cb25ffeba3d08c84314ce04e857",
+			"Peers": [{
+				"ID":         2928912232867134,
+				"StableID":   "nHavRMZWsP11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a16b59205fec4ebfc2649a535c20b112607eb0a47536a4a20e19ad0a36ca3b1f",
+				"DiscoKey":   "discokey:9395332bf0d4c455a4c0348cb1405739d26c892f2cfad07dd6d4c2ba20860009",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:49490", "10.65.0.27:49490", "172.17.0.1:49490"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:44:39.460816504Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1214378484917727,
+				"StableID":   "nQyZGVfzUA11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:32d4218018e385f2d253a532d17010b29d482e717589be92fd23f5c8d9754608",
+				"DiscoKey":   "discokey:57129ee77ec0d49a8c39867b616d29c2da91071710db800891939f7e3aa35070",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47290", "10.65.0.27:47290", "172.17.0.1:47290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:44:40.005182572Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5061435419225657,
+				"StableID":   "nkrgvtKLXg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:834286553b420dead9f9f1839e73679510d5b1d903220816bcfa1193b6b47b58",
+				"DiscoKey":   "discokey:75ec547a1851cb2afc8385bb8739cdf26628e82e28af05c23e9e02586bf3f62d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49961", "10.65.0.27:49961", "172.17.0.1:49961"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:44:40.515703385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         518598010798556,
+				"StableID":   "nD3pM3hs3511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3f500b270ffe929300a84585c2a9e96d844f86622cf30ebd84285e280813d26e",
+				"DiscoKey":   "discokey:680055814c43c2b5f865dea0f61efda81285e1e9517fc4d1cfebbd0fb6172355",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47805", "10.65.0.27:47805", "172.17.0.1:47805"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:44:41.06241377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3564166014540759,
+				"StableID":   "nEkvnebDqU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7e4e295bc79020d901f67598d90731e8607aaf34b39a9cd24a8b27aad4456308",
+				"DiscoKey":   "discokey:89a4c78ceea3766090e09d4eec7098578dfd5eb2dba557bdba24ac9ba9493007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:50820", "10.65.0.27:50820", "172.17.0.1:50820"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:44:41.581327489Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5218714219158154,
+				"StableID":   "nmgBuqmZkh11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0a058629a12e57bc156572913479077e44a89709de5c5b847f5500a59c264e6b",
+				"KeyExpiry":  "2026-10-26T10:44:42Z",
+				"DiscoKey":   "discokey:6dc44a7bf6e3bdfff885e51474392dd9b8c526f04ca8459827a0ac611c7d080f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:51601", "10.65.0.27:51601", "172.17.0.1:51601"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:44:42.654686675Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2633744816531722,
+				"StableID":   "nyQtbb1qZM11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:81b04c4d337014a6809319f08d1637333806912bc20a13f2559c721651c30a6b",
+				"KeyExpiry":  "2026-10-26T10:44:43Z",
+				"DiscoKey":   "discokey:e00022adfefa77acef5577750e6703c5dca0e23b723a9d2ba2b6aaf1973f6f39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:44608", "10.65.0.27:44608", "172.17.0.1:44608"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:44:43.184901839Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         518598010798556,
+				"StableID":   "nD3pM3hs3511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       518598010798556,
+				"Key":        "nodekey:3f500b270ffe929300a84585c2a9e96d844f86622cf30ebd84285e280813d26e",
+				"DiscoKey":   "discokey:680055814c43c2b5f865dea0f61efda81285e1e9517fc4d1cfebbd0fb6172355",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47805", "10.65.0.27:47805", "172.17.0.1:47805"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:44:41.06241377Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3f500b270ffe929300a84585c2a9e96d844f86622cf30ebd84285e280813d26e",
+			"MachineKey": "mkey:cf8ba4e2407351975ff236e90698cdf57870c8b66ab9c89788501007a35cd379",
+			"Peers": [{
+				"ID":         2928912232867134,
+				"StableID":   "nHavRMZWsP11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a16b59205fec4ebfc2649a535c20b112607eb0a47536a4a20e19ad0a36ca3b1f",
+				"DiscoKey":   "discokey:9395332bf0d4c455a4c0348cb1405739d26c892f2cfad07dd6d4c2ba20860009",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:49490", "10.65.0.27:49490", "172.17.0.1:49490"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:44:39.460816504Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1214378484917727,
+				"StableID":   "nQyZGVfzUA11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:32d4218018e385f2d253a532d17010b29d482e717589be92fd23f5c8d9754608",
+				"DiscoKey":   "discokey:57129ee77ec0d49a8c39867b616d29c2da91071710db800891939f7e3aa35070",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47290", "10.65.0.27:47290", "172.17.0.1:47290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:44:40.005182572Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5061435419225657,
+				"StableID":   "nkrgvtKLXg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:834286553b420dead9f9f1839e73679510d5b1d903220816bcfa1193b6b47b58",
+				"DiscoKey":   "discokey:75ec547a1851cb2afc8385bb8739cdf26628e82e28af05c23e9e02586bf3f62d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49961", "10.65.0.27:49961", "172.17.0.1:49961"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:44:40.515703385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3564166014540759,
+				"StableID":   "nEkvnebDqU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7e4e295bc79020d901f67598d90731e8607aaf34b39a9cd24a8b27aad4456308",
+				"DiscoKey":   "discokey:89a4c78ceea3766090e09d4eec7098578dfd5eb2dba557bdba24ac9ba9493007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:50820", "10.65.0.27:50820", "172.17.0.1:50820"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:44:41.581327489Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4138047431458956,
+				"StableID":   "n1DYSNV8KZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bf4d0bf9ee4a6550676ee4259f41a065f1341890c9aaaf6ad47b38044bf3e7c",
+				"KeyExpiry":  "2026-10-26T10:44:42Z",
+				"DiscoKey":   "discokey:8065236ef85c6b0fc7aaf2a9decc2b35730ad7a8801a2883ae37966b165b7a1e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49438", "10.65.0.27:49438", "172.17.0.1:49438"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:44:42.131759986Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5218714219158154,
+				"StableID":   "nmgBuqmZkh11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0a058629a12e57bc156572913479077e44a89709de5c5b847f5500a59c264e6b",
+				"KeyExpiry":  "2026-10-26T10:44:42Z",
+				"DiscoKey":   "discokey:6dc44a7bf6e3bdfff885e51474392dd9b8c526f04ca8459827a0ac611c7d080f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:51601", "10.65.0.27:51601", "172.17.0.1:51601"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:44:42.654686675Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2633744816531722,
+				"StableID":   "nyQtbb1qZM11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:81b04c4d337014a6809319f08d1637333806912bc20a13f2559c721651c30a6b",
+				"KeyExpiry":  "2026-10-26T10:44:43Z",
+				"DiscoKey":   "discokey:e00022adfefa77acef5577750e6703c5dca0e23b723a9d2ba2b6aaf1973f6f39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:44608", "10.65.0.27:44608", "172.17.0.1:44608"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:44:43.184901839Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "518598010798556": {
+				"ID":          518598010798556,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1214378484917727,
+				"StableID":   "nQyZGVfzUA11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1214378484917727,
+				"Key":        "nodekey:32d4218018e385f2d253a532d17010b29d482e717589be92fd23f5c8d9754608",
+				"DiscoKey":   "discokey:57129ee77ec0d49a8c39867b616d29c2da91071710db800891939f7e3aa35070",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47290", "10.65.0.27:47290", "172.17.0.1:47290"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:44:40.005182572Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:32d4218018e385f2d253a532d17010b29d482e717589be92fd23f5c8d9754608",
+			"MachineKey": "mkey:24bed1fb34f30f648e3189e8fa9d3c22587356d3ccfe3b071ca7080cf701395a",
+			"Peers": [{
+				"ID":         2928912232867134,
+				"StableID":   "nHavRMZWsP11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a16b59205fec4ebfc2649a535c20b112607eb0a47536a4a20e19ad0a36ca3b1f",
+				"DiscoKey":   "discokey:9395332bf0d4c455a4c0348cb1405739d26c892f2cfad07dd6d4c2ba20860009",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:49490", "10.65.0.27:49490", "172.17.0.1:49490"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:44:39.460816504Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5061435419225657,
+				"StableID":   "nkrgvtKLXg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:834286553b420dead9f9f1839e73679510d5b1d903220816bcfa1193b6b47b58",
+				"DiscoKey":   "discokey:75ec547a1851cb2afc8385bb8739cdf26628e82e28af05c23e9e02586bf3f62d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49961", "10.65.0.27:49961", "172.17.0.1:49961"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:44:40.515703385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         518598010798556,
+				"StableID":   "nD3pM3hs3511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3f500b270ffe929300a84585c2a9e96d844f86622cf30ebd84285e280813d26e",
+				"DiscoKey":   "discokey:680055814c43c2b5f865dea0f61efda81285e1e9517fc4d1cfebbd0fb6172355",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47805", "10.65.0.27:47805", "172.17.0.1:47805"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:44:41.06241377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3564166014540759,
+				"StableID":   "nEkvnebDqU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7e4e295bc79020d901f67598d90731e8607aaf34b39a9cd24a8b27aad4456308",
+				"DiscoKey":   "discokey:89a4c78ceea3766090e09d4eec7098578dfd5eb2dba557bdba24ac9ba9493007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:50820", "10.65.0.27:50820", "172.17.0.1:50820"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:44:41.581327489Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4138047431458956,
+				"StableID":   "n1DYSNV8KZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bf4d0bf9ee4a6550676ee4259f41a065f1341890c9aaaf6ad47b38044bf3e7c",
+				"KeyExpiry":  "2026-10-26T10:44:42Z",
+				"DiscoKey":   "discokey:8065236ef85c6b0fc7aaf2a9decc2b35730ad7a8801a2883ae37966b165b7a1e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49438", "10.65.0.27:49438", "172.17.0.1:49438"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:44:42.131759986Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5218714219158154,
+				"StableID":   "nmgBuqmZkh11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0a058629a12e57bc156572913479077e44a89709de5c5b847f5500a59c264e6b",
+				"KeyExpiry":  "2026-10-26T10:44:42Z",
+				"DiscoKey":   "discokey:6dc44a7bf6e3bdfff885e51474392dd9b8c526f04ca8459827a0ac611c7d080f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:51601", "10.65.0.27:51601", "172.17.0.1:51601"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:44:42.654686675Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2633744816531722,
+				"StableID":   "nyQtbb1qZM11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:81b04c4d337014a6809319f08d1637333806912bc20a13f2559c721651c30a6b",
+				"KeyExpiry":  "2026-10-26T10:44:43Z",
+				"DiscoKey":   "discokey:e00022adfefa77acef5577750e6703c5dca0e23b723a9d2ba2b6aaf1973f6f39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:44608", "10.65.0.27:44608", "172.17.0.1:44608"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:44:43.184901839Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1214378484917727": {
+				"ID":          1214378484917727,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5218714219158154,
+				"StableID":   "nmgBuqmZkh11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0a058629a12e57bc156572913479077e44a89709de5c5b847f5500a59c264e6b",
+				"KeyExpiry":  "2026-10-26T10:44:42Z",
+				"DiscoKey":   "discokey:6dc44a7bf6e3bdfff885e51474392dd9b8c526f04ca8459827a0ac611c7d080f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:51601", "10.65.0.27:51601", "172.17.0.1:51601"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:44:42.654686675Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0a058629a12e57bc156572913479077e44a89709de5c5b847f5500a59c264e6b",
+			"MachineKey": "mkey:8a547fa3d037400b6a1073e846f94294222c729b8556596632da76ff3ad8457b",
+			"Peers": [{
+				"ID":         2928912232867134,
+				"StableID":   "nHavRMZWsP11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a16b59205fec4ebfc2649a535c20b112607eb0a47536a4a20e19ad0a36ca3b1f",
+				"DiscoKey":   "discokey:9395332bf0d4c455a4c0348cb1405739d26c892f2cfad07dd6d4c2ba20860009",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:49490", "10.65.0.27:49490", "172.17.0.1:49490"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:44:39.460816504Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1214378484917727,
+				"StableID":   "nQyZGVfzUA11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:32d4218018e385f2d253a532d17010b29d482e717589be92fd23f5c8d9754608",
+				"DiscoKey":   "discokey:57129ee77ec0d49a8c39867b616d29c2da91071710db800891939f7e3aa35070",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47290", "10.65.0.27:47290", "172.17.0.1:47290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:44:40.005182572Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5061435419225657,
+				"StableID":   "nkrgvtKLXg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:834286553b420dead9f9f1839e73679510d5b1d903220816bcfa1193b6b47b58",
+				"DiscoKey":   "discokey:75ec547a1851cb2afc8385bb8739cdf26628e82e28af05c23e9e02586bf3f62d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49961", "10.65.0.27:49961", "172.17.0.1:49961"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:44:40.515703385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         518598010798556,
+				"StableID":   "nD3pM3hs3511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3f500b270ffe929300a84585c2a9e96d844f86622cf30ebd84285e280813d26e",
+				"DiscoKey":   "discokey:680055814c43c2b5f865dea0f61efda81285e1e9517fc4d1cfebbd0fb6172355",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47805", "10.65.0.27:47805", "172.17.0.1:47805"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:44:41.06241377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3564166014540759,
+				"StableID":   "nEkvnebDqU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7e4e295bc79020d901f67598d90731e8607aaf34b39a9cd24a8b27aad4456308",
+				"DiscoKey":   "discokey:89a4c78ceea3766090e09d4eec7098578dfd5eb2dba557bdba24ac9ba9493007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:50820", "10.65.0.27:50820", "172.17.0.1:50820"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:44:41.581327489Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4138047431458956,
+				"StableID":   "n1DYSNV8KZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bf4d0bf9ee4a6550676ee4259f41a065f1341890c9aaaf6ad47b38044bf3e7c",
+				"KeyExpiry":  "2026-10-26T10:44:42Z",
+				"DiscoKey":   "discokey:8065236ef85c6b0fc7aaf2a9decc2b35730ad7a8801a2883ae37966b165b7a1e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49438", "10.65.0.27:49438", "172.17.0.1:49438"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:44:42.131759986Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2633744816531722,
+				"StableID":   "nyQtbb1qZM11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:81b04c4d337014a6809319f08d1637333806912bc20a13f2559c721651c30a6b",
+				"KeyExpiry":  "2026-10-26T10:44:43Z",
+				"DiscoKey":   "discokey:e00022adfefa77acef5577750e6703c5dca0e23b723a9d2ba2b6aaf1973f6f39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:44608", "10.65.0.27:44608", "172.17.0.1:44608"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:44:43.184901839Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5061435419225657,
+				"StableID":   "nkrgvtKLXg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       5061435419225657,
+				"Key":        "nodekey:834286553b420dead9f9f1839e73679510d5b1d903220816bcfa1193b6b47b58",
+				"DiscoKey":   "discokey:75ec547a1851cb2afc8385bb8739cdf26628e82e28af05c23e9e02586bf3f62d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49961", "10.65.0.27:49961", "172.17.0.1:49961"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:44:40.515703385Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:834286553b420dead9f9f1839e73679510d5b1d903220816bcfa1193b6b47b58",
+			"MachineKey": "mkey:d21081958b617d1711bbb653334bee5587e651f041ffbc1159d2f7c28a7dc52b",
+			"Peers": [{
+				"ID":         2928912232867134,
+				"StableID":   "nHavRMZWsP11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a16b59205fec4ebfc2649a535c20b112607eb0a47536a4a20e19ad0a36ca3b1f",
+				"DiscoKey":   "discokey:9395332bf0d4c455a4c0348cb1405739d26c892f2cfad07dd6d4c2ba20860009",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:49490", "10.65.0.27:49490", "172.17.0.1:49490"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:44:39.460816504Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1214378484917727,
+				"StableID":   "nQyZGVfzUA11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:32d4218018e385f2d253a532d17010b29d482e717589be92fd23f5c8d9754608",
+				"DiscoKey":   "discokey:57129ee77ec0d49a8c39867b616d29c2da91071710db800891939f7e3aa35070",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47290", "10.65.0.27:47290", "172.17.0.1:47290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:44:40.005182572Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         518598010798556,
+				"StableID":   "nD3pM3hs3511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3f500b270ffe929300a84585c2a9e96d844f86622cf30ebd84285e280813d26e",
+				"DiscoKey":   "discokey:680055814c43c2b5f865dea0f61efda81285e1e9517fc4d1cfebbd0fb6172355",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47805", "10.65.0.27:47805", "172.17.0.1:47805"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:44:41.06241377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3564166014540759,
+				"StableID":   "nEkvnebDqU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7e4e295bc79020d901f67598d90731e8607aaf34b39a9cd24a8b27aad4456308",
+				"DiscoKey":   "discokey:89a4c78ceea3766090e09d4eec7098578dfd5eb2dba557bdba24ac9ba9493007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:50820", "10.65.0.27:50820", "172.17.0.1:50820"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:44:41.581327489Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4138047431458956,
+				"StableID":   "n1DYSNV8KZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bf4d0bf9ee4a6550676ee4259f41a065f1341890c9aaaf6ad47b38044bf3e7c",
+				"KeyExpiry":  "2026-10-26T10:44:42Z",
+				"DiscoKey":   "discokey:8065236ef85c6b0fc7aaf2a9decc2b35730ad7a8801a2883ae37966b165b7a1e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49438", "10.65.0.27:49438", "172.17.0.1:49438"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:44:42.131759986Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5218714219158154,
+				"StableID":   "nmgBuqmZkh11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0a058629a12e57bc156572913479077e44a89709de5c5b847f5500a59c264e6b",
+				"KeyExpiry":  "2026-10-26T10:44:42Z",
+				"DiscoKey":   "discokey:6dc44a7bf6e3bdfff885e51474392dd9b8c526f04ca8459827a0ac611c7d080f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:51601", "10.65.0.27:51601", "172.17.0.1:51601"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:44:42.654686675Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2633744816531722,
+				"StableID":   "nyQtbb1qZM11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:81b04c4d337014a6809319f08d1637333806912bc20a13f2559c721651c30a6b",
+				"KeyExpiry":  "2026-10-26T10:44:43Z",
+				"DiscoKey":   "discokey:e00022adfefa77acef5577750e6703c5dca0e23b723a9d2ba2b6aaf1973f6f39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:44608", "10.65.0.27:44608", "172.17.0.1:44608"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:44:43.184901839Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5061435419225657": {
+				"ID":          5061435419225657,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-deny-fail-autogroup-self-dst.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-deny-fail-autogroup-self-dst.hujson
@@ -1,0 +1,7757 @@
+// policytest-deny-fail-autogroup-self-dst
+//
+// tests block deny-fail: user src to autogroup:self dst, allow rule covers it
+//
+// Nodes with filter rules: 7 of 7
+// Captured at:    2026-04-29T10:45:04Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-deny-fail-autogroup-self-dst",
+	"description":    "tests block deny-fail: user src to autogroup:self dst, allow rule covers it",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:45:04.930167361Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                          \n  \n                                                                   \n                                                              \n{\n\t\"id\":          \"policytest-deny-fail-autogroup-self-dst\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block deny-fail: user src to autogroup:self dst, allow rule covers it\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"thor@example.org\"], \"dst\": [\"autogroup:self:22\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"deny\": [\"autogroup:self:22\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-deny-fail-autogroup-self-dst.hujson",
+		"full_policy": {
+			"acls": [{
+				"action": "accept",
+				"dst":    ["autogroup:self:22"],
+				"src":    ["thor@example.org"]
+			}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"deny": ["autogroup:self:22"], "src": "thor@example.org"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7964937749526870,
+				"StableID":   "n5J7HhQLC521CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       7964937749526870,
+				"Key":        "nodekey:556bdcb6b9ef29bcb25d0dde1538c2b3fc7d4edb535c2650f02dc4fdf172ee5d",
+				"DiscoKey":   "discokey:bbdb271661864e14aab5baa834c86b0e686132ec32132ff2dd834b0a20178027",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:37538", "10.65.0.27:37538", "172.17.0.1:37538"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:45:25.234687906Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:556bdcb6b9ef29bcb25d0dde1538c2b3fc7d4edb535c2650f02dc4fdf172ee5d",
+			"MachineKey": "mkey:42ba5811526e103b0c839cface59fdaa0b855ed24b913980bb8989d3df9a8644",
+			"Peers": [{
+				"ID":         6018192886955943,
+				"StableID":   "ncT36tiezo11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:24c21e279b98a859a335140a65cdae321640d4c80665a4da2af2e756b4769e4f",
+				"DiscoKey":   "discokey:065d62e815a5206950d0adf4570412682d0cd04f7342113287bbf0f6bcb1da14",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41719", "10.65.0.27:41719", "172.17.0.1:41719"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:45:10.432336627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2640296570983815,
+				"StableID":   "nkK1ib7ocM11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6247aa8dbf49bd028613ae75190053e9c12f1da986031b899451e4ed7cdb814d",
+				"DiscoKey":   "discokey:096d8f96e7deacbddc9b40a000882bcd30a5f2f8fd5fa37b69cc446eb33b544e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52151", "10.65.0.27:52151", "172.17.0.1:52151"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:45:12.859964622Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8797478807099931,
+				"StableID":   "nrtgdKrPhB21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:14e6bba16ab2622039c06377379649a866b6d72fb3bc7c96fbead2d66da8de49",
+				"DiscoKey":   "discokey:b8d0ee46cd24f63ee3c69d1b4d1bde98f20eb5d44163337490f23243d3196f41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59592", "10.65.0.27:59592", "172.17.0.1:59592"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:45:15.391814064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4621281802007578,
+				"StableID":   "nXfR1jEz5d11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4d3052356a4d7eb693aa324fd9d8f2611f2edffb6ae897bc46a9387b9652372",
+				"DiscoKey":   "discokey:666888ad841a84154f35d10805c2bf11c1cfdffb4ac5578fc5a4ff125d19366c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50336", "10.65.0.27:50336", "172.17.0.1:50336"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:45:19.856666165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6910339702057255,
+				"StableID":   "nQoC8Zuhxv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:591692e1c8a7326b41fa408254ff2df58b9eeaf1209cd6a2eb6e663b765de50f",
+				"KeyExpiry":  "2026-10-26T10:45:27Z",
+				"DiscoKey":   "discokey:be3aff8701b38997d82bf91ebd31ff8315c675e5e8530b338a4eb2f7b9c01366",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33100", "10.65.0.27:33100", "172.17.0.1:33100"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:45:27.603876755Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1725298868988020,
+				"StableID":   "nPCZ3CgPUE11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fc2fdf1fa9b3d4157c8dfece7383d68513d3eeb37ef8311f92b5f7db0b5e274d",
+				"KeyExpiry":  "2026-10-26T10:45:29Z",
+				"DiscoKey":   "discokey:05002fdafc3fd1405a20f5aeb67344354c0da2f58fca1cf3c524e0c1b400f033",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41973", "10.65.0.27:41973", "172.17.0.1:41973"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:45:29.106627127Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6624382809517615,
+				"StableID":   "nxH9kbJCjt11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f8b3c02fd4d4d7401195d0932abf4b8a152831bc07e9757daede66b1c796ae10",
+				"KeyExpiry":  "2026-10-26T10:45:29Z",
+				"DiscoKey":   "discokey:6057c722b6d7bdd1bbdeb2f47c0b996ab0c729e095037d9df9363d0453f2766d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:33180", "10.65.0.27:33180", "172.17.0.1:33180"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:45:29.738883273Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7964937749526870": {
+				"ID":          7964937749526870,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6624382809517615,
+				"StableID":   "nxH9kbJCjt11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f8b3c02fd4d4d7401195d0932abf4b8a152831bc07e9757daede66b1c796ae10",
+				"KeyExpiry":  "2026-10-26T10:45:29Z",
+				"DiscoKey":   "discokey:6057c722b6d7bdd1bbdeb2f47c0b996ab0c729e095037d9df9363d0453f2766d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:33180", "10.65.0.27:33180", "172.17.0.1:33180"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:45:29.738883273Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f8b3c02fd4d4d7401195d0932abf4b8a152831bc07e9757daede66b1c796ae10",
+			"MachineKey": "mkey:c2e865498b609855c0240d06c9680f0c8a50109a1ba8f7765879fba348481252",
+			"Peers": [{
+				"ID":         6018192886955943,
+				"StableID":   "ncT36tiezo11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:24c21e279b98a859a335140a65cdae321640d4c80665a4da2af2e756b4769e4f",
+				"DiscoKey":   "discokey:065d62e815a5206950d0adf4570412682d0cd04f7342113287bbf0f6bcb1da14",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41719", "10.65.0.27:41719", "172.17.0.1:41719"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:45:10.432336627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2640296570983815,
+				"StableID":   "nkK1ib7ocM11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6247aa8dbf49bd028613ae75190053e9c12f1da986031b899451e4ed7cdb814d",
+				"DiscoKey":   "discokey:096d8f96e7deacbddc9b40a000882bcd30a5f2f8fd5fa37b69cc446eb33b544e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52151", "10.65.0.27:52151", "172.17.0.1:52151"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:45:12.859964622Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8797478807099931,
+				"StableID":   "nrtgdKrPhB21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:14e6bba16ab2622039c06377379649a866b6d72fb3bc7c96fbead2d66da8de49",
+				"DiscoKey":   "discokey:b8d0ee46cd24f63ee3c69d1b4d1bde98f20eb5d44163337490f23243d3196f41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59592", "10.65.0.27:59592", "172.17.0.1:59592"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:45:15.391814064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4621281802007578,
+				"StableID":   "nXfR1jEz5d11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4d3052356a4d7eb693aa324fd9d8f2611f2edffb6ae897bc46a9387b9652372",
+				"DiscoKey":   "discokey:666888ad841a84154f35d10805c2bf11c1cfdffb4ac5578fc5a4ff125d19366c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50336", "10.65.0.27:50336", "172.17.0.1:50336"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:45:19.856666165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7964937749526870,
+				"StableID":   "n5J7HhQLC521CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:556bdcb6b9ef29bcb25d0dde1538c2b3fc7d4edb535c2650f02dc4fdf172ee5d",
+				"DiscoKey":   "discokey:bbdb271661864e14aab5baa834c86b0e686132ec32132ff2dd834b0a20178027",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:37538", "10.65.0.27:37538", "172.17.0.1:37538"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:45:25.234687906Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6910339702057255,
+				"StableID":   "nQoC8Zuhxv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:591692e1c8a7326b41fa408254ff2df58b9eeaf1209cd6a2eb6e663b765de50f",
+				"KeyExpiry":  "2026-10-26T10:45:27Z",
+				"DiscoKey":   "discokey:be3aff8701b38997d82bf91ebd31ff8315c675e5e8530b338a4eb2f7b9c01366",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33100", "10.65.0.27:33100", "172.17.0.1:33100"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:45:27.603876755Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1725298868988020,
+				"StableID":   "nPCZ3CgPUE11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fc2fdf1fa9b3d4157c8dfece7383d68513d3eeb37ef8311f92b5f7db0b5e274d",
+				"KeyExpiry":  "2026-10-26T10:45:29Z",
+				"DiscoKey":   "discokey:05002fdafc3fd1405a20f5aeb67344354c0da2f58fca1cf3c524e0c1b400f033",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41973", "10.65.0.27:41973", "172.17.0.1:41973"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:45:29.106627127Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6018192886955943,
+				"StableID":   "ncT36tiezo11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       6018192886955943,
+				"Key":        "nodekey:24c21e279b98a859a335140a65cdae321640d4c80665a4da2af2e756b4769e4f",
+				"DiscoKey":   "discokey:065d62e815a5206950d0adf4570412682d0cd04f7342113287bbf0f6bcb1da14",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41719", "10.65.0.27:41719", "172.17.0.1:41719"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:45:10.432336627Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:24c21e279b98a859a335140a65cdae321640d4c80665a4da2af2e756b4769e4f",
+			"MachineKey": "mkey:aac064d4dc6f60a0980d1933aa7922ebc3654078db53da3b0d026b65edd3443d",
+			"Peers": [{
+				"ID":         2640296570983815,
+				"StableID":   "nkK1ib7ocM11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6247aa8dbf49bd028613ae75190053e9c12f1da986031b899451e4ed7cdb814d",
+				"DiscoKey":   "discokey:096d8f96e7deacbddc9b40a000882bcd30a5f2f8fd5fa37b69cc446eb33b544e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52151", "10.65.0.27:52151", "172.17.0.1:52151"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:45:12.859964622Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8797478807099931,
+				"StableID":   "nrtgdKrPhB21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:14e6bba16ab2622039c06377379649a866b6d72fb3bc7c96fbead2d66da8de49",
+				"DiscoKey":   "discokey:b8d0ee46cd24f63ee3c69d1b4d1bde98f20eb5d44163337490f23243d3196f41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59592", "10.65.0.27:59592", "172.17.0.1:59592"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:45:15.391814064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4621281802007578,
+				"StableID":   "nXfR1jEz5d11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4d3052356a4d7eb693aa324fd9d8f2611f2edffb6ae897bc46a9387b9652372",
+				"DiscoKey":   "discokey:666888ad841a84154f35d10805c2bf11c1cfdffb4ac5578fc5a4ff125d19366c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50336", "10.65.0.27:50336", "172.17.0.1:50336"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:45:19.856666165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7964937749526870,
+				"StableID":   "n5J7HhQLC521CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:556bdcb6b9ef29bcb25d0dde1538c2b3fc7d4edb535c2650f02dc4fdf172ee5d",
+				"DiscoKey":   "discokey:bbdb271661864e14aab5baa834c86b0e686132ec32132ff2dd834b0a20178027",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:37538", "10.65.0.27:37538", "172.17.0.1:37538"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:45:25.234687906Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6910339702057255,
+				"StableID":   "nQoC8Zuhxv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:591692e1c8a7326b41fa408254ff2df58b9eeaf1209cd6a2eb6e663b765de50f",
+				"KeyExpiry":  "2026-10-26T10:45:27Z",
+				"DiscoKey":   "discokey:be3aff8701b38997d82bf91ebd31ff8315c675e5e8530b338a4eb2f7b9c01366",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33100", "10.65.0.27:33100", "172.17.0.1:33100"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:45:27.603876755Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1725298868988020,
+				"StableID":   "nPCZ3CgPUE11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fc2fdf1fa9b3d4157c8dfece7383d68513d3eeb37ef8311f92b5f7db0b5e274d",
+				"KeyExpiry":  "2026-10-26T10:45:29Z",
+				"DiscoKey":   "discokey:05002fdafc3fd1405a20f5aeb67344354c0da2f58fca1cf3c524e0c1b400f033",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41973", "10.65.0.27:41973", "172.17.0.1:41973"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:45:29.106627127Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6624382809517615,
+				"StableID":   "nxH9kbJCjt11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f8b3c02fd4d4d7401195d0932abf4b8a152831bc07e9757daede66b1c796ae10",
+				"KeyExpiry":  "2026-10-26T10:45:29Z",
+				"DiscoKey":   "discokey:6057c722b6d7bdd1bbdeb2f47c0b996ab0c729e095037d9df9363d0453f2766d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:33180", "10.65.0.27:33180", "172.17.0.1:33180"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:45:29.738883273Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6018192886955943": {
+				"ID":          6018192886955943,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6910339702057255,
+				"StableID":   "nQoC8Zuhxv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:591692e1c8a7326b41fa408254ff2df58b9eeaf1209cd6a2eb6e663b765de50f",
+				"KeyExpiry":  "2026-10-26T10:45:27Z",
+				"DiscoKey":   "discokey:be3aff8701b38997d82bf91ebd31ff8315c675e5e8530b338a4eb2f7b9c01366",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33100", "10.65.0.27:33100", "172.17.0.1:33100"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:45:27.603876755Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:591692e1c8a7326b41fa408254ff2df58b9eeaf1209cd6a2eb6e663b765de50f",
+			"MachineKey": "mkey:3d1b688960ebf39356a8c06a9d3284dde529a2ebf9d50e4f02f07f7aa6f85567",
+			"Peers": [{
+				"ID":         6018192886955943,
+				"StableID":   "ncT36tiezo11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:24c21e279b98a859a335140a65cdae321640d4c80665a4da2af2e756b4769e4f",
+				"DiscoKey":   "discokey:065d62e815a5206950d0adf4570412682d0cd04f7342113287bbf0f6bcb1da14",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41719", "10.65.0.27:41719", "172.17.0.1:41719"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:45:10.432336627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2640296570983815,
+				"StableID":   "nkK1ib7ocM11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6247aa8dbf49bd028613ae75190053e9c12f1da986031b899451e4ed7cdb814d",
+				"DiscoKey":   "discokey:096d8f96e7deacbddc9b40a000882bcd30a5f2f8fd5fa37b69cc446eb33b544e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52151", "10.65.0.27:52151", "172.17.0.1:52151"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:45:12.859964622Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8797478807099931,
+				"StableID":   "nrtgdKrPhB21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:14e6bba16ab2622039c06377379649a866b6d72fb3bc7c96fbead2d66da8de49",
+				"DiscoKey":   "discokey:b8d0ee46cd24f63ee3c69d1b4d1bde98f20eb5d44163337490f23243d3196f41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59592", "10.65.0.27:59592", "172.17.0.1:59592"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:45:15.391814064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4621281802007578,
+				"StableID":   "nXfR1jEz5d11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4d3052356a4d7eb693aa324fd9d8f2611f2edffb6ae897bc46a9387b9652372",
+				"DiscoKey":   "discokey:666888ad841a84154f35d10805c2bf11c1cfdffb4ac5578fc5a4ff125d19366c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50336", "10.65.0.27:50336", "172.17.0.1:50336"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:45:19.856666165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7964937749526870,
+				"StableID":   "n5J7HhQLC521CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:556bdcb6b9ef29bcb25d0dde1538c2b3fc7d4edb535c2650f02dc4fdf172ee5d",
+				"DiscoKey":   "discokey:bbdb271661864e14aab5baa834c86b0e686132ec32132ff2dd834b0a20178027",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:37538", "10.65.0.27:37538", "172.17.0.1:37538"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:45:25.234687906Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1725298868988020,
+				"StableID":   "nPCZ3CgPUE11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fc2fdf1fa9b3d4157c8dfece7383d68513d3eeb37ef8311f92b5f7db0b5e274d",
+				"KeyExpiry":  "2026-10-26T10:45:29Z",
+				"DiscoKey":   "discokey:05002fdafc3fd1405a20f5aeb67344354c0da2f58fca1cf3c524e0c1b400f033",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41973", "10.65.0.27:41973", "172.17.0.1:41973"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:45:29.106627127Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6624382809517615,
+				"StableID":   "nxH9kbJCjt11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f8b3c02fd4d4d7401195d0932abf4b8a152831bc07e9757daede66b1c796ae10",
+				"KeyExpiry":  "2026-10-26T10:45:29Z",
+				"DiscoKey":   "discokey:6057c722b6d7bdd1bbdeb2f47c0b996ab0c729e095037d9df9363d0453f2766d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:33180", "10.65.0.27:33180", "172.17.0.1:33180"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:45:29.738883273Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4621281802007578,
+				"StableID":   "nXfR1jEz5d11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       4621281802007578,
+				"Key":        "nodekey:e4d3052356a4d7eb693aa324fd9d8f2611f2edffb6ae897bc46a9387b9652372",
+				"DiscoKey":   "discokey:666888ad841a84154f35d10805c2bf11c1cfdffb4ac5578fc5a4ff125d19366c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50336", "10.65.0.27:50336", "172.17.0.1:50336"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:45:19.856666165Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e4d3052356a4d7eb693aa324fd9d8f2611f2edffb6ae897bc46a9387b9652372",
+			"MachineKey": "mkey:d383fa5b45040187b5ddcba7efda71232b1338052e342d554e6eeca236620b27",
+			"Peers": [{
+				"ID":         6018192886955943,
+				"StableID":   "ncT36tiezo11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:24c21e279b98a859a335140a65cdae321640d4c80665a4da2af2e756b4769e4f",
+				"DiscoKey":   "discokey:065d62e815a5206950d0adf4570412682d0cd04f7342113287bbf0f6bcb1da14",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41719", "10.65.0.27:41719", "172.17.0.1:41719"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:45:10.432336627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2640296570983815,
+				"StableID":   "nkK1ib7ocM11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6247aa8dbf49bd028613ae75190053e9c12f1da986031b899451e4ed7cdb814d",
+				"DiscoKey":   "discokey:096d8f96e7deacbddc9b40a000882bcd30a5f2f8fd5fa37b69cc446eb33b544e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52151", "10.65.0.27:52151", "172.17.0.1:52151"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:45:12.859964622Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8797478807099931,
+				"StableID":   "nrtgdKrPhB21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:14e6bba16ab2622039c06377379649a866b6d72fb3bc7c96fbead2d66da8de49",
+				"DiscoKey":   "discokey:b8d0ee46cd24f63ee3c69d1b4d1bde98f20eb5d44163337490f23243d3196f41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59592", "10.65.0.27:59592", "172.17.0.1:59592"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:45:15.391814064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7964937749526870,
+				"StableID":   "n5J7HhQLC521CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:556bdcb6b9ef29bcb25d0dde1538c2b3fc7d4edb535c2650f02dc4fdf172ee5d",
+				"DiscoKey":   "discokey:bbdb271661864e14aab5baa834c86b0e686132ec32132ff2dd834b0a20178027",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:37538", "10.65.0.27:37538", "172.17.0.1:37538"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:45:25.234687906Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6910339702057255,
+				"StableID":   "nQoC8Zuhxv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:591692e1c8a7326b41fa408254ff2df58b9eeaf1209cd6a2eb6e663b765de50f",
+				"KeyExpiry":  "2026-10-26T10:45:27Z",
+				"DiscoKey":   "discokey:be3aff8701b38997d82bf91ebd31ff8315c675e5e8530b338a4eb2f7b9c01366",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33100", "10.65.0.27:33100", "172.17.0.1:33100"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:45:27.603876755Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1725298868988020,
+				"StableID":   "nPCZ3CgPUE11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fc2fdf1fa9b3d4157c8dfece7383d68513d3eeb37ef8311f92b5f7db0b5e274d",
+				"KeyExpiry":  "2026-10-26T10:45:29Z",
+				"DiscoKey":   "discokey:05002fdafc3fd1405a20f5aeb67344354c0da2f58fca1cf3c524e0c1b400f033",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41973", "10.65.0.27:41973", "172.17.0.1:41973"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:45:29.106627127Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6624382809517615,
+				"StableID":   "nxH9kbJCjt11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f8b3c02fd4d4d7401195d0932abf4b8a152831bc07e9757daede66b1c796ae10",
+				"KeyExpiry":  "2026-10-26T10:45:29Z",
+				"DiscoKey":   "discokey:6057c722b6d7bdd1bbdeb2f47c0b996ab0c729e095037d9df9363d0453f2766d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:33180", "10.65.0.27:33180", "172.17.0.1:33180"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:45:29.738883273Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4621281802007578": {
+				"ID":          4621281802007578,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2640296570983815,
+				"StableID":   "nkK1ib7ocM11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       2640296570983815,
+				"Key":        "nodekey:6247aa8dbf49bd028613ae75190053e9c12f1da986031b899451e4ed7cdb814d",
+				"DiscoKey":   "discokey:096d8f96e7deacbddc9b40a000882bcd30a5f2f8fd5fa37b69cc446eb33b544e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52151", "10.65.0.27:52151", "172.17.0.1:52151"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:45:12.859964622Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6247aa8dbf49bd028613ae75190053e9c12f1da986031b899451e4ed7cdb814d",
+			"MachineKey": "mkey:cffba48903f1762ceff0798f088ff4f36e5d849f2181501dcdf1898fd6395528",
+			"Peers": [{
+				"ID":         6018192886955943,
+				"StableID":   "ncT36tiezo11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:24c21e279b98a859a335140a65cdae321640d4c80665a4da2af2e756b4769e4f",
+				"DiscoKey":   "discokey:065d62e815a5206950d0adf4570412682d0cd04f7342113287bbf0f6bcb1da14",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41719", "10.65.0.27:41719", "172.17.0.1:41719"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:45:10.432336627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8797478807099931,
+				"StableID":   "nrtgdKrPhB21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:14e6bba16ab2622039c06377379649a866b6d72fb3bc7c96fbead2d66da8de49",
+				"DiscoKey":   "discokey:b8d0ee46cd24f63ee3c69d1b4d1bde98f20eb5d44163337490f23243d3196f41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59592", "10.65.0.27:59592", "172.17.0.1:59592"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:45:15.391814064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4621281802007578,
+				"StableID":   "nXfR1jEz5d11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4d3052356a4d7eb693aa324fd9d8f2611f2edffb6ae897bc46a9387b9652372",
+				"DiscoKey":   "discokey:666888ad841a84154f35d10805c2bf11c1cfdffb4ac5578fc5a4ff125d19366c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50336", "10.65.0.27:50336", "172.17.0.1:50336"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:45:19.856666165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7964937749526870,
+				"StableID":   "n5J7HhQLC521CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:556bdcb6b9ef29bcb25d0dde1538c2b3fc7d4edb535c2650f02dc4fdf172ee5d",
+				"DiscoKey":   "discokey:bbdb271661864e14aab5baa834c86b0e686132ec32132ff2dd834b0a20178027",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:37538", "10.65.0.27:37538", "172.17.0.1:37538"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:45:25.234687906Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6910339702057255,
+				"StableID":   "nQoC8Zuhxv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:591692e1c8a7326b41fa408254ff2df58b9eeaf1209cd6a2eb6e663b765de50f",
+				"KeyExpiry":  "2026-10-26T10:45:27Z",
+				"DiscoKey":   "discokey:be3aff8701b38997d82bf91ebd31ff8315c675e5e8530b338a4eb2f7b9c01366",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33100", "10.65.0.27:33100", "172.17.0.1:33100"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:45:27.603876755Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1725298868988020,
+				"StableID":   "nPCZ3CgPUE11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fc2fdf1fa9b3d4157c8dfece7383d68513d3eeb37ef8311f92b5f7db0b5e274d",
+				"KeyExpiry":  "2026-10-26T10:45:29Z",
+				"DiscoKey":   "discokey:05002fdafc3fd1405a20f5aeb67344354c0da2f58fca1cf3c524e0c1b400f033",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41973", "10.65.0.27:41973", "172.17.0.1:41973"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:45:29.106627127Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6624382809517615,
+				"StableID":   "nxH9kbJCjt11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f8b3c02fd4d4d7401195d0932abf4b8a152831bc07e9757daede66b1c796ae10",
+				"KeyExpiry":  "2026-10-26T10:45:29Z",
+				"DiscoKey":   "discokey:6057c722b6d7bdd1bbdeb2f47c0b996ab0c729e095037d9df9363d0453f2766d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:33180", "10.65.0.27:33180", "172.17.0.1:33180"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:45:29.738883273Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2640296570983815": {
+				"ID":          2640296570983815,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1725298868988020,
+				"StableID":   "nPCZ3CgPUE11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fc2fdf1fa9b3d4157c8dfece7383d68513d3eeb37ef8311f92b5f7db0b5e274d",
+				"KeyExpiry":  "2026-10-26T10:45:29Z",
+				"DiscoKey":   "discokey:05002fdafc3fd1405a20f5aeb67344354c0da2f58fca1cf3c524e0c1b400f033",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41973", "10.65.0.27:41973", "172.17.0.1:41973"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:45:29.106627127Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fc2fdf1fa9b3d4157c8dfece7383d68513d3eeb37ef8311f92b5f7db0b5e274d",
+			"MachineKey": "mkey:a5a6e2b9dfa04c0fa23d6227bb3a4d99171252a775a6b18b82354984217f1e1a",
+			"Peers": [{
+				"ID":         6018192886955943,
+				"StableID":   "ncT36tiezo11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:24c21e279b98a859a335140a65cdae321640d4c80665a4da2af2e756b4769e4f",
+				"DiscoKey":   "discokey:065d62e815a5206950d0adf4570412682d0cd04f7342113287bbf0f6bcb1da14",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41719", "10.65.0.27:41719", "172.17.0.1:41719"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:45:10.432336627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2640296570983815,
+				"StableID":   "nkK1ib7ocM11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6247aa8dbf49bd028613ae75190053e9c12f1da986031b899451e4ed7cdb814d",
+				"DiscoKey":   "discokey:096d8f96e7deacbddc9b40a000882bcd30a5f2f8fd5fa37b69cc446eb33b544e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52151", "10.65.0.27:52151", "172.17.0.1:52151"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:45:12.859964622Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8797478807099931,
+				"StableID":   "nrtgdKrPhB21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:14e6bba16ab2622039c06377379649a866b6d72fb3bc7c96fbead2d66da8de49",
+				"DiscoKey":   "discokey:b8d0ee46cd24f63ee3c69d1b4d1bde98f20eb5d44163337490f23243d3196f41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59592", "10.65.0.27:59592", "172.17.0.1:59592"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:45:15.391814064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4621281802007578,
+				"StableID":   "nXfR1jEz5d11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4d3052356a4d7eb693aa324fd9d8f2611f2edffb6ae897bc46a9387b9652372",
+				"DiscoKey":   "discokey:666888ad841a84154f35d10805c2bf11c1cfdffb4ac5578fc5a4ff125d19366c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50336", "10.65.0.27:50336", "172.17.0.1:50336"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:45:19.856666165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7964937749526870,
+				"StableID":   "n5J7HhQLC521CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:556bdcb6b9ef29bcb25d0dde1538c2b3fc7d4edb535c2650f02dc4fdf172ee5d",
+				"DiscoKey":   "discokey:bbdb271661864e14aab5baa834c86b0e686132ec32132ff2dd834b0a20178027",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:37538", "10.65.0.27:37538", "172.17.0.1:37538"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:45:25.234687906Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6910339702057255,
+				"StableID":   "nQoC8Zuhxv11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:591692e1c8a7326b41fa408254ff2df58b9eeaf1209cd6a2eb6e663b765de50f",
+				"KeyExpiry":  "2026-10-26T10:45:27Z",
+				"DiscoKey":   "discokey:be3aff8701b38997d82bf91ebd31ff8315c675e5e8530b338a4eb2f7b9c01366",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:33100", "10.65.0.27:33100", "172.17.0.1:33100"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:45:27.603876755Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6624382809517615,
+				"StableID":   "nxH9kbJCjt11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f8b3c02fd4d4d7401195d0932abf4b8a152831bc07e9757daede66b1c796ae10",
+				"KeyExpiry":  "2026-10-26T10:45:29Z",
+				"DiscoKey":   "discokey:6057c722b6d7bdd1bbdeb2f47c0b996ab0c729e095037d9df9363d0453f2766d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:33180", "10.65.0.27:33180", "172.17.0.1:33180"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:45:29.738883273Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-deny-fail-group-src-cidr-dst.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-deny-fail-group-src-cidr-dst.hujson
@@ -1,0 +1,7746 @@
+// policytest-deny-fail-group-src-cidr-dst
+//
+// tests block deny-fail: group src to cidr dst, allow rule covers it
+//
+// Nodes with filter rules: 7 of 7
+// Captured at:    2026-04-29T10:45:49Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-deny-fail-group-src-cidr-dst",
+	"description":    "tests block deny-fail: group src to cidr dst, allow rule covers it",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:45:49.738495603Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                          \n  \n                                                                       \n                                                            \n{\n\t\"id\":          \"policytest-deny-fail-group-src-cidr-dst\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block deny-fail: group src to cidr dst, allow rule covers it\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"group:developers\"], \"dst\": [\"10.0.0.0/8:443\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"group:developers\", \"deny\": [\"10.0.0.0/8:443\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-deny-fail-group-src-cidr-dst.hujson",
+		"full_policy": {"acls": [{
+			"action": "accept",
+			"dst":    ["10.0.0.0/8:443"],
+			"src":    ["group:developers"]
+		}], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [{"deny": ["10.0.0.0/8:443"], "src": "group:developers"}]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6297407670699862,
+				"StableID":   "nRYDQpD7Br11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6297407670699862,
+				"Key":        "nodekey:ab5c0b0472ddc1e9bdf5ff4d9b55d4205e2f231a3cd57712077566f10fd9e63d",
+				"DiscoKey":   "discokey:1e45f0101e813b0d25d35709b86039e6597ce03ae186b2357db1daa345416200",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40976", "10.65.0.27:40976", "172.17.0.1:40976"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:46:07.672175743Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ab5c0b0472ddc1e9bdf5ff4d9b55d4205e2f231a3cd57712077566f10fd9e63d",
+			"MachineKey": "mkey:d793b67e2572dfa002a2191ecfac1803ceef1e2fec65be65bcaef3af9eea491a",
+			"Peers": [{
+				"ID":         974475000005570,
+				"StableID":   "nKVRpjoLc811CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d12742d64b63e90af6557b5b3237c67993aa30e28dd41a479908de387694987d",
+				"DiscoKey":   "discokey:c8a149dfd78f07e0864ad4e12f8b2158960868518e43e328a7a796d934809a2c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:53090", "10.65.0.27:53090", "172.17.0.1:53090"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:45:55.07865741Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1073487736700629,
+				"StableID":   "n8zkJkhBP911CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6fb9011bd60e2824a2c72d4a9293a5466ff144669cae52d2885c43f41fd8972",
+				"DiscoKey":   "discokey:019009897d55fa349945689b607c3661b85376d2f2968a28453aa80697b06f6b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:38041", "10.65.0.27:38041", "172.17.0.1:38041"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:45:57.73643802Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3641686567142402,
+				"StableID":   "nhiyZzvKSV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b724dc80b159a85bf1e594d4cd58c867c5c681bc44d1eef4a000deb97055511",
+				"DiscoKey":   "discokey:9047bfb018319c04c6fe81ce64304540a51f2a9be51f238bd999471fc8f14e29",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:34169", "10.65.0.27:34169", "172.17.0.1:34169"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:45:59.564210643Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6491182082782558,
+				"StableID":   "nFbWe5Msgs11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c380240d1131a800ed88a70de33c9bad5c09907c74ea8790a23c90312170c735",
+				"DiscoKey":   "discokey:925bdf1dbfe79f1526b07d0fa073b1069ccf53010ec46cee1c770b49e6b9fe27",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58804", "10.65.0.27:58804", "172.17.0.1:58804"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:46:05.042735196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8817344809227684,
+				"StableID":   "nZMLDQhPrB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3a83b1375c38c3e138097ca034813546b4dc1db38841397820469f578d980315",
+				"KeyExpiry":  "2026-10-26T10:46:22Z",
+				"DiscoKey":   "discokey:3ad5b9007c9120d509d960b1d4ba7a25884474eb2a9de771f27d4fcd23599438",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54330", "10.65.0.27:54330", "172.17.0.1:54330"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:46:22.527918086Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8099323551656853,
+				"StableID":   "n4WuRkVCF621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:616abdb546944ca2c41dffb5250ab748b61e18047302abbdcfb4fa3458c66662",
+				"KeyExpiry":  "2026-10-26T10:46:26Z",
+				"DiscoKey":   "discokey:fc32e89f35a1ba6b9251a4bc329eeb478d408dc67e03600472f1d4fb5593d14f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43686", "10.65.0.27:43686", "172.17.0.1:43686"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:46:26.224806858Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1726390327541914,
+				"StableID":   "nbRwV6MtUE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b92953c534ea1a173dd2052eb312f93bb60f7c76e5b64f8031c5435077145e7b",
+				"KeyExpiry":  "2026-10-26T10:46:34Z",
+				"DiscoKey":   "discokey:d74e8be4aa57163128268c3c0fb9a275b5691a3046796fcd5111d6e021880f00",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:38335", "10.65.0.27:38335", "172.17.0.1:38335"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:46:34.28731365Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6297407670699862": {
+				"ID":          6297407670699862,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1726390327541914,
+				"StableID":   "nbRwV6MtUE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b92953c534ea1a173dd2052eb312f93bb60f7c76e5b64f8031c5435077145e7b",
+				"KeyExpiry":  "2026-10-26T10:46:34Z",
+				"DiscoKey":   "discokey:d74e8be4aa57163128268c3c0fb9a275b5691a3046796fcd5111d6e021880f00",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:38335", "10.65.0.27:38335", "172.17.0.1:38335"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:46:34.28731365Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b92953c534ea1a173dd2052eb312f93bb60f7c76e5b64f8031c5435077145e7b",
+			"MachineKey": "mkey:fcd5d189b7f987f8b3d2dd45239f5e0d03e074d550c4df2fdc9539d71bc09c5a",
+			"Peers": [{
+				"ID":         974475000005570,
+				"StableID":   "nKVRpjoLc811CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d12742d64b63e90af6557b5b3237c67993aa30e28dd41a479908de387694987d",
+				"DiscoKey":   "discokey:c8a149dfd78f07e0864ad4e12f8b2158960868518e43e328a7a796d934809a2c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:53090", "10.65.0.27:53090", "172.17.0.1:53090"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:45:55.07865741Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1073487736700629,
+				"StableID":   "n8zkJkhBP911CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6fb9011bd60e2824a2c72d4a9293a5466ff144669cae52d2885c43f41fd8972",
+				"DiscoKey":   "discokey:019009897d55fa349945689b607c3661b85376d2f2968a28453aa80697b06f6b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:38041", "10.65.0.27:38041", "172.17.0.1:38041"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:45:57.73643802Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3641686567142402,
+				"StableID":   "nhiyZzvKSV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b724dc80b159a85bf1e594d4cd58c867c5c681bc44d1eef4a000deb97055511",
+				"DiscoKey":   "discokey:9047bfb018319c04c6fe81ce64304540a51f2a9be51f238bd999471fc8f14e29",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:34169", "10.65.0.27:34169", "172.17.0.1:34169"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:45:59.564210643Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6491182082782558,
+				"StableID":   "nFbWe5Msgs11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c380240d1131a800ed88a70de33c9bad5c09907c74ea8790a23c90312170c735",
+				"DiscoKey":   "discokey:925bdf1dbfe79f1526b07d0fa073b1069ccf53010ec46cee1c770b49e6b9fe27",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58804", "10.65.0.27:58804", "172.17.0.1:58804"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:46:05.042735196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6297407670699862,
+				"StableID":   "nRYDQpD7Br11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab5c0b0472ddc1e9bdf5ff4d9b55d4205e2f231a3cd57712077566f10fd9e63d",
+				"DiscoKey":   "discokey:1e45f0101e813b0d25d35709b86039e6597ce03ae186b2357db1daa345416200",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40976", "10.65.0.27:40976", "172.17.0.1:40976"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:46:07.672175743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8817344809227684,
+				"StableID":   "nZMLDQhPrB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3a83b1375c38c3e138097ca034813546b4dc1db38841397820469f578d980315",
+				"KeyExpiry":  "2026-10-26T10:46:22Z",
+				"DiscoKey":   "discokey:3ad5b9007c9120d509d960b1d4ba7a25884474eb2a9de771f27d4fcd23599438",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54330", "10.65.0.27:54330", "172.17.0.1:54330"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:46:22.527918086Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8099323551656853,
+				"StableID":   "n4WuRkVCF621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:616abdb546944ca2c41dffb5250ab748b61e18047302abbdcfb4fa3458c66662",
+				"KeyExpiry":  "2026-10-26T10:46:26Z",
+				"DiscoKey":   "discokey:fc32e89f35a1ba6b9251a4bc329eeb478d408dc67e03600472f1d4fb5593d14f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43686", "10.65.0.27:43686", "172.17.0.1:43686"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:46:26.224806858Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         974475000005570,
+				"StableID":   "nKVRpjoLc811CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       974475000005570,
+				"Key":        "nodekey:d12742d64b63e90af6557b5b3237c67993aa30e28dd41a479908de387694987d",
+				"DiscoKey":   "discokey:c8a149dfd78f07e0864ad4e12f8b2158960868518e43e328a7a796d934809a2c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:53090", "10.65.0.27:53090", "172.17.0.1:53090"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:45:55.07865741Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d12742d64b63e90af6557b5b3237c67993aa30e28dd41a479908de387694987d",
+			"MachineKey": "mkey:0135412539aaa09b470103eed4b304c184ee34984c43e35d18cb2a5020765911",
+			"Peers": [{
+				"ID":         1073487736700629,
+				"StableID":   "n8zkJkhBP911CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6fb9011bd60e2824a2c72d4a9293a5466ff144669cae52d2885c43f41fd8972",
+				"DiscoKey":   "discokey:019009897d55fa349945689b607c3661b85376d2f2968a28453aa80697b06f6b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:38041", "10.65.0.27:38041", "172.17.0.1:38041"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:45:57.73643802Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3641686567142402,
+				"StableID":   "nhiyZzvKSV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b724dc80b159a85bf1e594d4cd58c867c5c681bc44d1eef4a000deb97055511",
+				"DiscoKey":   "discokey:9047bfb018319c04c6fe81ce64304540a51f2a9be51f238bd999471fc8f14e29",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:34169", "10.65.0.27:34169", "172.17.0.1:34169"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:45:59.564210643Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6491182082782558,
+				"StableID":   "nFbWe5Msgs11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c380240d1131a800ed88a70de33c9bad5c09907c74ea8790a23c90312170c735",
+				"DiscoKey":   "discokey:925bdf1dbfe79f1526b07d0fa073b1069ccf53010ec46cee1c770b49e6b9fe27",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58804", "10.65.0.27:58804", "172.17.0.1:58804"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:46:05.042735196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6297407670699862,
+				"StableID":   "nRYDQpD7Br11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab5c0b0472ddc1e9bdf5ff4d9b55d4205e2f231a3cd57712077566f10fd9e63d",
+				"DiscoKey":   "discokey:1e45f0101e813b0d25d35709b86039e6597ce03ae186b2357db1daa345416200",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40976", "10.65.0.27:40976", "172.17.0.1:40976"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:46:07.672175743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8817344809227684,
+				"StableID":   "nZMLDQhPrB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3a83b1375c38c3e138097ca034813546b4dc1db38841397820469f578d980315",
+				"KeyExpiry":  "2026-10-26T10:46:22Z",
+				"DiscoKey":   "discokey:3ad5b9007c9120d509d960b1d4ba7a25884474eb2a9de771f27d4fcd23599438",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54330", "10.65.0.27:54330", "172.17.0.1:54330"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:46:22.527918086Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8099323551656853,
+				"StableID":   "n4WuRkVCF621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:616abdb546944ca2c41dffb5250ab748b61e18047302abbdcfb4fa3458c66662",
+				"KeyExpiry":  "2026-10-26T10:46:26Z",
+				"DiscoKey":   "discokey:fc32e89f35a1ba6b9251a4bc329eeb478d408dc67e03600472f1d4fb5593d14f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43686", "10.65.0.27:43686", "172.17.0.1:43686"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:46:26.224806858Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1726390327541914,
+				"StableID":   "nbRwV6MtUE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b92953c534ea1a173dd2052eb312f93bb60f7c76e5b64f8031c5435077145e7b",
+				"KeyExpiry":  "2026-10-26T10:46:34Z",
+				"DiscoKey":   "discokey:d74e8be4aa57163128268c3c0fb9a275b5691a3046796fcd5111d6e021880f00",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:38335", "10.65.0.27:38335", "172.17.0.1:38335"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:46:34.28731365Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "974475000005570": {
+				"ID":          974475000005570,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8817344809227684,
+				"StableID":   "nZMLDQhPrB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3a83b1375c38c3e138097ca034813546b4dc1db38841397820469f578d980315",
+				"KeyExpiry":  "2026-10-26T10:46:22Z",
+				"DiscoKey":   "discokey:3ad5b9007c9120d509d960b1d4ba7a25884474eb2a9de771f27d4fcd23599438",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54330", "10.65.0.27:54330", "172.17.0.1:54330"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:46:22.527918086Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3a83b1375c38c3e138097ca034813546b4dc1db38841397820469f578d980315",
+			"MachineKey": "mkey:8c327be918038d0eac32cd0ac4a76c807b99272974c7f415fb0027988d545d2b",
+			"Peers": [{
+				"ID":         974475000005570,
+				"StableID":   "nKVRpjoLc811CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d12742d64b63e90af6557b5b3237c67993aa30e28dd41a479908de387694987d",
+				"DiscoKey":   "discokey:c8a149dfd78f07e0864ad4e12f8b2158960868518e43e328a7a796d934809a2c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:53090", "10.65.0.27:53090", "172.17.0.1:53090"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:45:55.07865741Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1073487736700629,
+				"StableID":   "n8zkJkhBP911CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6fb9011bd60e2824a2c72d4a9293a5466ff144669cae52d2885c43f41fd8972",
+				"DiscoKey":   "discokey:019009897d55fa349945689b607c3661b85376d2f2968a28453aa80697b06f6b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:38041", "10.65.0.27:38041", "172.17.0.1:38041"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:45:57.73643802Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3641686567142402,
+				"StableID":   "nhiyZzvKSV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b724dc80b159a85bf1e594d4cd58c867c5c681bc44d1eef4a000deb97055511",
+				"DiscoKey":   "discokey:9047bfb018319c04c6fe81ce64304540a51f2a9be51f238bd999471fc8f14e29",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:34169", "10.65.0.27:34169", "172.17.0.1:34169"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:45:59.564210643Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6491182082782558,
+				"StableID":   "nFbWe5Msgs11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c380240d1131a800ed88a70de33c9bad5c09907c74ea8790a23c90312170c735",
+				"DiscoKey":   "discokey:925bdf1dbfe79f1526b07d0fa073b1069ccf53010ec46cee1c770b49e6b9fe27",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58804", "10.65.0.27:58804", "172.17.0.1:58804"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:46:05.042735196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6297407670699862,
+				"StableID":   "nRYDQpD7Br11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab5c0b0472ddc1e9bdf5ff4d9b55d4205e2f231a3cd57712077566f10fd9e63d",
+				"DiscoKey":   "discokey:1e45f0101e813b0d25d35709b86039e6597ce03ae186b2357db1daa345416200",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40976", "10.65.0.27:40976", "172.17.0.1:40976"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:46:07.672175743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8099323551656853,
+				"StableID":   "n4WuRkVCF621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:616abdb546944ca2c41dffb5250ab748b61e18047302abbdcfb4fa3458c66662",
+				"KeyExpiry":  "2026-10-26T10:46:26Z",
+				"DiscoKey":   "discokey:fc32e89f35a1ba6b9251a4bc329eeb478d408dc67e03600472f1d4fb5593d14f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43686", "10.65.0.27:43686", "172.17.0.1:43686"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:46:26.224806858Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1726390327541914,
+				"StableID":   "nbRwV6MtUE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b92953c534ea1a173dd2052eb312f93bb60f7c76e5b64f8031c5435077145e7b",
+				"KeyExpiry":  "2026-10-26T10:46:34Z",
+				"DiscoKey":   "discokey:d74e8be4aa57163128268c3c0fb9a275b5691a3046796fcd5111d6e021880f00",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:38335", "10.65.0.27:38335", "172.17.0.1:38335"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:46:34.28731365Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6491182082782558,
+				"StableID":   "nFbWe5Msgs11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       6491182082782558,
+				"Key":        "nodekey:c380240d1131a800ed88a70de33c9bad5c09907c74ea8790a23c90312170c735",
+				"DiscoKey":   "discokey:925bdf1dbfe79f1526b07d0fa073b1069ccf53010ec46cee1c770b49e6b9fe27",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58804", "10.65.0.27:58804", "172.17.0.1:58804"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:46:05.042735196Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c380240d1131a800ed88a70de33c9bad5c09907c74ea8790a23c90312170c735",
+			"MachineKey": "mkey:cdbb1cdc58cad67baa3a8250dba52b58e0086c05ca7853f53f2a313d9514cc3c",
+			"Peers": [{
+				"ID":         974475000005570,
+				"StableID":   "nKVRpjoLc811CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d12742d64b63e90af6557b5b3237c67993aa30e28dd41a479908de387694987d",
+				"DiscoKey":   "discokey:c8a149dfd78f07e0864ad4e12f8b2158960868518e43e328a7a796d934809a2c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:53090", "10.65.0.27:53090", "172.17.0.1:53090"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:45:55.07865741Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1073487736700629,
+				"StableID":   "n8zkJkhBP911CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6fb9011bd60e2824a2c72d4a9293a5466ff144669cae52d2885c43f41fd8972",
+				"DiscoKey":   "discokey:019009897d55fa349945689b607c3661b85376d2f2968a28453aa80697b06f6b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:38041", "10.65.0.27:38041", "172.17.0.1:38041"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:45:57.73643802Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3641686567142402,
+				"StableID":   "nhiyZzvKSV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b724dc80b159a85bf1e594d4cd58c867c5c681bc44d1eef4a000deb97055511",
+				"DiscoKey":   "discokey:9047bfb018319c04c6fe81ce64304540a51f2a9be51f238bd999471fc8f14e29",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:34169", "10.65.0.27:34169", "172.17.0.1:34169"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:45:59.564210643Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6297407670699862,
+				"StableID":   "nRYDQpD7Br11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab5c0b0472ddc1e9bdf5ff4d9b55d4205e2f231a3cd57712077566f10fd9e63d",
+				"DiscoKey":   "discokey:1e45f0101e813b0d25d35709b86039e6597ce03ae186b2357db1daa345416200",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40976", "10.65.0.27:40976", "172.17.0.1:40976"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:46:07.672175743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8817344809227684,
+				"StableID":   "nZMLDQhPrB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3a83b1375c38c3e138097ca034813546b4dc1db38841397820469f578d980315",
+				"KeyExpiry":  "2026-10-26T10:46:22Z",
+				"DiscoKey":   "discokey:3ad5b9007c9120d509d960b1d4ba7a25884474eb2a9de771f27d4fcd23599438",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54330", "10.65.0.27:54330", "172.17.0.1:54330"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:46:22.527918086Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8099323551656853,
+				"StableID":   "n4WuRkVCF621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:616abdb546944ca2c41dffb5250ab748b61e18047302abbdcfb4fa3458c66662",
+				"KeyExpiry":  "2026-10-26T10:46:26Z",
+				"DiscoKey":   "discokey:fc32e89f35a1ba6b9251a4bc329eeb478d408dc67e03600472f1d4fb5593d14f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43686", "10.65.0.27:43686", "172.17.0.1:43686"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:46:26.224806858Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1726390327541914,
+				"StableID":   "nbRwV6MtUE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b92953c534ea1a173dd2052eb312f93bb60f7c76e5b64f8031c5435077145e7b",
+				"KeyExpiry":  "2026-10-26T10:46:34Z",
+				"DiscoKey":   "discokey:d74e8be4aa57163128268c3c0fb9a275b5691a3046796fcd5111d6e021880f00",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:38335", "10.65.0.27:38335", "172.17.0.1:38335"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:46:34.28731365Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6491182082782558": {
+				"ID":          6491182082782558,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8099323551656853,
+				"StableID":   "n4WuRkVCF621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:616abdb546944ca2c41dffb5250ab748b61e18047302abbdcfb4fa3458c66662",
+				"KeyExpiry":  "2026-10-26T10:46:26Z",
+				"DiscoKey":   "discokey:fc32e89f35a1ba6b9251a4bc329eeb478d408dc67e03600472f1d4fb5593d14f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43686", "10.65.0.27:43686", "172.17.0.1:43686"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:46:26.224806858Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:616abdb546944ca2c41dffb5250ab748b61e18047302abbdcfb4fa3458c66662",
+			"MachineKey": "mkey:18a0e7de8fbef3840e4053f06c9b04c4949f9a5c8e3295ffffcfa007c4f48304",
+			"Peers": [{
+				"ID":         974475000005570,
+				"StableID":   "nKVRpjoLc811CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d12742d64b63e90af6557b5b3237c67993aa30e28dd41a479908de387694987d",
+				"DiscoKey":   "discokey:c8a149dfd78f07e0864ad4e12f8b2158960868518e43e328a7a796d934809a2c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:53090", "10.65.0.27:53090", "172.17.0.1:53090"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:45:55.07865741Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1073487736700629,
+				"StableID":   "n8zkJkhBP911CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6fb9011bd60e2824a2c72d4a9293a5466ff144669cae52d2885c43f41fd8972",
+				"DiscoKey":   "discokey:019009897d55fa349945689b607c3661b85376d2f2968a28453aa80697b06f6b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:38041", "10.65.0.27:38041", "172.17.0.1:38041"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:45:57.73643802Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3641686567142402,
+				"StableID":   "nhiyZzvKSV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b724dc80b159a85bf1e594d4cd58c867c5c681bc44d1eef4a000deb97055511",
+				"DiscoKey":   "discokey:9047bfb018319c04c6fe81ce64304540a51f2a9be51f238bd999471fc8f14e29",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:34169", "10.65.0.27:34169", "172.17.0.1:34169"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:45:59.564210643Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6491182082782558,
+				"StableID":   "nFbWe5Msgs11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c380240d1131a800ed88a70de33c9bad5c09907c74ea8790a23c90312170c735",
+				"DiscoKey":   "discokey:925bdf1dbfe79f1526b07d0fa073b1069ccf53010ec46cee1c770b49e6b9fe27",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58804", "10.65.0.27:58804", "172.17.0.1:58804"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:46:05.042735196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6297407670699862,
+				"StableID":   "nRYDQpD7Br11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab5c0b0472ddc1e9bdf5ff4d9b55d4205e2f231a3cd57712077566f10fd9e63d",
+				"DiscoKey":   "discokey:1e45f0101e813b0d25d35709b86039e6597ce03ae186b2357db1daa345416200",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40976", "10.65.0.27:40976", "172.17.0.1:40976"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:46:07.672175743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8817344809227684,
+				"StableID":   "nZMLDQhPrB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3a83b1375c38c3e138097ca034813546b4dc1db38841397820469f578d980315",
+				"KeyExpiry":  "2026-10-26T10:46:22Z",
+				"DiscoKey":   "discokey:3ad5b9007c9120d509d960b1d4ba7a25884474eb2a9de771f27d4fcd23599438",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54330", "10.65.0.27:54330", "172.17.0.1:54330"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:46:22.527918086Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1726390327541914,
+				"StableID":   "nbRwV6MtUE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b92953c534ea1a173dd2052eb312f93bb60f7c76e5b64f8031c5435077145e7b",
+				"KeyExpiry":  "2026-10-26T10:46:34Z",
+				"DiscoKey":   "discokey:d74e8be4aa57163128268c3c0fb9a275b5691a3046796fcd5111d6e021880f00",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:38335", "10.65.0.27:38335", "172.17.0.1:38335"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:46:34.28731365Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3641686567142402,
+				"StableID":   "nhiyZzvKSV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       3641686567142402,
+				"Key":        "nodekey:9b724dc80b159a85bf1e594d4cd58c867c5c681bc44d1eef4a000deb97055511",
+				"DiscoKey":   "discokey:9047bfb018319c04c6fe81ce64304540a51f2a9be51f238bd999471fc8f14e29",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:34169", "10.65.0.27:34169", "172.17.0.1:34169"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:45:59.564210643Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9b724dc80b159a85bf1e594d4cd58c867c5c681bc44d1eef4a000deb97055511",
+			"MachineKey": "mkey:d7f89b9918369b5131de7002069dd777ec849463ac3fa7e9058397e03b691a13",
+			"Peers": [{
+				"ID":         974475000005570,
+				"StableID":   "nKVRpjoLc811CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d12742d64b63e90af6557b5b3237c67993aa30e28dd41a479908de387694987d",
+				"DiscoKey":   "discokey:c8a149dfd78f07e0864ad4e12f8b2158960868518e43e328a7a796d934809a2c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:53090", "10.65.0.27:53090", "172.17.0.1:53090"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:45:55.07865741Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1073487736700629,
+				"StableID":   "n8zkJkhBP911CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6fb9011bd60e2824a2c72d4a9293a5466ff144669cae52d2885c43f41fd8972",
+				"DiscoKey":   "discokey:019009897d55fa349945689b607c3661b85376d2f2968a28453aa80697b06f6b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:38041", "10.65.0.27:38041", "172.17.0.1:38041"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:45:57.73643802Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6491182082782558,
+				"StableID":   "nFbWe5Msgs11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c380240d1131a800ed88a70de33c9bad5c09907c74ea8790a23c90312170c735",
+				"DiscoKey":   "discokey:925bdf1dbfe79f1526b07d0fa073b1069ccf53010ec46cee1c770b49e6b9fe27",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58804", "10.65.0.27:58804", "172.17.0.1:58804"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:46:05.042735196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6297407670699862,
+				"StableID":   "nRYDQpD7Br11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab5c0b0472ddc1e9bdf5ff4d9b55d4205e2f231a3cd57712077566f10fd9e63d",
+				"DiscoKey":   "discokey:1e45f0101e813b0d25d35709b86039e6597ce03ae186b2357db1daa345416200",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40976", "10.65.0.27:40976", "172.17.0.1:40976"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:46:07.672175743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8817344809227684,
+				"StableID":   "nZMLDQhPrB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3a83b1375c38c3e138097ca034813546b4dc1db38841397820469f578d980315",
+				"KeyExpiry":  "2026-10-26T10:46:22Z",
+				"DiscoKey":   "discokey:3ad5b9007c9120d509d960b1d4ba7a25884474eb2a9de771f27d4fcd23599438",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:54330", "10.65.0.27:54330", "172.17.0.1:54330"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:46:22.527918086Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8099323551656853,
+				"StableID":   "n4WuRkVCF621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:616abdb546944ca2c41dffb5250ab748b61e18047302abbdcfb4fa3458c66662",
+				"KeyExpiry":  "2026-10-26T10:46:26Z",
+				"DiscoKey":   "discokey:fc32e89f35a1ba6b9251a4bc329eeb478d408dc67e03600472f1d4fb5593d14f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43686", "10.65.0.27:43686", "172.17.0.1:43686"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:46:26.224806858Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1726390327541914,
+				"StableID":   "nbRwV6MtUE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b92953c534ea1a173dd2052eb312f93bb60f7c76e5b64f8031c5435077145e7b",
+				"KeyExpiry":  "2026-10-26T10:46:34Z",
+				"DiscoKey":   "discokey:d74e8be4aa57163128268c3c0fb9a275b5691a3046796fcd5111d6e021880f00",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:38335", "10.65.0.27:38335", "172.17.0.1:38335"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:46:34.28731365Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3641686567142402": {
+				"ID":          3641686567142402,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-deny-fail-port-wildcard.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-deny-fail-port-wildcard.hujson
@@ -1,0 +1,8839 @@
+// policytest-deny-fail-port-wildcard
+//
+// tests block deny-fail: dst port wildcard, allow rule covers all ports
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:46:54Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-deny-fail-port-wildcard",
+	"description":    "tests block deny-fail: dst port wildcard, allow rule covers all ports",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:46:54.236104522Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                     \n  \n                                                                       \n                                                      \n{\n\t\"id\":          \"policytest-deny-fail-port-wildcard\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block deny-fail: dst port wildcard, allow rule covers all ports\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"thor@example.org\"], \"dst\": [\"webserver:*\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"deny\": [\"webserver:8080\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-deny-fail-port-wildcard.hujson",
+		"full_policy": {"acls": [
+			{"action": "accept", "dst": ["webserver:*"], "src": ["thor@example.org"]}
+		], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [{"deny": ["webserver:8080"], "src": "thor@example.org"}]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3996574832627009,
+				"StableID":   "nAoEL9F4DY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       3996574832627009,
+				"Key":        "nodekey:9fbad70c101b60afa5b213876385e68233b96452f19821d7d3a05efb670ae04e",
+				"DiscoKey":   "discokey:a7bd1132c1228a8a7051cd0ce3d26c05fb22ea9b4c31d483f11ca6ada6f2161c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39530", "10.65.0.27:39530", "172.17.0.1:39530"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:47:19.953264588Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9fbad70c101b60afa5b213876385e68233b96452f19821d7d3a05efb670ae04e",
+			"MachineKey": "mkey:e70cfc6825028140bbe8874c60c991cdb43d40e0858710338b82f1358de89663",
+			"Peers": [{
+				"ID":         8284341850822851,
+				"StableID":   "ntokxXczg721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6e8fb48bf9101c3941852e7f3288469e9ca57826188dca26a8317b8292fc604",
+				"DiscoKey":   "discokey:5fadf1f81424748b3009e8a64db7e5b02fb17e5c8aeb167f6fca95c7fd532260",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:42844", "10.65.0.27:42844", "172.17.0.1:42844"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:47:05.963637064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6795175505933163,
+				"StableID":   "nzSVUojY4v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cf95b76350c6eac986c710861fd4ad32a0e8e41efc0cebe54f93e06a06ac504",
+				"DiscoKey":   "discokey:155080528161703fe93c8da3fe86fe19f6b25c5af274fe36e55a39f72ff7685f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54595", "10.65.0.27:54595", "172.17.0.1:54595"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:47:08.814994047Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6700907684658438,
+				"StableID":   "nf3xuxUrKu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d8e4c92ba0ce74cd9b2fd9ba72ea2d8cd610b053263adadf4cb159010fe17b",
+				"DiscoKey":   "discokey:8d76c09d1ce76f8220bd861e33f4a0a621c18a89f21691a0bb591477aceefb32",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59406", "10.65.0.27:59406", "172.17.0.1:59406"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:47:11.036537247Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3968185434358641,
+				"StableID":   "nnPTR9WCzX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4baf8b7861df4c0b6c7cbd5f51e71410cd19cdc069d784d1c02f2ccbdfd1a65b",
+				"DiscoKey":   "discokey:fd4d468cd8207db6db410f3cefd57427e6c7348fefcd3beab69272d0e6f66872",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38402", "10.65.0.27:38402", "172.17.0.1:38402"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:47:13.411265464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1006932084652541,
+				"StableID":   "niB9F7Q3s811CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ed91d8b081082045c525e25c41286b6935bb1ba24bd3e5f2f1d203bcfdbb551",
+				"KeyExpiry":  "2026-10-26T10:47:21Z",
+				"DiscoKey":   "discokey:eaf43caab5f9ca00093a935f0e4798121de2747c7687580ffcec979fb9ceac26",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:59900", "10.65.0.27:59900", "172.17.0.1:59900"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:47:21.857089185Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8761376519968534,
+				"StableID":   "nTXR9GW3RB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:7eac39284dfcfddb1a19c41471d22e4c8ec5cd5a5992db91a2dd341a55de2c40",
+				"KeyExpiry":  "2026-10-26T10:47:22Z",
+				"DiscoKey":   "discokey:a82a8fa9ab4d6e173da87c04d2bc80e326d5a071fab901644e2bd79bf787fe77",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:34993", "10.65.0.27:34993", "172.17.0.1:34993"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:47:22.865053522Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3717711984542387,
+				"StableID":   "n8yJNQzk2W11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:178a68cc16f584f7d347b2a6bd5d10d633bdcc412628681f7e92da89b3f33b50",
+				"KeyExpiry":  "2026-10-26T10:47:24Z",
+				"DiscoKey":   "discokey:46e3d2e8bd74eed12c76404289cf9f56b699a61629fe594bbf1381eb83a44a33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51942", "10.65.0.27:51942", "172.17.0.1:51942"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:47:24.58748233Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "3996574832627009": {
+				"ID":          3996574832627009,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3717711984542387,
+				"StableID":   "n8yJNQzk2W11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:178a68cc16f584f7d347b2a6bd5d10d633bdcc412628681f7e92da89b3f33b50",
+				"KeyExpiry":  "2026-10-26T10:47:24Z",
+				"DiscoKey":   "discokey:46e3d2e8bd74eed12c76404289cf9f56b699a61629fe594bbf1381eb83a44a33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51942", "10.65.0.27:51942", "172.17.0.1:51942"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:47:24.58748233Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:178a68cc16f584f7d347b2a6bd5d10d633bdcc412628681f7e92da89b3f33b50",
+			"MachineKey": "mkey:bffee1f22cbccc852967eceda06ee2401b27803ae3a1634519a4e8502624cb09",
+			"Peers": [{
+				"ID":         8284341850822851,
+				"StableID":   "ntokxXczg721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6e8fb48bf9101c3941852e7f3288469e9ca57826188dca26a8317b8292fc604",
+				"DiscoKey":   "discokey:5fadf1f81424748b3009e8a64db7e5b02fb17e5c8aeb167f6fca95c7fd532260",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:42844", "10.65.0.27:42844", "172.17.0.1:42844"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:47:05.963637064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6795175505933163,
+				"StableID":   "nzSVUojY4v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cf95b76350c6eac986c710861fd4ad32a0e8e41efc0cebe54f93e06a06ac504",
+				"DiscoKey":   "discokey:155080528161703fe93c8da3fe86fe19f6b25c5af274fe36e55a39f72ff7685f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54595", "10.65.0.27:54595", "172.17.0.1:54595"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:47:08.814994047Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6700907684658438,
+				"StableID":   "nf3xuxUrKu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d8e4c92ba0ce74cd9b2fd9ba72ea2d8cd610b053263adadf4cb159010fe17b",
+				"DiscoKey":   "discokey:8d76c09d1ce76f8220bd861e33f4a0a621c18a89f21691a0bb591477aceefb32",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59406", "10.65.0.27:59406", "172.17.0.1:59406"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:47:11.036537247Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3968185434358641,
+				"StableID":   "nnPTR9WCzX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4baf8b7861df4c0b6c7cbd5f51e71410cd19cdc069d784d1c02f2ccbdfd1a65b",
+				"DiscoKey":   "discokey:fd4d468cd8207db6db410f3cefd57427e6c7348fefcd3beab69272d0e6f66872",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38402", "10.65.0.27:38402", "172.17.0.1:38402"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:47:13.411265464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3996574832627009,
+				"StableID":   "nAoEL9F4DY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9fbad70c101b60afa5b213876385e68233b96452f19821d7d3a05efb670ae04e",
+				"DiscoKey":   "discokey:a7bd1132c1228a8a7051cd0ce3d26c05fb22ea9b4c31d483f11ca6ada6f2161c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39530", "10.65.0.27:39530", "172.17.0.1:39530"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:47:19.953264588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1006932084652541,
+				"StableID":   "niB9F7Q3s811CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ed91d8b081082045c525e25c41286b6935bb1ba24bd3e5f2f1d203bcfdbb551",
+				"KeyExpiry":  "2026-10-26T10:47:21Z",
+				"DiscoKey":   "discokey:eaf43caab5f9ca00093a935f0e4798121de2747c7687580ffcec979fb9ceac26",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:59900", "10.65.0.27:59900", "172.17.0.1:59900"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:47:21.857089185Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8761376519968534,
+				"StableID":   "nTXR9GW3RB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:7eac39284dfcfddb1a19c41471d22e4c8ec5cd5a5992db91a2dd341a55de2c40",
+				"KeyExpiry":  "2026-10-26T10:47:22Z",
+				"DiscoKey":   "discokey:a82a8fa9ab4d6e173da87c04d2bc80e326d5a071fab901644e2bd79bf787fe77",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:34993", "10.65.0.27:34993", "172.17.0.1:34993"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:47:22.865053522Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8284341850822851,
+				"StableID":   "ntokxXczg721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       8284341850822851,
+				"Key":        "nodekey:c6e8fb48bf9101c3941852e7f3288469e9ca57826188dca26a8317b8292fc604",
+				"DiscoKey":   "discokey:5fadf1f81424748b3009e8a64db7e5b02fb17e5c8aeb167f6fca95c7fd532260",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:42844", "10.65.0.27:42844", "172.17.0.1:42844"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:47:05.963637064Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c6e8fb48bf9101c3941852e7f3288469e9ca57826188dca26a8317b8292fc604",
+			"MachineKey": "mkey:55bfe259f25c8a755cd767835bd79044775399f65ed9e469419e25d38c15ac7a",
+			"Peers": [{
+				"ID":         6795175505933163,
+				"StableID":   "nzSVUojY4v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cf95b76350c6eac986c710861fd4ad32a0e8e41efc0cebe54f93e06a06ac504",
+				"DiscoKey":   "discokey:155080528161703fe93c8da3fe86fe19f6b25c5af274fe36e55a39f72ff7685f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54595", "10.65.0.27:54595", "172.17.0.1:54595"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:47:08.814994047Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6700907684658438,
+				"StableID":   "nf3xuxUrKu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d8e4c92ba0ce74cd9b2fd9ba72ea2d8cd610b053263adadf4cb159010fe17b",
+				"DiscoKey":   "discokey:8d76c09d1ce76f8220bd861e33f4a0a621c18a89f21691a0bb591477aceefb32",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59406", "10.65.0.27:59406", "172.17.0.1:59406"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:47:11.036537247Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3968185434358641,
+				"StableID":   "nnPTR9WCzX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4baf8b7861df4c0b6c7cbd5f51e71410cd19cdc069d784d1c02f2ccbdfd1a65b",
+				"DiscoKey":   "discokey:fd4d468cd8207db6db410f3cefd57427e6c7348fefcd3beab69272d0e6f66872",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38402", "10.65.0.27:38402", "172.17.0.1:38402"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:47:13.411265464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3996574832627009,
+				"StableID":   "nAoEL9F4DY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9fbad70c101b60afa5b213876385e68233b96452f19821d7d3a05efb670ae04e",
+				"DiscoKey":   "discokey:a7bd1132c1228a8a7051cd0ce3d26c05fb22ea9b4c31d483f11ca6ada6f2161c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39530", "10.65.0.27:39530", "172.17.0.1:39530"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:47:19.953264588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1006932084652541,
+				"StableID":   "niB9F7Q3s811CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ed91d8b081082045c525e25c41286b6935bb1ba24bd3e5f2f1d203bcfdbb551",
+				"KeyExpiry":  "2026-10-26T10:47:21Z",
+				"DiscoKey":   "discokey:eaf43caab5f9ca00093a935f0e4798121de2747c7687580ffcec979fb9ceac26",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:59900", "10.65.0.27:59900", "172.17.0.1:59900"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:47:21.857089185Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8761376519968534,
+				"StableID":   "nTXR9GW3RB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:7eac39284dfcfddb1a19c41471d22e4c8ec5cd5a5992db91a2dd341a55de2c40",
+				"KeyExpiry":  "2026-10-26T10:47:22Z",
+				"DiscoKey":   "discokey:a82a8fa9ab4d6e173da87c04d2bc80e326d5a071fab901644e2bd79bf787fe77",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:34993", "10.65.0.27:34993", "172.17.0.1:34993"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:47:22.865053522Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3717711984542387,
+				"StableID":   "n8yJNQzk2W11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:178a68cc16f584f7d347b2a6bd5d10d633bdcc412628681f7e92da89b3f33b50",
+				"KeyExpiry":  "2026-10-26T10:47:24Z",
+				"DiscoKey":   "discokey:46e3d2e8bd74eed12c76404289cf9f56b699a61629fe594bbf1381eb83a44a33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51942", "10.65.0.27:51942", "172.17.0.1:51942"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:47:24.58748233Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8284341850822851": {
+				"ID":          8284341850822851,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1006932084652541,
+				"StableID":   "niB9F7Q3s811CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ed91d8b081082045c525e25c41286b6935bb1ba24bd3e5f2f1d203bcfdbb551",
+				"KeyExpiry":  "2026-10-26T10:47:21Z",
+				"DiscoKey":   "discokey:eaf43caab5f9ca00093a935f0e4798121de2747c7687580ffcec979fb9ceac26",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:59900", "10.65.0.27:59900", "172.17.0.1:59900"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:47:21.857089185Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2ed91d8b081082045c525e25c41286b6935bb1ba24bd3e5f2f1d203bcfdbb551",
+			"MachineKey": "mkey:72394192775e18b0ad7848282ef500a59d0d338b0bda9300acb3e81600f7e42b",
+			"Peers": [{
+				"ID":         8284341850822851,
+				"StableID":   "ntokxXczg721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6e8fb48bf9101c3941852e7f3288469e9ca57826188dca26a8317b8292fc604",
+				"DiscoKey":   "discokey:5fadf1f81424748b3009e8a64db7e5b02fb17e5c8aeb167f6fca95c7fd532260",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:42844", "10.65.0.27:42844", "172.17.0.1:42844"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:47:05.963637064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6795175505933163,
+				"StableID":   "nzSVUojY4v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cf95b76350c6eac986c710861fd4ad32a0e8e41efc0cebe54f93e06a06ac504",
+				"DiscoKey":   "discokey:155080528161703fe93c8da3fe86fe19f6b25c5af274fe36e55a39f72ff7685f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54595", "10.65.0.27:54595", "172.17.0.1:54595"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:47:08.814994047Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6700907684658438,
+				"StableID":   "nf3xuxUrKu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d8e4c92ba0ce74cd9b2fd9ba72ea2d8cd610b053263adadf4cb159010fe17b",
+				"DiscoKey":   "discokey:8d76c09d1ce76f8220bd861e33f4a0a621c18a89f21691a0bb591477aceefb32",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59406", "10.65.0.27:59406", "172.17.0.1:59406"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:47:11.036537247Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3968185434358641,
+				"StableID":   "nnPTR9WCzX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4baf8b7861df4c0b6c7cbd5f51e71410cd19cdc069d784d1c02f2ccbdfd1a65b",
+				"DiscoKey":   "discokey:fd4d468cd8207db6db410f3cefd57427e6c7348fefcd3beab69272d0e6f66872",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38402", "10.65.0.27:38402", "172.17.0.1:38402"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:47:13.411265464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3996574832627009,
+				"StableID":   "nAoEL9F4DY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9fbad70c101b60afa5b213876385e68233b96452f19821d7d3a05efb670ae04e",
+				"DiscoKey":   "discokey:a7bd1132c1228a8a7051cd0ce3d26c05fb22ea9b4c31d483f11ca6ada6f2161c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39530", "10.65.0.27:39530", "172.17.0.1:39530"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:47:19.953264588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8761376519968534,
+				"StableID":   "nTXR9GW3RB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:7eac39284dfcfddb1a19c41471d22e4c8ec5cd5a5992db91a2dd341a55de2c40",
+				"KeyExpiry":  "2026-10-26T10:47:22Z",
+				"DiscoKey":   "discokey:a82a8fa9ab4d6e173da87c04d2bc80e326d5a071fab901644e2bd79bf787fe77",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:34993", "10.65.0.27:34993", "172.17.0.1:34993"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:47:22.865053522Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3717711984542387,
+				"StableID":   "n8yJNQzk2W11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:178a68cc16f584f7d347b2a6bd5d10d633bdcc412628681f7e92da89b3f33b50",
+				"KeyExpiry":  "2026-10-26T10:47:24Z",
+				"DiscoKey":   "discokey:46e3d2e8bd74eed12c76404289cf9f56b699a61629fe594bbf1381eb83a44a33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51942", "10.65.0.27:51942", "172.17.0.1:51942"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:47:24.58748233Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3968185434358641,
+				"StableID":   "nnPTR9WCzX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       3968185434358641,
+				"Key":        "nodekey:4baf8b7861df4c0b6c7cbd5f51e71410cd19cdc069d784d1c02f2ccbdfd1a65b",
+				"DiscoKey":   "discokey:fd4d468cd8207db6db410f3cefd57427e6c7348fefcd3beab69272d0e6f66872",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38402", "10.65.0.27:38402", "172.17.0.1:38402"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:47:13.411265464Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4baf8b7861df4c0b6c7cbd5f51e71410cd19cdc069d784d1c02f2ccbdfd1a65b",
+			"MachineKey": "mkey:65fa0d0b29022d1514be0aacee4ebbeafc61a7f456d75d050064b14d40610d24",
+			"Peers": [{
+				"ID":         8284341850822851,
+				"StableID":   "ntokxXczg721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6e8fb48bf9101c3941852e7f3288469e9ca57826188dca26a8317b8292fc604",
+				"DiscoKey":   "discokey:5fadf1f81424748b3009e8a64db7e5b02fb17e5c8aeb167f6fca95c7fd532260",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:42844", "10.65.0.27:42844", "172.17.0.1:42844"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:47:05.963637064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6795175505933163,
+				"StableID":   "nzSVUojY4v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cf95b76350c6eac986c710861fd4ad32a0e8e41efc0cebe54f93e06a06ac504",
+				"DiscoKey":   "discokey:155080528161703fe93c8da3fe86fe19f6b25c5af274fe36e55a39f72ff7685f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54595", "10.65.0.27:54595", "172.17.0.1:54595"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:47:08.814994047Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6700907684658438,
+				"StableID":   "nf3xuxUrKu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d8e4c92ba0ce74cd9b2fd9ba72ea2d8cd610b053263adadf4cb159010fe17b",
+				"DiscoKey":   "discokey:8d76c09d1ce76f8220bd861e33f4a0a621c18a89f21691a0bb591477aceefb32",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59406", "10.65.0.27:59406", "172.17.0.1:59406"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:47:11.036537247Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3996574832627009,
+				"StableID":   "nAoEL9F4DY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9fbad70c101b60afa5b213876385e68233b96452f19821d7d3a05efb670ae04e",
+				"DiscoKey":   "discokey:a7bd1132c1228a8a7051cd0ce3d26c05fb22ea9b4c31d483f11ca6ada6f2161c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39530", "10.65.0.27:39530", "172.17.0.1:39530"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:47:19.953264588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1006932084652541,
+				"StableID":   "niB9F7Q3s811CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ed91d8b081082045c525e25c41286b6935bb1ba24bd3e5f2f1d203bcfdbb551",
+				"KeyExpiry":  "2026-10-26T10:47:21Z",
+				"DiscoKey":   "discokey:eaf43caab5f9ca00093a935f0e4798121de2747c7687580ffcec979fb9ceac26",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:59900", "10.65.0.27:59900", "172.17.0.1:59900"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:47:21.857089185Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8761376519968534,
+				"StableID":   "nTXR9GW3RB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:7eac39284dfcfddb1a19c41471d22e4c8ec5cd5a5992db91a2dd341a55de2c40",
+				"KeyExpiry":  "2026-10-26T10:47:22Z",
+				"DiscoKey":   "discokey:a82a8fa9ab4d6e173da87c04d2bc80e326d5a071fab901644e2bd79bf787fe77",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:34993", "10.65.0.27:34993", "172.17.0.1:34993"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:47:22.865053522Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3717711984542387,
+				"StableID":   "n8yJNQzk2W11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:178a68cc16f584f7d347b2a6bd5d10d633bdcc412628681f7e92da89b3f33b50",
+				"KeyExpiry":  "2026-10-26T10:47:24Z",
+				"DiscoKey":   "discokey:46e3d2e8bd74eed12c76404289cf9f56b699a61629fe594bbf1381eb83a44a33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51942", "10.65.0.27:51942", "172.17.0.1:51942"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:47:24.58748233Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3968185434358641": {
+				"ID":          3968185434358641,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6795175505933163,
+				"StableID":   "nzSVUojY4v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       6795175505933163,
+				"Key":        "nodekey:2cf95b76350c6eac986c710861fd4ad32a0e8e41efc0cebe54f93e06a06ac504",
+				"DiscoKey":   "discokey:155080528161703fe93c8da3fe86fe19f6b25c5af274fe36e55a39f72ff7685f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54595", "10.65.0.27:54595", "172.17.0.1:54595"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:47:08.814994047Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2cf95b76350c6eac986c710861fd4ad32a0e8e41efc0cebe54f93e06a06ac504",
+			"MachineKey": "mkey:b2ac8a87cc020e063566268dd7ca9cf255ae3be0e8f38b5b6a66c5ac5821b465",
+			"Peers": [{
+				"ID":         8284341850822851,
+				"StableID":   "ntokxXczg721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6e8fb48bf9101c3941852e7f3288469e9ca57826188dca26a8317b8292fc604",
+				"DiscoKey":   "discokey:5fadf1f81424748b3009e8a64db7e5b02fb17e5c8aeb167f6fca95c7fd532260",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:42844", "10.65.0.27:42844", "172.17.0.1:42844"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:47:05.963637064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6700907684658438,
+				"StableID":   "nf3xuxUrKu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d8e4c92ba0ce74cd9b2fd9ba72ea2d8cd610b053263adadf4cb159010fe17b",
+				"DiscoKey":   "discokey:8d76c09d1ce76f8220bd861e33f4a0a621c18a89f21691a0bb591477aceefb32",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59406", "10.65.0.27:59406", "172.17.0.1:59406"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:47:11.036537247Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3968185434358641,
+				"StableID":   "nnPTR9WCzX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4baf8b7861df4c0b6c7cbd5f51e71410cd19cdc069d784d1c02f2ccbdfd1a65b",
+				"DiscoKey":   "discokey:fd4d468cd8207db6db410f3cefd57427e6c7348fefcd3beab69272d0e6f66872",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38402", "10.65.0.27:38402", "172.17.0.1:38402"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:47:13.411265464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3996574832627009,
+				"StableID":   "nAoEL9F4DY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9fbad70c101b60afa5b213876385e68233b96452f19821d7d3a05efb670ae04e",
+				"DiscoKey":   "discokey:a7bd1132c1228a8a7051cd0ce3d26c05fb22ea9b4c31d483f11ca6ada6f2161c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39530", "10.65.0.27:39530", "172.17.0.1:39530"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:47:19.953264588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1006932084652541,
+				"StableID":   "niB9F7Q3s811CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ed91d8b081082045c525e25c41286b6935bb1ba24bd3e5f2f1d203bcfdbb551",
+				"KeyExpiry":  "2026-10-26T10:47:21Z",
+				"DiscoKey":   "discokey:eaf43caab5f9ca00093a935f0e4798121de2747c7687580ffcec979fb9ceac26",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:59900", "10.65.0.27:59900", "172.17.0.1:59900"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:47:21.857089185Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8761376519968534,
+				"StableID":   "nTXR9GW3RB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:7eac39284dfcfddb1a19c41471d22e4c8ec5cd5a5992db91a2dd341a55de2c40",
+				"KeyExpiry":  "2026-10-26T10:47:22Z",
+				"DiscoKey":   "discokey:a82a8fa9ab4d6e173da87c04d2bc80e326d5a071fab901644e2bd79bf787fe77",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:34993", "10.65.0.27:34993", "172.17.0.1:34993"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:47:22.865053522Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3717711984542387,
+				"StableID":   "n8yJNQzk2W11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:178a68cc16f584f7d347b2a6bd5d10d633bdcc412628681f7e92da89b3f33b50",
+				"KeyExpiry":  "2026-10-26T10:47:24Z",
+				"DiscoKey":   "discokey:46e3d2e8bd74eed12c76404289cf9f56b699a61629fe594bbf1381eb83a44a33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51942", "10.65.0.27:51942", "172.17.0.1:51942"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:47:24.58748233Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6795175505933163": {
+				"ID":          6795175505933163,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8761376519968534,
+				"StableID":   "nTXR9GW3RB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:7eac39284dfcfddb1a19c41471d22e4c8ec5cd5a5992db91a2dd341a55de2c40",
+				"KeyExpiry":  "2026-10-26T10:47:22Z",
+				"DiscoKey":   "discokey:a82a8fa9ab4d6e173da87c04d2bc80e326d5a071fab901644e2bd79bf787fe77",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:34993", "10.65.0.27:34993", "172.17.0.1:34993"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:47:22.865053522Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7eac39284dfcfddb1a19c41471d22e4c8ec5cd5a5992db91a2dd341a55de2c40",
+			"MachineKey": "mkey:6983f429e941b2c19d289aa172612bc7c4eca065da3c1ceeee2af25a2ce3ab27",
+			"Peers": [{
+				"ID":         8284341850822851,
+				"StableID":   "ntokxXczg721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6e8fb48bf9101c3941852e7f3288469e9ca57826188dca26a8317b8292fc604",
+				"DiscoKey":   "discokey:5fadf1f81424748b3009e8a64db7e5b02fb17e5c8aeb167f6fca95c7fd532260",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:42844", "10.65.0.27:42844", "172.17.0.1:42844"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:47:05.963637064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6795175505933163,
+				"StableID":   "nzSVUojY4v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cf95b76350c6eac986c710861fd4ad32a0e8e41efc0cebe54f93e06a06ac504",
+				"DiscoKey":   "discokey:155080528161703fe93c8da3fe86fe19f6b25c5af274fe36e55a39f72ff7685f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54595", "10.65.0.27:54595", "172.17.0.1:54595"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:47:08.814994047Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6700907684658438,
+				"StableID":   "nf3xuxUrKu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d8e4c92ba0ce74cd9b2fd9ba72ea2d8cd610b053263adadf4cb159010fe17b",
+				"DiscoKey":   "discokey:8d76c09d1ce76f8220bd861e33f4a0a621c18a89f21691a0bb591477aceefb32",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59406", "10.65.0.27:59406", "172.17.0.1:59406"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:47:11.036537247Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3968185434358641,
+				"StableID":   "nnPTR9WCzX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4baf8b7861df4c0b6c7cbd5f51e71410cd19cdc069d784d1c02f2ccbdfd1a65b",
+				"DiscoKey":   "discokey:fd4d468cd8207db6db410f3cefd57427e6c7348fefcd3beab69272d0e6f66872",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38402", "10.65.0.27:38402", "172.17.0.1:38402"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:47:13.411265464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3996574832627009,
+				"StableID":   "nAoEL9F4DY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9fbad70c101b60afa5b213876385e68233b96452f19821d7d3a05efb670ae04e",
+				"DiscoKey":   "discokey:a7bd1132c1228a8a7051cd0ce3d26c05fb22ea9b4c31d483f11ca6ada6f2161c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39530", "10.65.0.27:39530", "172.17.0.1:39530"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:47:19.953264588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1006932084652541,
+				"StableID":   "niB9F7Q3s811CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ed91d8b081082045c525e25c41286b6935bb1ba24bd3e5f2f1d203bcfdbb551",
+				"KeyExpiry":  "2026-10-26T10:47:21Z",
+				"DiscoKey":   "discokey:eaf43caab5f9ca00093a935f0e4798121de2747c7687580ffcec979fb9ceac26",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:59900", "10.65.0.27:59900", "172.17.0.1:59900"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:47:21.857089185Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3717711984542387,
+				"StableID":   "n8yJNQzk2W11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:178a68cc16f584f7d347b2a6bd5d10d633bdcc412628681f7e92da89b3f33b50",
+				"KeyExpiry":  "2026-10-26T10:47:24Z",
+				"DiscoKey":   "discokey:46e3d2e8bd74eed12c76404289cf9f56b699a61629fe594bbf1381eb83a44a33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51942", "10.65.0.27:51942", "172.17.0.1:51942"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:47:24.58748233Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6700907684658438,
+				"StableID":   "nf3xuxUrKu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       6700907684658438,
+				"Key":        "nodekey:e3d8e4c92ba0ce74cd9b2fd9ba72ea2d8cd610b053263adadf4cb159010fe17b",
+				"DiscoKey":   "discokey:8d76c09d1ce76f8220bd861e33f4a0a621c18a89f21691a0bb591477aceefb32",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59406", "10.65.0.27:59406", "172.17.0.1:59406"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:47:11.036537247Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e3d8e4c92ba0ce74cd9b2fd9ba72ea2d8cd610b053263adadf4cb159010fe17b",
+			"MachineKey": "mkey:6679e1351a5a62748af4beacf4f1ce7237233cbfecd9d6af5311b2c8c2a71d13",
+			"Peers": [{
+				"ID":         8284341850822851,
+				"StableID":   "ntokxXczg721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6e8fb48bf9101c3941852e7f3288469e9ca57826188dca26a8317b8292fc604",
+				"DiscoKey":   "discokey:5fadf1f81424748b3009e8a64db7e5b02fb17e5c8aeb167f6fca95c7fd532260",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:42844", "10.65.0.27:42844", "172.17.0.1:42844"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:47:05.963637064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6795175505933163,
+				"StableID":   "nzSVUojY4v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cf95b76350c6eac986c710861fd4ad32a0e8e41efc0cebe54f93e06a06ac504",
+				"DiscoKey":   "discokey:155080528161703fe93c8da3fe86fe19f6b25c5af274fe36e55a39f72ff7685f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54595", "10.65.0.27:54595", "172.17.0.1:54595"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:47:08.814994047Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3968185434358641,
+				"StableID":   "nnPTR9WCzX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4baf8b7861df4c0b6c7cbd5f51e71410cd19cdc069d784d1c02f2ccbdfd1a65b",
+				"DiscoKey":   "discokey:fd4d468cd8207db6db410f3cefd57427e6c7348fefcd3beab69272d0e6f66872",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38402", "10.65.0.27:38402", "172.17.0.1:38402"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:47:13.411265464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3996574832627009,
+				"StableID":   "nAoEL9F4DY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9fbad70c101b60afa5b213876385e68233b96452f19821d7d3a05efb670ae04e",
+				"DiscoKey":   "discokey:a7bd1132c1228a8a7051cd0ce3d26c05fb22ea9b4c31d483f11ca6ada6f2161c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39530", "10.65.0.27:39530", "172.17.0.1:39530"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:47:19.953264588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1006932084652541,
+				"StableID":   "niB9F7Q3s811CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ed91d8b081082045c525e25c41286b6935bb1ba24bd3e5f2f1d203bcfdbb551",
+				"KeyExpiry":  "2026-10-26T10:47:21Z",
+				"DiscoKey":   "discokey:eaf43caab5f9ca00093a935f0e4798121de2747c7687580ffcec979fb9ceac26",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:59900", "10.65.0.27:59900", "172.17.0.1:59900"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:47:21.857089185Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8761376519968534,
+				"StableID":   "nTXR9GW3RB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:7eac39284dfcfddb1a19c41471d22e4c8ec5cd5a5992db91a2dd341a55de2c40",
+				"KeyExpiry":  "2026-10-26T10:47:22Z",
+				"DiscoKey":   "discokey:a82a8fa9ab4d6e173da87c04d2bc80e326d5a071fab901644e2bd79bf787fe77",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:34993", "10.65.0.27:34993", "172.17.0.1:34993"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:47:22.865053522Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3717711984542387,
+				"StableID":   "n8yJNQzk2W11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:178a68cc16f584f7d347b2a6bd5d10d633bdcc412628681f7e92da89b3f33b50",
+				"KeyExpiry":  "2026-10-26T10:47:24Z",
+				"DiscoKey":   "discokey:46e3d2e8bd74eed12c76404289cf9f56b699a61629fe594bbf1381eb83a44a33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51942", "10.65.0.27:51942", "172.17.0.1:51942"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:47:24.58748233Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6700907684658438": {
+				"ID":          6700907684658438,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-deny-fail-tag-src-host-dst.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-deny-fail-tag-src-host-dst.hujson
@@ -1,0 +1,8843 @@
+// policytest-deny-fail-tag-src-host-dst
+//
+// tests block deny-fail: tag src to host dst, allow rule covers it
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:47:46Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-deny-fail-tag-src-host-dst",
+	"description":    "tests block deny-fail: tag src to host dst, allow rule covers it",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:47:46.640367384Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                        \n  \n                                                                        \n                                                   \n{\n\t\"id\":          \"policytest-deny-fail-tag-src-host-dst\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block deny-fail: tag src to host dst, allow rule covers it\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"tag:client\"], \"dst\": [\"webserver:80\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"tag:client\", \"deny\": [\"webserver:80\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-deny-fail-tag-src-host-dst.hujson",
+		"full_policy": {
+			"acls": [{"action": "accept", "dst": ["webserver:80"], "src": ["tag:client"]}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"deny": ["webserver:80"], "src": "tag:client"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6110551226132076,
+				"StableID":   "noJiFWpUip11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6110551226132076,
+				"Key":        "nodekey:022570369ed7d0d45df672510e0b36fac80cec1889cc9dbf06326e26165d0949",
+				"DiscoKey":   "discokey:701be98d766a6a75e9e8b84a56cace8e18a398f83f8231880d654421e7656967",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:50142", "10.65.0.27:50142", "172.17.0.1:50142"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:47:50.275876462Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:022570369ed7d0d45df672510e0b36fac80cec1889cc9dbf06326e26165d0949",
+			"MachineKey": "mkey:c73331dbd319bb6521a727e68fba6bcc77f5c700591990e5f42829d66eb7b57e",
+			"Peers": [{
+				"ID":         135822673697181,
+				"StableID":   "nJHAaDqW4211CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:051b2a25f45dc31631fc8186fba6a5ab7b35ec6fce92c3140b3dd1e2f7fe037f",
+				"DiscoKey":   "discokey:9f4c02c782865ede272268cefc10001043ebae4672c1f0ad830d307125579108",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:39313", "10.65.0.27:39313", "172.17.0.1:39313"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:47:48.149919378Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3311643915677435,
+				"StableID":   "nGVvdfGrrS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69af0892bc6b9da16af3ff685879f8b3bfe03140c9f14a5d319a7fbb76c4bc29",
+				"DiscoKey":   "discokey:6916dbf6717480f46683566c1368d5b86c2de1372b1f54773e9e35315dc36a4a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54562", "10.65.0.27:54562", "172.17.0.1:54562"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:47:48.665526089Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1380759511701602,
+				"StableID":   "nqttrEDMnB11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b37fd29cb646123462d727043bec003a08cf301d968b5220da6726e63ae0d116",
+				"DiscoKey":   "discokey:fc9c50ce18c1761d99797e889fdc78ae432e3f176bdf5b1560b209b9a490bb68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50991", "10.65.0.27:50991", "172.17.0.1:50991"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:47:49.200854889Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5455098146134088,
+				"StableID":   "nhHw4LBdbj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e58d9a109426bb562480d742049b51364d751ddc7f8033c0c6c49f1fc05ee003",
+				"DiscoKey":   "discokey:41408c54dc2f7d22ab38abe86ae8fff2c27b9c4b717dd2fb7390b641ac8f0602",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58775", "10.65.0.27:58775", "172.17.0.1:58775"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:47:49.743870021Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8210014807772066,
+				"StableID":   "ny6ughAL7721CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ae018163a88faf6f0ec0033a4fcf67e080acebe0305e8f3bdd99801ff252e347",
+				"KeyExpiry":  "2026-10-26T10:47:50Z",
+				"DiscoKey":   "discokey:96d47f409bcab58dc3115b9ebf3a59ecea47e9772855a74afa82b817fa4ff160",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50065", "10.65.0.27:50065", "172.17.0.1:50065"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:47:50.809706192Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3444887776609333,
+				"StableID":   "nx8bMuMCuT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:77b9b5139c8f840fdb0bea1b53aa67fe8e2a8e9c317faa42ba3976b9adc31156",
+				"KeyExpiry":  "2026-10-26T10:47:51Z",
+				"DiscoKey":   "discokey:f0e945897dfd9f90f57fe3e0e447384abde1c96d8d46df678141bde33dce3547",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:40396", "10.65.0.27:40396", "172.17.0.1:40396"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:47:51.349290399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7711233746111113,
+				"StableID":   "nzXLG13SD321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bf171e1ad54c5eb572a8621714fef62e913dadea18ddb35e295c188cd708a355",
+				"KeyExpiry":  "2026-10-26T10:47:51Z",
+				"DiscoKey":   "discokey:8db27c1f73bbbb3f95ac9ee72b255e4f7cd8cf0c9c246b96f5b1dfabfdc37c04",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43609", "10.65.0.27:43609", "172.17.0.1:43609"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:47:51.894880518Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6110551226132076": {
+				"ID":          6110551226132076,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7711233746111113,
+				"StableID":   "nzXLG13SD321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bf171e1ad54c5eb572a8621714fef62e913dadea18ddb35e295c188cd708a355",
+				"KeyExpiry":  "2026-10-26T10:47:51Z",
+				"DiscoKey":   "discokey:8db27c1f73bbbb3f95ac9ee72b255e4f7cd8cf0c9c246b96f5b1dfabfdc37c04",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43609", "10.65.0.27:43609", "172.17.0.1:43609"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:47:51.894880518Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bf171e1ad54c5eb572a8621714fef62e913dadea18ddb35e295c188cd708a355",
+			"MachineKey": "mkey:69fdbbb054b5748e99719d986828820d460910d765ac1821e618c6888a65ba2d",
+			"Peers": [{
+				"ID":         135822673697181,
+				"StableID":   "nJHAaDqW4211CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:051b2a25f45dc31631fc8186fba6a5ab7b35ec6fce92c3140b3dd1e2f7fe037f",
+				"DiscoKey":   "discokey:9f4c02c782865ede272268cefc10001043ebae4672c1f0ad830d307125579108",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:39313", "10.65.0.27:39313", "172.17.0.1:39313"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:47:48.149919378Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3311643915677435,
+				"StableID":   "nGVvdfGrrS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69af0892bc6b9da16af3ff685879f8b3bfe03140c9f14a5d319a7fbb76c4bc29",
+				"DiscoKey":   "discokey:6916dbf6717480f46683566c1368d5b86c2de1372b1f54773e9e35315dc36a4a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54562", "10.65.0.27:54562", "172.17.0.1:54562"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:47:48.665526089Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1380759511701602,
+				"StableID":   "nqttrEDMnB11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b37fd29cb646123462d727043bec003a08cf301d968b5220da6726e63ae0d116",
+				"DiscoKey":   "discokey:fc9c50ce18c1761d99797e889fdc78ae432e3f176bdf5b1560b209b9a490bb68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50991", "10.65.0.27:50991", "172.17.0.1:50991"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:47:49.200854889Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5455098146134088,
+				"StableID":   "nhHw4LBdbj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e58d9a109426bb562480d742049b51364d751ddc7f8033c0c6c49f1fc05ee003",
+				"DiscoKey":   "discokey:41408c54dc2f7d22ab38abe86ae8fff2c27b9c4b717dd2fb7390b641ac8f0602",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58775", "10.65.0.27:58775", "172.17.0.1:58775"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:47:49.743870021Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6110551226132076,
+				"StableID":   "noJiFWpUip11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:022570369ed7d0d45df672510e0b36fac80cec1889cc9dbf06326e26165d0949",
+				"DiscoKey":   "discokey:701be98d766a6a75e9e8b84a56cace8e18a398f83f8231880d654421e7656967",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:50142", "10.65.0.27:50142", "172.17.0.1:50142"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:47:50.275876462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8210014807772066,
+				"StableID":   "ny6ughAL7721CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ae018163a88faf6f0ec0033a4fcf67e080acebe0305e8f3bdd99801ff252e347",
+				"KeyExpiry":  "2026-10-26T10:47:50Z",
+				"DiscoKey":   "discokey:96d47f409bcab58dc3115b9ebf3a59ecea47e9772855a74afa82b817fa4ff160",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50065", "10.65.0.27:50065", "172.17.0.1:50065"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:47:50.809706192Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3444887776609333,
+				"StableID":   "nx8bMuMCuT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:77b9b5139c8f840fdb0bea1b53aa67fe8e2a8e9c317faa42ba3976b9adc31156",
+				"KeyExpiry":  "2026-10-26T10:47:51Z",
+				"DiscoKey":   "discokey:f0e945897dfd9f90f57fe3e0e447384abde1c96d8d46df678141bde33dce3547",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:40396", "10.65.0.27:40396", "172.17.0.1:40396"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:47:51.349290399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         135822673697181,
+				"StableID":   "nJHAaDqW4211CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       135822673697181,
+				"Key":        "nodekey:051b2a25f45dc31631fc8186fba6a5ab7b35ec6fce92c3140b3dd1e2f7fe037f",
+				"DiscoKey":   "discokey:9f4c02c782865ede272268cefc10001043ebae4672c1f0ad830d307125579108",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:39313", "10.65.0.27:39313", "172.17.0.1:39313"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:47:48.149919378Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:051b2a25f45dc31631fc8186fba6a5ab7b35ec6fce92c3140b3dd1e2f7fe037f",
+			"MachineKey": "mkey:7764bde9b919b5dac86f4268977173a52fe1f2c44e29f0b7cf4682f89228595f",
+			"Peers": [{
+				"ID":         3311643915677435,
+				"StableID":   "nGVvdfGrrS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69af0892bc6b9da16af3ff685879f8b3bfe03140c9f14a5d319a7fbb76c4bc29",
+				"DiscoKey":   "discokey:6916dbf6717480f46683566c1368d5b86c2de1372b1f54773e9e35315dc36a4a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54562", "10.65.0.27:54562", "172.17.0.1:54562"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:47:48.665526089Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1380759511701602,
+				"StableID":   "nqttrEDMnB11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b37fd29cb646123462d727043bec003a08cf301d968b5220da6726e63ae0d116",
+				"DiscoKey":   "discokey:fc9c50ce18c1761d99797e889fdc78ae432e3f176bdf5b1560b209b9a490bb68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50991", "10.65.0.27:50991", "172.17.0.1:50991"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:47:49.200854889Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5455098146134088,
+				"StableID":   "nhHw4LBdbj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e58d9a109426bb562480d742049b51364d751ddc7f8033c0c6c49f1fc05ee003",
+				"DiscoKey":   "discokey:41408c54dc2f7d22ab38abe86ae8fff2c27b9c4b717dd2fb7390b641ac8f0602",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58775", "10.65.0.27:58775", "172.17.0.1:58775"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:47:49.743870021Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6110551226132076,
+				"StableID":   "noJiFWpUip11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:022570369ed7d0d45df672510e0b36fac80cec1889cc9dbf06326e26165d0949",
+				"DiscoKey":   "discokey:701be98d766a6a75e9e8b84a56cace8e18a398f83f8231880d654421e7656967",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:50142", "10.65.0.27:50142", "172.17.0.1:50142"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:47:50.275876462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8210014807772066,
+				"StableID":   "ny6ughAL7721CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ae018163a88faf6f0ec0033a4fcf67e080acebe0305e8f3bdd99801ff252e347",
+				"KeyExpiry":  "2026-10-26T10:47:50Z",
+				"DiscoKey":   "discokey:96d47f409bcab58dc3115b9ebf3a59ecea47e9772855a74afa82b817fa4ff160",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50065", "10.65.0.27:50065", "172.17.0.1:50065"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:47:50.809706192Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3444887776609333,
+				"StableID":   "nx8bMuMCuT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:77b9b5139c8f840fdb0bea1b53aa67fe8e2a8e9c317faa42ba3976b9adc31156",
+				"KeyExpiry":  "2026-10-26T10:47:51Z",
+				"DiscoKey":   "discokey:f0e945897dfd9f90f57fe3e0e447384abde1c96d8d46df678141bde33dce3547",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:40396", "10.65.0.27:40396", "172.17.0.1:40396"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:47:51.349290399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7711233746111113,
+				"StableID":   "nzXLG13SD321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bf171e1ad54c5eb572a8621714fef62e913dadea18ddb35e295c188cd708a355",
+				"KeyExpiry":  "2026-10-26T10:47:51Z",
+				"DiscoKey":   "discokey:8db27c1f73bbbb3f95ac9ee72b255e4f7cd8cf0c9c246b96f5b1dfabfdc37c04",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43609", "10.65.0.27:43609", "172.17.0.1:43609"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:47:51.894880518Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "135822673697181": {
+				"ID":          135822673697181,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8210014807772066,
+				"StableID":   "ny6ughAL7721CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ae018163a88faf6f0ec0033a4fcf67e080acebe0305e8f3bdd99801ff252e347",
+				"KeyExpiry":  "2026-10-26T10:47:50Z",
+				"DiscoKey":   "discokey:96d47f409bcab58dc3115b9ebf3a59ecea47e9772855a74afa82b817fa4ff160",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50065", "10.65.0.27:50065", "172.17.0.1:50065"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:47:50.809706192Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ae018163a88faf6f0ec0033a4fcf67e080acebe0305e8f3bdd99801ff252e347",
+			"MachineKey": "mkey:afb217e0fdc2726555d47b67ca160e07feff3d40ee792e63788bcfd4ab2e3817",
+			"Peers": [{
+				"ID":         135822673697181,
+				"StableID":   "nJHAaDqW4211CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:051b2a25f45dc31631fc8186fba6a5ab7b35ec6fce92c3140b3dd1e2f7fe037f",
+				"DiscoKey":   "discokey:9f4c02c782865ede272268cefc10001043ebae4672c1f0ad830d307125579108",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:39313", "10.65.0.27:39313", "172.17.0.1:39313"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:47:48.149919378Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3311643915677435,
+				"StableID":   "nGVvdfGrrS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69af0892bc6b9da16af3ff685879f8b3bfe03140c9f14a5d319a7fbb76c4bc29",
+				"DiscoKey":   "discokey:6916dbf6717480f46683566c1368d5b86c2de1372b1f54773e9e35315dc36a4a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54562", "10.65.0.27:54562", "172.17.0.1:54562"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:47:48.665526089Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1380759511701602,
+				"StableID":   "nqttrEDMnB11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b37fd29cb646123462d727043bec003a08cf301d968b5220da6726e63ae0d116",
+				"DiscoKey":   "discokey:fc9c50ce18c1761d99797e889fdc78ae432e3f176bdf5b1560b209b9a490bb68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50991", "10.65.0.27:50991", "172.17.0.1:50991"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:47:49.200854889Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5455098146134088,
+				"StableID":   "nhHw4LBdbj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e58d9a109426bb562480d742049b51364d751ddc7f8033c0c6c49f1fc05ee003",
+				"DiscoKey":   "discokey:41408c54dc2f7d22ab38abe86ae8fff2c27b9c4b717dd2fb7390b641ac8f0602",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58775", "10.65.0.27:58775", "172.17.0.1:58775"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:47:49.743870021Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6110551226132076,
+				"StableID":   "noJiFWpUip11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:022570369ed7d0d45df672510e0b36fac80cec1889cc9dbf06326e26165d0949",
+				"DiscoKey":   "discokey:701be98d766a6a75e9e8b84a56cace8e18a398f83f8231880d654421e7656967",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:50142", "10.65.0.27:50142", "172.17.0.1:50142"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:47:50.275876462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3444887776609333,
+				"StableID":   "nx8bMuMCuT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:77b9b5139c8f840fdb0bea1b53aa67fe8e2a8e9c317faa42ba3976b9adc31156",
+				"KeyExpiry":  "2026-10-26T10:47:51Z",
+				"DiscoKey":   "discokey:f0e945897dfd9f90f57fe3e0e447384abde1c96d8d46df678141bde33dce3547",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:40396", "10.65.0.27:40396", "172.17.0.1:40396"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:47:51.349290399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7711233746111113,
+				"StableID":   "nzXLG13SD321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bf171e1ad54c5eb572a8621714fef62e913dadea18ddb35e295c188cd708a355",
+				"KeyExpiry":  "2026-10-26T10:47:51Z",
+				"DiscoKey":   "discokey:8db27c1f73bbbb3f95ac9ee72b255e4f7cd8cf0c9c246b96f5b1dfabfdc37c04",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43609", "10.65.0.27:43609", "172.17.0.1:43609"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:47:51.894880518Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5455098146134088,
+				"StableID":   "nhHw4LBdbj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       5455098146134088,
+				"Key":        "nodekey:e58d9a109426bb562480d742049b51364d751ddc7f8033c0c6c49f1fc05ee003",
+				"DiscoKey":   "discokey:41408c54dc2f7d22ab38abe86ae8fff2c27b9c4b717dd2fb7390b641ac8f0602",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58775", "10.65.0.27:58775", "172.17.0.1:58775"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:47:49.743870021Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e58d9a109426bb562480d742049b51364d751ddc7f8033c0c6c49f1fc05ee003",
+			"MachineKey": "mkey:b23f04564734fac2feb1f2901e3f18fdf69d791fd780ab7c7738d566b8c59318",
+			"Peers": [{
+				"ID":         135822673697181,
+				"StableID":   "nJHAaDqW4211CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:051b2a25f45dc31631fc8186fba6a5ab7b35ec6fce92c3140b3dd1e2f7fe037f",
+				"DiscoKey":   "discokey:9f4c02c782865ede272268cefc10001043ebae4672c1f0ad830d307125579108",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:39313", "10.65.0.27:39313", "172.17.0.1:39313"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:47:48.149919378Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3311643915677435,
+				"StableID":   "nGVvdfGrrS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69af0892bc6b9da16af3ff685879f8b3bfe03140c9f14a5d319a7fbb76c4bc29",
+				"DiscoKey":   "discokey:6916dbf6717480f46683566c1368d5b86c2de1372b1f54773e9e35315dc36a4a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54562", "10.65.0.27:54562", "172.17.0.1:54562"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:47:48.665526089Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1380759511701602,
+				"StableID":   "nqttrEDMnB11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b37fd29cb646123462d727043bec003a08cf301d968b5220da6726e63ae0d116",
+				"DiscoKey":   "discokey:fc9c50ce18c1761d99797e889fdc78ae432e3f176bdf5b1560b209b9a490bb68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50991", "10.65.0.27:50991", "172.17.0.1:50991"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:47:49.200854889Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6110551226132076,
+				"StableID":   "noJiFWpUip11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:022570369ed7d0d45df672510e0b36fac80cec1889cc9dbf06326e26165d0949",
+				"DiscoKey":   "discokey:701be98d766a6a75e9e8b84a56cace8e18a398f83f8231880d654421e7656967",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:50142", "10.65.0.27:50142", "172.17.0.1:50142"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:47:50.275876462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8210014807772066,
+				"StableID":   "ny6ughAL7721CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ae018163a88faf6f0ec0033a4fcf67e080acebe0305e8f3bdd99801ff252e347",
+				"KeyExpiry":  "2026-10-26T10:47:50Z",
+				"DiscoKey":   "discokey:96d47f409bcab58dc3115b9ebf3a59ecea47e9772855a74afa82b817fa4ff160",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50065", "10.65.0.27:50065", "172.17.0.1:50065"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:47:50.809706192Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3444887776609333,
+				"StableID":   "nx8bMuMCuT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:77b9b5139c8f840fdb0bea1b53aa67fe8e2a8e9c317faa42ba3976b9adc31156",
+				"KeyExpiry":  "2026-10-26T10:47:51Z",
+				"DiscoKey":   "discokey:f0e945897dfd9f90f57fe3e0e447384abde1c96d8d46df678141bde33dce3547",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:40396", "10.65.0.27:40396", "172.17.0.1:40396"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:47:51.349290399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7711233746111113,
+				"StableID":   "nzXLG13SD321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bf171e1ad54c5eb572a8621714fef62e913dadea18ddb35e295c188cd708a355",
+				"KeyExpiry":  "2026-10-26T10:47:51Z",
+				"DiscoKey":   "discokey:8db27c1f73bbbb3f95ac9ee72b255e4f7cd8cf0c9c246b96f5b1dfabfdc37c04",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43609", "10.65.0.27:43609", "172.17.0.1:43609"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:47:51.894880518Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5455098146134088": {
+				"ID":          5455098146134088,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3311643915677435,
+				"StableID":   "nGVvdfGrrS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       3311643915677435,
+				"Key":        "nodekey:69af0892bc6b9da16af3ff685879f8b3bfe03140c9f14a5d319a7fbb76c4bc29",
+				"DiscoKey":   "discokey:6916dbf6717480f46683566c1368d5b86c2de1372b1f54773e9e35315dc36a4a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54562", "10.65.0.27:54562", "172.17.0.1:54562"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:47:48.665526089Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:69af0892bc6b9da16af3ff685879f8b3bfe03140c9f14a5d319a7fbb76c4bc29",
+			"MachineKey": "mkey:e2bbb3a7cc68386c689787d61b7c8396c2ed05f6eb6c0104b061444a7e30185e",
+			"Peers": [{
+				"ID":         135822673697181,
+				"StableID":   "nJHAaDqW4211CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:051b2a25f45dc31631fc8186fba6a5ab7b35ec6fce92c3140b3dd1e2f7fe037f",
+				"DiscoKey":   "discokey:9f4c02c782865ede272268cefc10001043ebae4672c1f0ad830d307125579108",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:39313", "10.65.0.27:39313", "172.17.0.1:39313"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:47:48.149919378Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1380759511701602,
+				"StableID":   "nqttrEDMnB11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b37fd29cb646123462d727043bec003a08cf301d968b5220da6726e63ae0d116",
+				"DiscoKey":   "discokey:fc9c50ce18c1761d99797e889fdc78ae432e3f176bdf5b1560b209b9a490bb68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50991", "10.65.0.27:50991", "172.17.0.1:50991"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:47:49.200854889Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5455098146134088,
+				"StableID":   "nhHw4LBdbj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e58d9a109426bb562480d742049b51364d751ddc7f8033c0c6c49f1fc05ee003",
+				"DiscoKey":   "discokey:41408c54dc2f7d22ab38abe86ae8fff2c27b9c4b717dd2fb7390b641ac8f0602",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58775", "10.65.0.27:58775", "172.17.0.1:58775"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:47:49.743870021Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6110551226132076,
+				"StableID":   "noJiFWpUip11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:022570369ed7d0d45df672510e0b36fac80cec1889cc9dbf06326e26165d0949",
+				"DiscoKey":   "discokey:701be98d766a6a75e9e8b84a56cace8e18a398f83f8231880d654421e7656967",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:50142", "10.65.0.27:50142", "172.17.0.1:50142"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:47:50.275876462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8210014807772066,
+				"StableID":   "ny6ughAL7721CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ae018163a88faf6f0ec0033a4fcf67e080acebe0305e8f3bdd99801ff252e347",
+				"KeyExpiry":  "2026-10-26T10:47:50Z",
+				"DiscoKey":   "discokey:96d47f409bcab58dc3115b9ebf3a59ecea47e9772855a74afa82b817fa4ff160",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50065", "10.65.0.27:50065", "172.17.0.1:50065"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:47:50.809706192Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3444887776609333,
+				"StableID":   "nx8bMuMCuT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:77b9b5139c8f840fdb0bea1b53aa67fe8e2a8e9c317faa42ba3976b9adc31156",
+				"KeyExpiry":  "2026-10-26T10:47:51Z",
+				"DiscoKey":   "discokey:f0e945897dfd9f90f57fe3e0e447384abde1c96d8d46df678141bde33dce3547",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:40396", "10.65.0.27:40396", "172.17.0.1:40396"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:47:51.349290399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7711233746111113,
+				"StableID":   "nzXLG13SD321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bf171e1ad54c5eb572a8621714fef62e913dadea18ddb35e295c188cd708a355",
+				"KeyExpiry":  "2026-10-26T10:47:51Z",
+				"DiscoKey":   "discokey:8db27c1f73bbbb3f95ac9ee72b255e4f7cd8cf0c9c246b96f5b1dfabfdc37c04",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43609", "10.65.0.27:43609", "172.17.0.1:43609"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:47:51.894880518Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3311643915677435": {
+				"ID":          3311643915677435,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3444887776609333,
+				"StableID":   "nx8bMuMCuT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:77b9b5139c8f840fdb0bea1b53aa67fe8e2a8e9c317faa42ba3976b9adc31156",
+				"KeyExpiry":  "2026-10-26T10:47:51Z",
+				"DiscoKey":   "discokey:f0e945897dfd9f90f57fe3e0e447384abde1c96d8d46df678141bde33dce3547",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:40396", "10.65.0.27:40396", "172.17.0.1:40396"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:47:51.349290399Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:77b9b5139c8f840fdb0bea1b53aa67fe8e2a8e9c317faa42ba3976b9adc31156",
+			"MachineKey": "mkey:6d83979bd91daa5ed74616acead492ae0edaa611571ee4c7752fc8e0e2c97f37",
+			"Peers": [{
+				"ID":         135822673697181,
+				"StableID":   "nJHAaDqW4211CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:051b2a25f45dc31631fc8186fba6a5ab7b35ec6fce92c3140b3dd1e2f7fe037f",
+				"DiscoKey":   "discokey:9f4c02c782865ede272268cefc10001043ebae4672c1f0ad830d307125579108",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:39313", "10.65.0.27:39313", "172.17.0.1:39313"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:47:48.149919378Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3311643915677435,
+				"StableID":   "nGVvdfGrrS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69af0892bc6b9da16af3ff685879f8b3bfe03140c9f14a5d319a7fbb76c4bc29",
+				"DiscoKey":   "discokey:6916dbf6717480f46683566c1368d5b86c2de1372b1f54773e9e35315dc36a4a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54562", "10.65.0.27:54562", "172.17.0.1:54562"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:47:48.665526089Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1380759511701602,
+				"StableID":   "nqttrEDMnB11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b37fd29cb646123462d727043bec003a08cf301d968b5220da6726e63ae0d116",
+				"DiscoKey":   "discokey:fc9c50ce18c1761d99797e889fdc78ae432e3f176bdf5b1560b209b9a490bb68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50991", "10.65.0.27:50991", "172.17.0.1:50991"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:47:49.200854889Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5455098146134088,
+				"StableID":   "nhHw4LBdbj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e58d9a109426bb562480d742049b51364d751ddc7f8033c0c6c49f1fc05ee003",
+				"DiscoKey":   "discokey:41408c54dc2f7d22ab38abe86ae8fff2c27b9c4b717dd2fb7390b641ac8f0602",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58775", "10.65.0.27:58775", "172.17.0.1:58775"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:47:49.743870021Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6110551226132076,
+				"StableID":   "noJiFWpUip11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:022570369ed7d0d45df672510e0b36fac80cec1889cc9dbf06326e26165d0949",
+				"DiscoKey":   "discokey:701be98d766a6a75e9e8b84a56cace8e18a398f83f8231880d654421e7656967",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:50142", "10.65.0.27:50142", "172.17.0.1:50142"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:47:50.275876462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8210014807772066,
+				"StableID":   "ny6ughAL7721CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ae018163a88faf6f0ec0033a4fcf67e080acebe0305e8f3bdd99801ff252e347",
+				"KeyExpiry":  "2026-10-26T10:47:50Z",
+				"DiscoKey":   "discokey:96d47f409bcab58dc3115b9ebf3a59ecea47e9772855a74afa82b817fa4ff160",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50065", "10.65.0.27:50065", "172.17.0.1:50065"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:47:50.809706192Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7711233746111113,
+				"StableID":   "nzXLG13SD321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bf171e1ad54c5eb572a8621714fef62e913dadea18ddb35e295c188cd708a355",
+				"KeyExpiry":  "2026-10-26T10:47:51Z",
+				"DiscoKey":   "discokey:8db27c1f73bbbb3f95ac9ee72b255e4f7cd8cf0c9c246b96f5b1dfabfdc37c04",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43609", "10.65.0.27:43609", "172.17.0.1:43609"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:47:51.894880518Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1380759511701602,
+				"StableID":   "nqttrEDMnB11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1380759511701602,
+				"Key":        "nodekey:b37fd29cb646123462d727043bec003a08cf301d968b5220da6726e63ae0d116",
+				"DiscoKey":   "discokey:fc9c50ce18c1761d99797e889fdc78ae432e3f176bdf5b1560b209b9a490bb68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50991", "10.65.0.27:50991", "172.17.0.1:50991"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:47:49.200854889Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b37fd29cb646123462d727043bec003a08cf301d968b5220da6726e63ae0d116",
+			"MachineKey": "mkey:ff126c10f29f95e1f8e0b89666ce26435c42b08de0732c5421efa8b2820b5d54",
+			"Peers": [{
+				"ID":         135822673697181,
+				"StableID":   "nJHAaDqW4211CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:051b2a25f45dc31631fc8186fba6a5ab7b35ec6fce92c3140b3dd1e2f7fe037f",
+				"DiscoKey":   "discokey:9f4c02c782865ede272268cefc10001043ebae4672c1f0ad830d307125579108",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:39313", "10.65.0.27:39313", "172.17.0.1:39313"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:47:48.149919378Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3311643915677435,
+				"StableID":   "nGVvdfGrrS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69af0892bc6b9da16af3ff685879f8b3bfe03140c9f14a5d319a7fbb76c4bc29",
+				"DiscoKey":   "discokey:6916dbf6717480f46683566c1368d5b86c2de1372b1f54773e9e35315dc36a4a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54562", "10.65.0.27:54562", "172.17.0.1:54562"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:47:48.665526089Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5455098146134088,
+				"StableID":   "nhHw4LBdbj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e58d9a109426bb562480d742049b51364d751ddc7f8033c0c6c49f1fc05ee003",
+				"DiscoKey":   "discokey:41408c54dc2f7d22ab38abe86ae8fff2c27b9c4b717dd2fb7390b641ac8f0602",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58775", "10.65.0.27:58775", "172.17.0.1:58775"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:47:49.743870021Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6110551226132076,
+				"StableID":   "noJiFWpUip11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:022570369ed7d0d45df672510e0b36fac80cec1889cc9dbf06326e26165d0949",
+				"DiscoKey":   "discokey:701be98d766a6a75e9e8b84a56cace8e18a398f83f8231880d654421e7656967",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:50142", "10.65.0.27:50142", "172.17.0.1:50142"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:47:50.275876462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8210014807772066,
+				"StableID":   "ny6ughAL7721CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ae018163a88faf6f0ec0033a4fcf67e080acebe0305e8f3bdd99801ff252e347",
+				"KeyExpiry":  "2026-10-26T10:47:50Z",
+				"DiscoKey":   "discokey:96d47f409bcab58dc3115b9ebf3a59ecea47e9772855a74afa82b817fa4ff160",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50065", "10.65.0.27:50065", "172.17.0.1:50065"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:47:50.809706192Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3444887776609333,
+				"StableID":   "nx8bMuMCuT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:77b9b5139c8f840fdb0bea1b53aa67fe8e2a8e9c317faa42ba3976b9adc31156",
+				"KeyExpiry":  "2026-10-26T10:47:51Z",
+				"DiscoKey":   "discokey:f0e945897dfd9f90f57fe3e0e447384abde1c96d8d46df678141bde33dce3547",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:40396", "10.65.0.27:40396", "172.17.0.1:40396"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:47:51.349290399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7711233746111113,
+				"StableID":   "nzXLG13SD321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bf171e1ad54c5eb572a8621714fef62e913dadea18ddb35e295c188cd708a355",
+				"KeyExpiry":  "2026-10-26T10:47:51Z",
+				"DiscoKey":   "discokey:8db27c1f73bbbb3f95ac9ee72b255e4f7cd8cf0c9c246b96f5b1dfabfdc37c04",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43609", "10.65.0.27:43609", "172.17.0.1:43609"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:47:51.894880518Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1380759511701602": {
+				"ID":          1380759511701602,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-deny-fail-user-src-tag-dst.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-deny-fail-user-src-tag-dst.hujson
@@ -1,0 +1,8841 @@
+// policytest-deny-fail-user-src-tag-dst
+//
+// tests block deny-fail: user src to tag dst, allow rule covers it
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:48:13Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-deny-fail-user-src-tag-dst",
+	"description":    "tests block deny-fail: user src to tag dst, allow rule covers it",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:48:13.616261883Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                        \n  \n                                                                     \n                                                        \n{\n\t\"id\":          \"policytest-deny-fail-user-src-tag-dst\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block deny-fail: user src to tag dst, allow rule covers it\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"thor@example.org\"], \"dst\": [\"tag:server:22\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"deny\": [\"tag:server:22\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-deny-fail-user-src-tag-dst.hujson",
+		"full_policy": {"acls": [{
+			"action": "accept",
+			"dst":    ["tag:server:22"],
+			"src":    ["thor@example.org"]
+		}], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [{"deny": ["tag:server:22"], "src": "thor@example.org"}]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6256085505137799,
+				"StableID":   "n2aa8xkPrq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6256085505137799,
+				"Key":        "nodekey:730fe57492bbef73bbd99c1c20b705bf5e6604b9498953c88e10d72fb6ae3436",
+				"DiscoKey":   "discokey:a97e50b5b70013b33b81c56da91b00c679478fd78342df4ccc9149080cfc8e18",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:56164", "10.65.0.27:56164", "172.17.0.1:56164"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:48:18.986397212Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:730fe57492bbef73bbd99c1c20b705bf5e6604b9498953c88e10d72fb6ae3436",
+			"MachineKey": "mkey:3053655fc72fdb12df7d17b4db29e6bba9b2fc94bf925403e91b13148750cd1a",
+			"Peers": [{
+				"ID":         4134352601998007,
+				"StableID":   "nkPm15STHZ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d21aad6c76aa84bc2f4f15f810f77716e9c8a9ef3dc0f28b38d5a7bf7a3a520",
+				"DiscoKey":   "discokey:9e8da7ddad7bd6ce91ff97c295f08d39359725daae8443c168663cc62a552200",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46748", "10.65.0.27:46748", "172.17.0.1:46748"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:48:15.203988235Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2217086213883031,
+				"StableID":   "negcfX68KJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ffe03092e166f98b81d13030e63214cdb77eb7a39ab44ac495f728a9b288b06",
+				"DiscoKey":   "discokey:bcc8fd198a4f130171372dd17046854ba69a56ea3a93f0552d914b36644eb91f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56032", "10.65.0.27:56032", "172.17.0.1:56032"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:48:15.844651129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4020296473889876,
+				"StableID":   "nBgGYXNoPY11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e44b195c44da0d4b73f3eb0debc228d2f60824d302ff04dfba56f0199f03216",
+				"DiscoKey":   "discokey:1df649ee1919de95653f378f5c30eb9e6b2def7a78ee0a80e2f87bf9de4d9714",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:52157", "10.65.0.27:52157", "172.17.0.1:52157"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:48:17.728026064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2014139748150863,
+				"StableID":   "nSCuS53DjG11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cda12ef231617fe52fdca865297428d94aedf79c20d1032596e0f57f2c107e3c",
+				"DiscoKey":   "discokey:4a64b1229c8193d34d75b57c6ef8a92a046b3f8583bff8ab4c81f8cc33da3702",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40027", "10.65.0.27:40027", "172.17.0.1:40027"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:48:18.485154344Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2753892583947537,
+				"StableID":   "n8n7P86FWN11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1c011fcaae378f99b9006395bb01b9f59d5c0d0486dbaf2f9a6673f5dfaa4e22",
+				"KeyExpiry":  "2026-10-26T10:48:20Z",
+				"DiscoKey":   "discokey:4110f677b2eca162a05a69087ade28b62f4216d726bd65e1f165c24d6852dc61",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38470", "10.65.0.27:38470", "172.17.0.1:38470"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:48:20.947280604Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8837949965143678,
+				"StableID":   "n1LMHdxi1C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8067c69167d16349c8f0ea52b108239efc72244bf1467c6074388280c99feb41",
+				"KeyExpiry":  "2026-10-26T10:48:21Z",
+				"DiscoKey":   "discokey:14666bbe2a3c806a58942a6202130c6333d81b3f9c59cacba7c2d11b0ef90153",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59393", "10.65.0.27:59393", "172.17.0.1:59393"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:48:21.569145384Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         883749285244521,
+				"StableID":   "nvTd5XbFu711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:118db550352aca2c0bfa41184895312ed2f04d53240a7f94e61cd5c2d91b4243",
+				"KeyExpiry":  "2026-10-26T10:48:22Z",
+				"DiscoKey":   "discokey:831e49b971fc3bba8304e9a3ef4e33982e8430d9011bfd6308e09087169fd573",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:32929", "10.65.0.27:32929", "172.17.0.1:32929"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:48:22.090438386Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6256085505137799": {
+				"ID":          6256085505137799,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         883749285244521,
+				"StableID":   "nvTd5XbFu711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:118db550352aca2c0bfa41184895312ed2f04d53240a7f94e61cd5c2d91b4243",
+				"KeyExpiry":  "2026-10-26T10:48:22Z",
+				"DiscoKey":   "discokey:831e49b971fc3bba8304e9a3ef4e33982e8430d9011bfd6308e09087169fd573",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:32929", "10.65.0.27:32929", "172.17.0.1:32929"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:48:22.090438386Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:118db550352aca2c0bfa41184895312ed2f04d53240a7f94e61cd5c2d91b4243",
+			"MachineKey": "mkey:c1ce5cced2b88ee85a6ce0a0d581691618d5de39621fde1c8c0e625ed3dd3414",
+			"Peers": [{
+				"ID":         4134352601998007,
+				"StableID":   "nkPm15STHZ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d21aad6c76aa84bc2f4f15f810f77716e9c8a9ef3dc0f28b38d5a7bf7a3a520",
+				"DiscoKey":   "discokey:9e8da7ddad7bd6ce91ff97c295f08d39359725daae8443c168663cc62a552200",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46748", "10.65.0.27:46748", "172.17.0.1:46748"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:48:15.203988235Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2217086213883031,
+				"StableID":   "negcfX68KJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ffe03092e166f98b81d13030e63214cdb77eb7a39ab44ac495f728a9b288b06",
+				"DiscoKey":   "discokey:bcc8fd198a4f130171372dd17046854ba69a56ea3a93f0552d914b36644eb91f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56032", "10.65.0.27:56032", "172.17.0.1:56032"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:48:15.844651129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4020296473889876,
+				"StableID":   "nBgGYXNoPY11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e44b195c44da0d4b73f3eb0debc228d2f60824d302ff04dfba56f0199f03216",
+				"DiscoKey":   "discokey:1df649ee1919de95653f378f5c30eb9e6b2def7a78ee0a80e2f87bf9de4d9714",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:52157", "10.65.0.27:52157", "172.17.0.1:52157"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:48:17.728026064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2014139748150863,
+				"StableID":   "nSCuS53DjG11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cda12ef231617fe52fdca865297428d94aedf79c20d1032596e0f57f2c107e3c",
+				"DiscoKey":   "discokey:4a64b1229c8193d34d75b57c6ef8a92a046b3f8583bff8ab4c81f8cc33da3702",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40027", "10.65.0.27:40027", "172.17.0.1:40027"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:48:18.485154344Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6256085505137799,
+				"StableID":   "n2aa8xkPrq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:730fe57492bbef73bbd99c1c20b705bf5e6604b9498953c88e10d72fb6ae3436",
+				"DiscoKey":   "discokey:a97e50b5b70013b33b81c56da91b00c679478fd78342df4ccc9149080cfc8e18",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:56164", "10.65.0.27:56164", "172.17.0.1:56164"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:48:18.986397212Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2753892583947537,
+				"StableID":   "n8n7P86FWN11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1c011fcaae378f99b9006395bb01b9f59d5c0d0486dbaf2f9a6673f5dfaa4e22",
+				"KeyExpiry":  "2026-10-26T10:48:20Z",
+				"DiscoKey":   "discokey:4110f677b2eca162a05a69087ade28b62f4216d726bd65e1f165c24d6852dc61",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38470", "10.65.0.27:38470", "172.17.0.1:38470"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:48:20.947280604Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8837949965143678,
+				"StableID":   "n1LMHdxi1C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8067c69167d16349c8f0ea52b108239efc72244bf1467c6074388280c99feb41",
+				"KeyExpiry":  "2026-10-26T10:48:21Z",
+				"DiscoKey":   "discokey:14666bbe2a3c806a58942a6202130c6333d81b3f9c59cacba7c2d11b0ef90153",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59393", "10.65.0.27:59393", "172.17.0.1:59393"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:48:21.569145384Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4134352601998007,
+				"StableID":   "nkPm15STHZ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       4134352601998007,
+				"Key":        "nodekey:4d21aad6c76aa84bc2f4f15f810f77716e9c8a9ef3dc0f28b38d5a7bf7a3a520",
+				"DiscoKey":   "discokey:9e8da7ddad7bd6ce91ff97c295f08d39359725daae8443c168663cc62a552200",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46748", "10.65.0.27:46748", "172.17.0.1:46748"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:48:15.203988235Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4d21aad6c76aa84bc2f4f15f810f77716e9c8a9ef3dc0f28b38d5a7bf7a3a520",
+			"MachineKey": "mkey:15e1d1718deb6cda6d19eb13c65e1153b77d040436a83f6d74ff7143a4183e0d",
+			"Peers": [{
+				"ID":         2217086213883031,
+				"StableID":   "negcfX68KJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ffe03092e166f98b81d13030e63214cdb77eb7a39ab44ac495f728a9b288b06",
+				"DiscoKey":   "discokey:bcc8fd198a4f130171372dd17046854ba69a56ea3a93f0552d914b36644eb91f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56032", "10.65.0.27:56032", "172.17.0.1:56032"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:48:15.844651129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4020296473889876,
+				"StableID":   "nBgGYXNoPY11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e44b195c44da0d4b73f3eb0debc228d2f60824d302ff04dfba56f0199f03216",
+				"DiscoKey":   "discokey:1df649ee1919de95653f378f5c30eb9e6b2def7a78ee0a80e2f87bf9de4d9714",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:52157", "10.65.0.27:52157", "172.17.0.1:52157"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:48:17.728026064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2014139748150863,
+				"StableID":   "nSCuS53DjG11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cda12ef231617fe52fdca865297428d94aedf79c20d1032596e0f57f2c107e3c",
+				"DiscoKey":   "discokey:4a64b1229c8193d34d75b57c6ef8a92a046b3f8583bff8ab4c81f8cc33da3702",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40027", "10.65.0.27:40027", "172.17.0.1:40027"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:48:18.485154344Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6256085505137799,
+				"StableID":   "n2aa8xkPrq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:730fe57492bbef73bbd99c1c20b705bf5e6604b9498953c88e10d72fb6ae3436",
+				"DiscoKey":   "discokey:a97e50b5b70013b33b81c56da91b00c679478fd78342df4ccc9149080cfc8e18",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:56164", "10.65.0.27:56164", "172.17.0.1:56164"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:48:18.986397212Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2753892583947537,
+				"StableID":   "n8n7P86FWN11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1c011fcaae378f99b9006395bb01b9f59d5c0d0486dbaf2f9a6673f5dfaa4e22",
+				"KeyExpiry":  "2026-10-26T10:48:20Z",
+				"DiscoKey":   "discokey:4110f677b2eca162a05a69087ade28b62f4216d726bd65e1f165c24d6852dc61",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38470", "10.65.0.27:38470", "172.17.0.1:38470"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:48:20.947280604Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8837949965143678,
+				"StableID":   "n1LMHdxi1C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8067c69167d16349c8f0ea52b108239efc72244bf1467c6074388280c99feb41",
+				"KeyExpiry":  "2026-10-26T10:48:21Z",
+				"DiscoKey":   "discokey:14666bbe2a3c806a58942a6202130c6333d81b3f9c59cacba7c2d11b0ef90153",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59393", "10.65.0.27:59393", "172.17.0.1:59393"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:48:21.569145384Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         883749285244521,
+				"StableID":   "nvTd5XbFu711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:118db550352aca2c0bfa41184895312ed2f04d53240a7f94e61cd5c2d91b4243",
+				"KeyExpiry":  "2026-10-26T10:48:22Z",
+				"DiscoKey":   "discokey:831e49b971fc3bba8304e9a3ef4e33982e8430d9011bfd6308e09087169fd573",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:32929", "10.65.0.27:32929", "172.17.0.1:32929"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:48:22.090438386Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4134352601998007": {
+				"ID":          4134352601998007,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2753892583947537,
+				"StableID":   "n8n7P86FWN11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1c011fcaae378f99b9006395bb01b9f59d5c0d0486dbaf2f9a6673f5dfaa4e22",
+				"KeyExpiry":  "2026-10-26T10:48:20Z",
+				"DiscoKey":   "discokey:4110f677b2eca162a05a69087ade28b62f4216d726bd65e1f165c24d6852dc61",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38470", "10.65.0.27:38470", "172.17.0.1:38470"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:48:20.947280604Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1c011fcaae378f99b9006395bb01b9f59d5c0d0486dbaf2f9a6673f5dfaa4e22",
+			"MachineKey": "mkey:6b20dd23e6ff6ab3ec0def07290488056723006168c72b6f608b819cf7a17432",
+			"Peers": [{
+				"ID":         4134352601998007,
+				"StableID":   "nkPm15STHZ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d21aad6c76aa84bc2f4f15f810f77716e9c8a9ef3dc0f28b38d5a7bf7a3a520",
+				"DiscoKey":   "discokey:9e8da7ddad7bd6ce91ff97c295f08d39359725daae8443c168663cc62a552200",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46748", "10.65.0.27:46748", "172.17.0.1:46748"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:48:15.203988235Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2217086213883031,
+				"StableID":   "negcfX68KJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ffe03092e166f98b81d13030e63214cdb77eb7a39ab44ac495f728a9b288b06",
+				"DiscoKey":   "discokey:bcc8fd198a4f130171372dd17046854ba69a56ea3a93f0552d914b36644eb91f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56032", "10.65.0.27:56032", "172.17.0.1:56032"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:48:15.844651129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4020296473889876,
+				"StableID":   "nBgGYXNoPY11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e44b195c44da0d4b73f3eb0debc228d2f60824d302ff04dfba56f0199f03216",
+				"DiscoKey":   "discokey:1df649ee1919de95653f378f5c30eb9e6b2def7a78ee0a80e2f87bf9de4d9714",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:52157", "10.65.0.27:52157", "172.17.0.1:52157"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:48:17.728026064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2014139748150863,
+				"StableID":   "nSCuS53DjG11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cda12ef231617fe52fdca865297428d94aedf79c20d1032596e0f57f2c107e3c",
+				"DiscoKey":   "discokey:4a64b1229c8193d34d75b57c6ef8a92a046b3f8583bff8ab4c81f8cc33da3702",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40027", "10.65.0.27:40027", "172.17.0.1:40027"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:48:18.485154344Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6256085505137799,
+				"StableID":   "n2aa8xkPrq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:730fe57492bbef73bbd99c1c20b705bf5e6604b9498953c88e10d72fb6ae3436",
+				"DiscoKey":   "discokey:a97e50b5b70013b33b81c56da91b00c679478fd78342df4ccc9149080cfc8e18",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:56164", "10.65.0.27:56164", "172.17.0.1:56164"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:48:18.986397212Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8837949965143678,
+				"StableID":   "n1LMHdxi1C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8067c69167d16349c8f0ea52b108239efc72244bf1467c6074388280c99feb41",
+				"KeyExpiry":  "2026-10-26T10:48:21Z",
+				"DiscoKey":   "discokey:14666bbe2a3c806a58942a6202130c6333d81b3f9c59cacba7c2d11b0ef90153",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59393", "10.65.0.27:59393", "172.17.0.1:59393"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:48:21.569145384Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         883749285244521,
+				"StableID":   "nvTd5XbFu711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:118db550352aca2c0bfa41184895312ed2f04d53240a7f94e61cd5c2d91b4243",
+				"KeyExpiry":  "2026-10-26T10:48:22Z",
+				"DiscoKey":   "discokey:831e49b971fc3bba8304e9a3ef4e33982e8430d9011bfd6308e09087169fd573",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:32929", "10.65.0.27:32929", "172.17.0.1:32929"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:48:22.090438386Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2014139748150863,
+				"StableID":   "nSCuS53DjG11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       2014139748150863,
+				"Key":        "nodekey:cda12ef231617fe52fdca865297428d94aedf79c20d1032596e0f57f2c107e3c",
+				"DiscoKey":   "discokey:4a64b1229c8193d34d75b57c6ef8a92a046b3f8583bff8ab4c81f8cc33da3702",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40027", "10.65.0.27:40027", "172.17.0.1:40027"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:48:18.485154344Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cda12ef231617fe52fdca865297428d94aedf79c20d1032596e0f57f2c107e3c",
+			"MachineKey": "mkey:393e3932f1a47abc7f69848ea6eeeef1ba0fffedcd9715842f569976baa42c28",
+			"Peers": [{
+				"ID":         4134352601998007,
+				"StableID":   "nkPm15STHZ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d21aad6c76aa84bc2f4f15f810f77716e9c8a9ef3dc0f28b38d5a7bf7a3a520",
+				"DiscoKey":   "discokey:9e8da7ddad7bd6ce91ff97c295f08d39359725daae8443c168663cc62a552200",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46748", "10.65.0.27:46748", "172.17.0.1:46748"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:48:15.203988235Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2217086213883031,
+				"StableID":   "negcfX68KJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ffe03092e166f98b81d13030e63214cdb77eb7a39ab44ac495f728a9b288b06",
+				"DiscoKey":   "discokey:bcc8fd198a4f130171372dd17046854ba69a56ea3a93f0552d914b36644eb91f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56032", "10.65.0.27:56032", "172.17.0.1:56032"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:48:15.844651129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4020296473889876,
+				"StableID":   "nBgGYXNoPY11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e44b195c44da0d4b73f3eb0debc228d2f60824d302ff04dfba56f0199f03216",
+				"DiscoKey":   "discokey:1df649ee1919de95653f378f5c30eb9e6b2def7a78ee0a80e2f87bf9de4d9714",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:52157", "10.65.0.27:52157", "172.17.0.1:52157"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:48:17.728026064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6256085505137799,
+				"StableID":   "n2aa8xkPrq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:730fe57492bbef73bbd99c1c20b705bf5e6604b9498953c88e10d72fb6ae3436",
+				"DiscoKey":   "discokey:a97e50b5b70013b33b81c56da91b00c679478fd78342df4ccc9149080cfc8e18",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:56164", "10.65.0.27:56164", "172.17.0.1:56164"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:48:18.986397212Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2753892583947537,
+				"StableID":   "n8n7P86FWN11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1c011fcaae378f99b9006395bb01b9f59d5c0d0486dbaf2f9a6673f5dfaa4e22",
+				"KeyExpiry":  "2026-10-26T10:48:20Z",
+				"DiscoKey":   "discokey:4110f677b2eca162a05a69087ade28b62f4216d726bd65e1f165c24d6852dc61",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38470", "10.65.0.27:38470", "172.17.0.1:38470"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:48:20.947280604Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8837949965143678,
+				"StableID":   "n1LMHdxi1C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8067c69167d16349c8f0ea52b108239efc72244bf1467c6074388280c99feb41",
+				"KeyExpiry":  "2026-10-26T10:48:21Z",
+				"DiscoKey":   "discokey:14666bbe2a3c806a58942a6202130c6333d81b3f9c59cacba7c2d11b0ef90153",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59393", "10.65.0.27:59393", "172.17.0.1:59393"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:48:21.569145384Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         883749285244521,
+				"StableID":   "nvTd5XbFu711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:118db550352aca2c0bfa41184895312ed2f04d53240a7f94e61cd5c2d91b4243",
+				"KeyExpiry":  "2026-10-26T10:48:22Z",
+				"DiscoKey":   "discokey:831e49b971fc3bba8304e9a3ef4e33982e8430d9011bfd6308e09087169fd573",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:32929", "10.65.0.27:32929", "172.17.0.1:32929"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:48:22.090438386Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2014139748150863": {
+				"ID":          2014139748150863,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2217086213883031,
+				"StableID":   "negcfX68KJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       2217086213883031,
+				"Key":        "nodekey:2ffe03092e166f98b81d13030e63214cdb77eb7a39ab44ac495f728a9b288b06",
+				"DiscoKey":   "discokey:bcc8fd198a4f130171372dd17046854ba69a56ea3a93f0552d914b36644eb91f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56032", "10.65.0.27:56032", "172.17.0.1:56032"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:48:15.844651129Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2ffe03092e166f98b81d13030e63214cdb77eb7a39ab44ac495f728a9b288b06",
+			"MachineKey": "mkey:b2b802886fecd9ad92fa877927731aa65c534989263a78ff6871e90e9d6afb53",
+			"Peers": [{
+				"ID":         4134352601998007,
+				"StableID":   "nkPm15STHZ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d21aad6c76aa84bc2f4f15f810f77716e9c8a9ef3dc0f28b38d5a7bf7a3a520",
+				"DiscoKey":   "discokey:9e8da7ddad7bd6ce91ff97c295f08d39359725daae8443c168663cc62a552200",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46748", "10.65.0.27:46748", "172.17.0.1:46748"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:48:15.203988235Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4020296473889876,
+				"StableID":   "nBgGYXNoPY11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e44b195c44da0d4b73f3eb0debc228d2f60824d302ff04dfba56f0199f03216",
+				"DiscoKey":   "discokey:1df649ee1919de95653f378f5c30eb9e6b2def7a78ee0a80e2f87bf9de4d9714",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:52157", "10.65.0.27:52157", "172.17.0.1:52157"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:48:17.728026064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2014139748150863,
+				"StableID":   "nSCuS53DjG11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cda12ef231617fe52fdca865297428d94aedf79c20d1032596e0f57f2c107e3c",
+				"DiscoKey":   "discokey:4a64b1229c8193d34d75b57c6ef8a92a046b3f8583bff8ab4c81f8cc33da3702",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40027", "10.65.0.27:40027", "172.17.0.1:40027"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:48:18.485154344Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6256085505137799,
+				"StableID":   "n2aa8xkPrq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:730fe57492bbef73bbd99c1c20b705bf5e6604b9498953c88e10d72fb6ae3436",
+				"DiscoKey":   "discokey:a97e50b5b70013b33b81c56da91b00c679478fd78342df4ccc9149080cfc8e18",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:56164", "10.65.0.27:56164", "172.17.0.1:56164"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:48:18.986397212Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2753892583947537,
+				"StableID":   "n8n7P86FWN11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1c011fcaae378f99b9006395bb01b9f59d5c0d0486dbaf2f9a6673f5dfaa4e22",
+				"KeyExpiry":  "2026-10-26T10:48:20Z",
+				"DiscoKey":   "discokey:4110f677b2eca162a05a69087ade28b62f4216d726bd65e1f165c24d6852dc61",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38470", "10.65.0.27:38470", "172.17.0.1:38470"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:48:20.947280604Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8837949965143678,
+				"StableID":   "n1LMHdxi1C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8067c69167d16349c8f0ea52b108239efc72244bf1467c6074388280c99feb41",
+				"KeyExpiry":  "2026-10-26T10:48:21Z",
+				"DiscoKey":   "discokey:14666bbe2a3c806a58942a6202130c6333d81b3f9c59cacba7c2d11b0ef90153",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59393", "10.65.0.27:59393", "172.17.0.1:59393"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:48:21.569145384Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         883749285244521,
+				"StableID":   "nvTd5XbFu711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:118db550352aca2c0bfa41184895312ed2f04d53240a7f94e61cd5c2d91b4243",
+				"KeyExpiry":  "2026-10-26T10:48:22Z",
+				"DiscoKey":   "discokey:831e49b971fc3bba8304e9a3ef4e33982e8430d9011bfd6308e09087169fd573",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:32929", "10.65.0.27:32929", "172.17.0.1:32929"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:48:22.090438386Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2217086213883031": {
+				"ID":          2217086213883031,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8837949965143678,
+				"StableID":   "n1LMHdxi1C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8067c69167d16349c8f0ea52b108239efc72244bf1467c6074388280c99feb41",
+				"KeyExpiry":  "2026-10-26T10:48:21Z",
+				"DiscoKey":   "discokey:14666bbe2a3c806a58942a6202130c6333d81b3f9c59cacba7c2d11b0ef90153",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59393", "10.65.0.27:59393", "172.17.0.1:59393"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:48:21.569145384Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8067c69167d16349c8f0ea52b108239efc72244bf1467c6074388280c99feb41",
+			"MachineKey": "mkey:3111bdc61bba10d219f6d7fb1ef3c9729b9ebe0d2e36f7ae87e12ed9923d4725",
+			"Peers": [{
+				"ID":         4134352601998007,
+				"StableID":   "nkPm15STHZ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d21aad6c76aa84bc2f4f15f810f77716e9c8a9ef3dc0f28b38d5a7bf7a3a520",
+				"DiscoKey":   "discokey:9e8da7ddad7bd6ce91ff97c295f08d39359725daae8443c168663cc62a552200",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46748", "10.65.0.27:46748", "172.17.0.1:46748"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:48:15.203988235Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2217086213883031,
+				"StableID":   "negcfX68KJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ffe03092e166f98b81d13030e63214cdb77eb7a39ab44ac495f728a9b288b06",
+				"DiscoKey":   "discokey:bcc8fd198a4f130171372dd17046854ba69a56ea3a93f0552d914b36644eb91f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56032", "10.65.0.27:56032", "172.17.0.1:56032"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:48:15.844651129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4020296473889876,
+				"StableID":   "nBgGYXNoPY11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e44b195c44da0d4b73f3eb0debc228d2f60824d302ff04dfba56f0199f03216",
+				"DiscoKey":   "discokey:1df649ee1919de95653f378f5c30eb9e6b2def7a78ee0a80e2f87bf9de4d9714",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:52157", "10.65.0.27:52157", "172.17.0.1:52157"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:48:17.728026064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2014139748150863,
+				"StableID":   "nSCuS53DjG11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cda12ef231617fe52fdca865297428d94aedf79c20d1032596e0f57f2c107e3c",
+				"DiscoKey":   "discokey:4a64b1229c8193d34d75b57c6ef8a92a046b3f8583bff8ab4c81f8cc33da3702",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40027", "10.65.0.27:40027", "172.17.0.1:40027"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:48:18.485154344Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6256085505137799,
+				"StableID":   "n2aa8xkPrq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:730fe57492bbef73bbd99c1c20b705bf5e6604b9498953c88e10d72fb6ae3436",
+				"DiscoKey":   "discokey:a97e50b5b70013b33b81c56da91b00c679478fd78342df4ccc9149080cfc8e18",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:56164", "10.65.0.27:56164", "172.17.0.1:56164"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:48:18.986397212Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2753892583947537,
+				"StableID":   "n8n7P86FWN11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1c011fcaae378f99b9006395bb01b9f59d5c0d0486dbaf2f9a6673f5dfaa4e22",
+				"KeyExpiry":  "2026-10-26T10:48:20Z",
+				"DiscoKey":   "discokey:4110f677b2eca162a05a69087ade28b62f4216d726bd65e1f165c24d6852dc61",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38470", "10.65.0.27:38470", "172.17.0.1:38470"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:48:20.947280604Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         883749285244521,
+				"StableID":   "nvTd5XbFu711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:118db550352aca2c0bfa41184895312ed2f04d53240a7f94e61cd5c2d91b4243",
+				"KeyExpiry":  "2026-10-26T10:48:22Z",
+				"DiscoKey":   "discokey:831e49b971fc3bba8304e9a3ef4e33982e8430d9011bfd6308e09087169fd573",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:32929", "10.65.0.27:32929", "172.17.0.1:32929"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:48:22.090438386Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4020296473889876,
+				"StableID":   "nBgGYXNoPY11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       4020296473889876,
+				"Key":        "nodekey:2e44b195c44da0d4b73f3eb0debc228d2f60824d302ff04dfba56f0199f03216",
+				"DiscoKey":   "discokey:1df649ee1919de95653f378f5c30eb9e6b2def7a78ee0a80e2f87bf9de4d9714",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:52157", "10.65.0.27:52157", "172.17.0.1:52157"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:48:17.728026064Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2e44b195c44da0d4b73f3eb0debc228d2f60824d302ff04dfba56f0199f03216",
+			"MachineKey": "mkey:665918b39fbb80a057c0aafa920cac51b11f38b7936a194bd10531fa4d491b28",
+			"Peers": [{
+				"ID":         4134352601998007,
+				"StableID":   "nkPm15STHZ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d21aad6c76aa84bc2f4f15f810f77716e9c8a9ef3dc0f28b38d5a7bf7a3a520",
+				"DiscoKey":   "discokey:9e8da7ddad7bd6ce91ff97c295f08d39359725daae8443c168663cc62a552200",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46748", "10.65.0.27:46748", "172.17.0.1:46748"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:48:15.203988235Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2217086213883031,
+				"StableID":   "negcfX68KJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ffe03092e166f98b81d13030e63214cdb77eb7a39ab44ac495f728a9b288b06",
+				"DiscoKey":   "discokey:bcc8fd198a4f130171372dd17046854ba69a56ea3a93f0552d914b36644eb91f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:56032", "10.65.0.27:56032", "172.17.0.1:56032"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:48:15.844651129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2014139748150863,
+				"StableID":   "nSCuS53DjG11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cda12ef231617fe52fdca865297428d94aedf79c20d1032596e0f57f2c107e3c",
+				"DiscoKey":   "discokey:4a64b1229c8193d34d75b57c6ef8a92a046b3f8583bff8ab4c81f8cc33da3702",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40027", "10.65.0.27:40027", "172.17.0.1:40027"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:48:18.485154344Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6256085505137799,
+				"StableID":   "n2aa8xkPrq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:730fe57492bbef73bbd99c1c20b705bf5e6604b9498953c88e10d72fb6ae3436",
+				"DiscoKey":   "discokey:a97e50b5b70013b33b81c56da91b00c679478fd78342df4ccc9149080cfc8e18",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:56164", "10.65.0.27:56164", "172.17.0.1:56164"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:48:18.986397212Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2753892583947537,
+				"StableID":   "n8n7P86FWN11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1c011fcaae378f99b9006395bb01b9f59d5c0d0486dbaf2f9a6673f5dfaa4e22",
+				"KeyExpiry":  "2026-10-26T10:48:20Z",
+				"DiscoKey":   "discokey:4110f677b2eca162a05a69087ade28b62f4216d726bd65e1f165c24d6852dc61",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38470", "10.65.0.27:38470", "172.17.0.1:38470"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:48:20.947280604Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8837949965143678,
+				"StableID":   "n1LMHdxi1C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8067c69167d16349c8f0ea52b108239efc72244bf1467c6074388280c99feb41",
+				"KeyExpiry":  "2026-10-26T10:48:21Z",
+				"DiscoKey":   "discokey:14666bbe2a3c806a58942a6202130c6333d81b3f9c59cacba7c2d11b0ef90153",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:59393", "10.65.0.27:59393", "172.17.0.1:59393"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:48:21.569145384Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         883749285244521,
+				"StableID":   "nvTd5XbFu711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:118db550352aca2c0bfa41184895312ed2f04d53240a7f94e61cd5c2d91b4243",
+				"KeyExpiry":  "2026-10-26T10:48:22Z",
+				"DiscoKey":   "discokey:831e49b971fc3bba8304e9a3ef4e33982e8430d9011bfd6308e09087169fd573",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:32929", "10.65.0.27:32929", "172.17.0.1:32929"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:48:22.090438386Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4020296473889876": {
+				"ID":          4020296473889876,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-dst-unknown-autogroup-internet-non-exit.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-dst-unknown-autogroup-internet-non-exit.hujson
@@ -1,0 +1,8839 @@
+// policytest-dst-unknown-autogroup-internet-non-exit
+//
+// tests block dst-unknown: autogroup:internet dst with non-wildcard port
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:48:43Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-dst-unknown-autogroup-internet-non-exit",
+	"description":    "tests block dst-unknown: autogroup:internet dst with non-wildcard port",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:48:43.93495013Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                     \n  \n                                                                         \n                                                                     \n{\n\t\"id\":          \"policytest-dst-unknown-autogroup-internet-non-exit\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block dst-unknown: autogroup:internet dst with non-wildcard port\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"tag:client\"], \"dst\": [\"autogroup:internet:*\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"tag:client\", \"accept\": [\"autogroup:internet:443\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-dst-unknown-autogroup-internet-non-exit.hujson",
+		"full_policy": {
+			"acls": [{
+				"action": "accept",
+				"dst":    ["autogroup:internet:*"],
+				"src":    ["tag:client"]
+			}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["autogroup:internet:443"], "src": "tag:client"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8618900626808382,
+				"StableID":   "n7bSMTuWJA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       8618900626808382,
+				"Key":        "nodekey:373ffc59db03ceb50783eab8c9e4d81e3d0ee3acb136420b41f273f7d5681600",
+				"DiscoKey":   "discokey:47fdbeb8243cbc5e5a2e56b8589c6c087b820b049b9264b27c1326a3e0749f50",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45966", "10.65.0.27:45966", "172.17.0.1:45966"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:48:47.852757924Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:373ffc59db03ceb50783eab8c9e4d81e3d0ee3acb136420b41f273f7d5681600",
+			"MachineKey": "mkey:5798aa40b545d110a09db37bcebc885778dab8b6e0d702cdb884e799d931612e",
+			"Peers": [{
+				"ID":         270707228932004,
+				"StableID":   "n3Gzp92c7311CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f128329cb13212785e3bcba05925ed534e34f1470dda25ef5075fb572a08e948",
+				"DiscoKey":   "discokey:1715aa193935481b693c143f0b4f9b08a40045410d2bb14d6e048d1eb240594f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46077", "10.65.0.27:46077", "172.17.0.1:46077"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:48:45.602442975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4342606674238656,
+				"StableID":   "njcBFzumua11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea26e145d6422a5330edc06d9d2fb9a934aa3913c21e6a9899da8d68fc35c0e",
+				"DiscoKey":   "discokey:313c0b46220ada3063d0da103334473d8ebbd5f9b4f8ff51f1c3a5f225766953",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58144", "10.65.0.27:58144", "172.17.0.1:58144"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:48:46.239991286Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5241017615229459,
+				"StableID":   "nz2udSefvh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5e28afe2fb82b1b5f57c6d4e41a36042d12e5c016925f315e3bbfcee6e41ff50",
+				"DiscoKey":   "discokey:43dd04a9d34fd18fca159eade3d415cf43c46456351f0f35e41a1560b0e49577",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:55227", "10.65.0.27:55227", "172.17.0.1:55227"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:48:46.754303841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1049312355666810,
+				"StableID":   "nwFof4fEC911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc53728607827afc2be28aa484caaa04575170d0fdabafc0ebafa8aeb672a305",
+				"DiscoKey":   "discokey:a17598314b2fbde477bf333119fbad8afe8cd24a50ec8cbe099959dee29b150d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:48:47.317747825Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8966004683536010,
+				"StableID":   "nby7Ftji1D21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d39bb162e947912611441512f0c6b232e20356c9275d778a6e08ee97999cd3e",
+				"KeyExpiry":  "2026-10-26T10:48:48Z",
+				"DiscoKey":   "discokey:096db25c741770c94e6af6d7d4d443c376fa97f36459c8fb15eb0f8d02e72820",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51269", "10.65.0.27:51269", "172.17.0.1:51269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:48:48.369461548Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7606923754461916,
+				"StableID":   "nHmiVJzBQ221CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b195ac3af8195b0d3c1a3eb04c24957789021c2f4b66295769555e855e9ac421",
+				"KeyExpiry":  "2026-10-26T10:48:48Z",
+				"DiscoKey":   "discokey:5f0c0c7eb96afee2248b48ba8ba648d833392050d61fdd174564c9e4791b1614",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45318", "10.65.0.27:45318", "172.17.0.1:45318"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:48:48.943478556Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4776435348089182,
+				"StableID":   "nXMRairFJe11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:eb8351b9fe077cbd643804abbfa463274eaef53853fca5cd9d6989401762955c",
+				"KeyExpiry":  "2026-10-26T10:48:49Z",
+				"DiscoKey":   "discokey:e55eb259f6421ca179c60170e82ed26d599dc1f290136fc68f580ee672427a57",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50443", "10.65.0.27:50443", "172.17.0.1:50443"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:48:49.501395367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8618900626808382": {
+				"ID":          8618900626808382,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4776435348089182,
+				"StableID":   "nXMRairFJe11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:eb8351b9fe077cbd643804abbfa463274eaef53853fca5cd9d6989401762955c",
+				"KeyExpiry":  "2026-10-26T10:48:49Z",
+				"DiscoKey":   "discokey:e55eb259f6421ca179c60170e82ed26d599dc1f290136fc68f580ee672427a57",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50443", "10.65.0.27:50443", "172.17.0.1:50443"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:48:49.501395367Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:eb8351b9fe077cbd643804abbfa463274eaef53853fca5cd9d6989401762955c",
+			"MachineKey": "mkey:c47b75d5d43188dfd75aae97ac4a569c7d2283ffcb28e61c4a405892f5e23369",
+			"Peers": [{
+				"ID":         270707228932004,
+				"StableID":   "n3Gzp92c7311CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f128329cb13212785e3bcba05925ed534e34f1470dda25ef5075fb572a08e948",
+				"DiscoKey":   "discokey:1715aa193935481b693c143f0b4f9b08a40045410d2bb14d6e048d1eb240594f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46077", "10.65.0.27:46077", "172.17.0.1:46077"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:48:45.602442975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4342606674238656,
+				"StableID":   "njcBFzumua11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea26e145d6422a5330edc06d9d2fb9a934aa3913c21e6a9899da8d68fc35c0e",
+				"DiscoKey":   "discokey:313c0b46220ada3063d0da103334473d8ebbd5f9b4f8ff51f1c3a5f225766953",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58144", "10.65.0.27:58144", "172.17.0.1:58144"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:48:46.239991286Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5241017615229459,
+				"StableID":   "nz2udSefvh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5e28afe2fb82b1b5f57c6d4e41a36042d12e5c016925f315e3bbfcee6e41ff50",
+				"DiscoKey":   "discokey:43dd04a9d34fd18fca159eade3d415cf43c46456351f0f35e41a1560b0e49577",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:55227", "10.65.0.27:55227", "172.17.0.1:55227"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:48:46.754303841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1049312355666810,
+				"StableID":   "nwFof4fEC911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc53728607827afc2be28aa484caaa04575170d0fdabafc0ebafa8aeb672a305",
+				"DiscoKey":   "discokey:a17598314b2fbde477bf333119fbad8afe8cd24a50ec8cbe099959dee29b150d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:48:47.317747825Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8618900626808382,
+				"StableID":   "n7bSMTuWJA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:373ffc59db03ceb50783eab8c9e4d81e3d0ee3acb136420b41f273f7d5681600",
+				"DiscoKey":   "discokey:47fdbeb8243cbc5e5a2e56b8589c6c087b820b049b9264b27c1326a3e0749f50",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45966", "10.65.0.27:45966", "172.17.0.1:45966"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:48:47.852757924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8966004683536010,
+				"StableID":   "nby7Ftji1D21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d39bb162e947912611441512f0c6b232e20356c9275d778a6e08ee97999cd3e",
+				"KeyExpiry":  "2026-10-26T10:48:48Z",
+				"DiscoKey":   "discokey:096db25c741770c94e6af6d7d4d443c376fa97f36459c8fb15eb0f8d02e72820",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51269", "10.65.0.27:51269", "172.17.0.1:51269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:48:48.369461548Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7606923754461916,
+				"StableID":   "nHmiVJzBQ221CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b195ac3af8195b0d3c1a3eb04c24957789021c2f4b66295769555e855e9ac421",
+				"KeyExpiry":  "2026-10-26T10:48:48Z",
+				"DiscoKey":   "discokey:5f0c0c7eb96afee2248b48ba8ba648d833392050d61fdd174564c9e4791b1614",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45318", "10.65.0.27:45318", "172.17.0.1:45318"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:48:48.943478556Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         270707228932004,
+				"StableID":   "n3Gzp92c7311CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       270707228932004,
+				"Key":        "nodekey:f128329cb13212785e3bcba05925ed534e34f1470dda25ef5075fb572a08e948",
+				"DiscoKey":   "discokey:1715aa193935481b693c143f0b4f9b08a40045410d2bb14d6e048d1eb240594f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46077", "10.65.0.27:46077", "172.17.0.1:46077"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:48:45.602442975Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f128329cb13212785e3bcba05925ed534e34f1470dda25ef5075fb572a08e948",
+			"MachineKey": "mkey:a64eebcd053cc5f00acd0e038ad855657fa7ad9750d6a3fed27a7174765eee3e",
+			"Peers": [{
+				"ID":         4342606674238656,
+				"StableID":   "njcBFzumua11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea26e145d6422a5330edc06d9d2fb9a934aa3913c21e6a9899da8d68fc35c0e",
+				"DiscoKey":   "discokey:313c0b46220ada3063d0da103334473d8ebbd5f9b4f8ff51f1c3a5f225766953",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58144", "10.65.0.27:58144", "172.17.0.1:58144"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:48:46.239991286Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5241017615229459,
+				"StableID":   "nz2udSefvh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5e28afe2fb82b1b5f57c6d4e41a36042d12e5c016925f315e3bbfcee6e41ff50",
+				"DiscoKey":   "discokey:43dd04a9d34fd18fca159eade3d415cf43c46456351f0f35e41a1560b0e49577",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:55227", "10.65.0.27:55227", "172.17.0.1:55227"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:48:46.754303841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1049312355666810,
+				"StableID":   "nwFof4fEC911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc53728607827afc2be28aa484caaa04575170d0fdabafc0ebafa8aeb672a305",
+				"DiscoKey":   "discokey:a17598314b2fbde477bf333119fbad8afe8cd24a50ec8cbe099959dee29b150d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:48:47.317747825Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8618900626808382,
+				"StableID":   "n7bSMTuWJA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:373ffc59db03ceb50783eab8c9e4d81e3d0ee3acb136420b41f273f7d5681600",
+				"DiscoKey":   "discokey:47fdbeb8243cbc5e5a2e56b8589c6c087b820b049b9264b27c1326a3e0749f50",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45966", "10.65.0.27:45966", "172.17.0.1:45966"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:48:47.852757924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8966004683536010,
+				"StableID":   "nby7Ftji1D21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d39bb162e947912611441512f0c6b232e20356c9275d778a6e08ee97999cd3e",
+				"KeyExpiry":  "2026-10-26T10:48:48Z",
+				"DiscoKey":   "discokey:096db25c741770c94e6af6d7d4d443c376fa97f36459c8fb15eb0f8d02e72820",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51269", "10.65.0.27:51269", "172.17.0.1:51269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:48:48.369461548Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7606923754461916,
+				"StableID":   "nHmiVJzBQ221CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b195ac3af8195b0d3c1a3eb04c24957789021c2f4b66295769555e855e9ac421",
+				"KeyExpiry":  "2026-10-26T10:48:48Z",
+				"DiscoKey":   "discokey:5f0c0c7eb96afee2248b48ba8ba648d833392050d61fdd174564c9e4791b1614",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45318", "10.65.0.27:45318", "172.17.0.1:45318"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:48:48.943478556Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4776435348089182,
+				"StableID":   "nXMRairFJe11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:eb8351b9fe077cbd643804abbfa463274eaef53853fca5cd9d6989401762955c",
+				"KeyExpiry":  "2026-10-26T10:48:49Z",
+				"DiscoKey":   "discokey:e55eb259f6421ca179c60170e82ed26d599dc1f290136fc68f580ee672427a57",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50443", "10.65.0.27:50443", "172.17.0.1:50443"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:48:49.501395367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "270707228932004": {
+				"ID":          270707228932004,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8966004683536010,
+				"StableID":   "nby7Ftji1D21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d39bb162e947912611441512f0c6b232e20356c9275d778a6e08ee97999cd3e",
+				"KeyExpiry":  "2026-10-26T10:48:48Z",
+				"DiscoKey":   "discokey:096db25c741770c94e6af6d7d4d443c376fa97f36459c8fb15eb0f8d02e72820",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51269", "10.65.0.27:51269", "172.17.0.1:51269"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:48:48.369461548Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9d39bb162e947912611441512f0c6b232e20356c9275d778a6e08ee97999cd3e",
+			"MachineKey": "mkey:5b8f0e00a990ef7ec4df254c70cb432ad8b6a599aa6ef217be856052856ecb15",
+			"Peers": [{
+				"ID":         270707228932004,
+				"StableID":   "n3Gzp92c7311CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f128329cb13212785e3bcba05925ed534e34f1470dda25ef5075fb572a08e948",
+				"DiscoKey":   "discokey:1715aa193935481b693c143f0b4f9b08a40045410d2bb14d6e048d1eb240594f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46077", "10.65.0.27:46077", "172.17.0.1:46077"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:48:45.602442975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4342606674238656,
+				"StableID":   "njcBFzumua11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea26e145d6422a5330edc06d9d2fb9a934aa3913c21e6a9899da8d68fc35c0e",
+				"DiscoKey":   "discokey:313c0b46220ada3063d0da103334473d8ebbd5f9b4f8ff51f1c3a5f225766953",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58144", "10.65.0.27:58144", "172.17.0.1:58144"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:48:46.239991286Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5241017615229459,
+				"StableID":   "nz2udSefvh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5e28afe2fb82b1b5f57c6d4e41a36042d12e5c016925f315e3bbfcee6e41ff50",
+				"DiscoKey":   "discokey:43dd04a9d34fd18fca159eade3d415cf43c46456351f0f35e41a1560b0e49577",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:55227", "10.65.0.27:55227", "172.17.0.1:55227"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:48:46.754303841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1049312355666810,
+				"StableID":   "nwFof4fEC911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc53728607827afc2be28aa484caaa04575170d0fdabafc0ebafa8aeb672a305",
+				"DiscoKey":   "discokey:a17598314b2fbde477bf333119fbad8afe8cd24a50ec8cbe099959dee29b150d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:48:47.317747825Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8618900626808382,
+				"StableID":   "n7bSMTuWJA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:373ffc59db03ceb50783eab8c9e4d81e3d0ee3acb136420b41f273f7d5681600",
+				"DiscoKey":   "discokey:47fdbeb8243cbc5e5a2e56b8589c6c087b820b049b9264b27c1326a3e0749f50",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45966", "10.65.0.27:45966", "172.17.0.1:45966"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:48:47.852757924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7606923754461916,
+				"StableID":   "nHmiVJzBQ221CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b195ac3af8195b0d3c1a3eb04c24957789021c2f4b66295769555e855e9ac421",
+				"KeyExpiry":  "2026-10-26T10:48:48Z",
+				"DiscoKey":   "discokey:5f0c0c7eb96afee2248b48ba8ba648d833392050d61fdd174564c9e4791b1614",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45318", "10.65.0.27:45318", "172.17.0.1:45318"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:48:48.943478556Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4776435348089182,
+				"StableID":   "nXMRairFJe11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:eb8351b9fe077cbd643804abbfa463274eaef53853fca5cd9d6989401762955c",
+				"KeyExpiry":  "2026-10-26T10:48:49Z",
+				"DiscoKey":   "discokey:e55eb259f6421ca179c60170e82ed26d599dc1f290136fc68f580ee672427a57",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50443", "10.65.0.27:50443", "172.17.0.1:50443"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:48:49.501395367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1049312355666810,
+				"StableID":   "nwFof4fEC911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1049312355666810,
+				"Key":        "nodekey:fc53728607827afc2be28aa484caaa04575170d0fdabafc0ebafa8aeb672a305",
+				"DiscoKey":   "discokey:a17598314b2fbde477bf333119fbad8afe8cd24a50ec8cbe099959dee29b150d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:48:47.317747825Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fc53728607827afc2be28aa484caaa04575170d0fdabafc0ebafa8aeb672a305",
+			"MachineKey": "mkey:d6a63e76167489c83aafbef2e29dee0e3945e0f6b17483483399366d6cb7744b",
+			"Peers": [{
+				"ID":         270707228932004,
+				"StableID":   "n3Gzp92c7311CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f128329cb13212785e3bcba05925ed534e34f1470dda25ef5075fb572a08e948",
+				"DiscoKey":   "discokey:1715aa193935481b693c143f0b4f9b08a40045410d2bb14d6e048d1eb240594f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46077", "10.65.0.27:46077", "172.17.0.1:46077"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:48:45.602442975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4342606674238656,
+				"StableID":   "njcBFzumua11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea26e145d6422a5330edc06d9d2fb9a934aa3913c21e6a9899da8d68fc35c0e",
+				"DiscoKey":   "discokey:313c0b46220ada3063d0da103334473d8ebbd5f9b4f8ff51f1c3a5f225766953",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58144", "10.65.0.27:58144", "172.17.0.1:58144"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:48:46.239991286Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5241017615229459,
+				"StableID":   "nz2udSefvh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5e28afe2fb82b1b5f57c6d4e41a36042d12e5c016925f315e3bbfcee6e41ff50",
+				"DiscoKey":   "discokey:43dd04a9d34fd18fca159eade3d415cf43c46456351f0f35e41a1560b0e49577",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:55227", "10.65.0.27:55227", "172.17.0.1:55227"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:48:46.754303841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8618900626808382,
+				"StableID":   "n7bSMTuWJA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:373ffc59db03ceb50783eab8c9e4d81e3d0ee3acb136420b41f273f7d5681600",
+				"DiscoKey":   "discokey:47fdbeb8243cbc5e5a2e56b8589c6c087b820b049b9264b27c1326a3e0749f50",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45966", "10.65.0.27:45966", "172.17.0.1:45966"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:48:47.852757924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8966004683536010,
+				"StableID":   "nby7Ftji1D21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d39bb162e947912611441512f0c6b232e20356c9275d778a6e08ee97999cd3e",
+				"KeyExpiry":  "2026-10-26T10:48:48Z",
+				"DiscoKey":   "discokey:096db25c741770c94e6af6d7d4d443c376fa97f36459c8fb15eb0f8d02e72820",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51269", "10.65.0.27:51269", "172.17.0.1:51269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:48:48.369461548Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7606923754461916,
+				"StableID":   "nHmiVJzBQ221CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b195ac3af8195b0d3c1a3eb04c24957789021c2f4b66295769555e855e9ac421",
+				"KeyExpiry":  "2026-10-26T10:48:48Z",
+				"DiscoKey":   "discokey:5f0c0c7eb96afee2248b48ba8ba648d833392050d61fdd174564c9e4791b1614",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45318", "10.65.0.27:45318", "172.17.0.1:45318"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:48:48.943478556Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4776435348089182,
+				"StableID":   "nXMRairFJe11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:eb8351b9fe077cbd643804abbfa463274eaef53853fca5cd9d6989401762955c",
+				"KeyExpiry":  "2026-10-26T10:48:49Z",
+				"DiscoKey":   "discokey:e55eb259f6421ca179c60170e82ed26d599dc1f290136fc68f580ee672427a57",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50443", "10.65.0.27:50443", "172.17.0.1:50443"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:48:49.501395367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1049312355666810": {
+				"ID":          1049312355666810,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4342606674238656,
+				"StableID":   "njcBFzumua11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       4342606674238656,
+				"Key":        "nodekey:eea26e145d6422a5330edc06d9d2fb9a934aa3913c21e6a9899da8d68fc35c0e",
+				"DiscoKey":   "discokey:313c0b46220ada3063d0da103334473d8ebbd5f9b4f8ff51f1c3a5f225766953",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58144", "10.65.0.27:58144", "172.17.0.1:58144"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:48:46.239991286Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:eea26e145d6422a5330edc06d9d2fb9a934aa3913c21e6a9899da8d68fc35c0e",
+			"MachineKey": "mkey:e847b93b0c342b19ab2461018445c52aa00601139c2bd11160174295054be967",
+			"Peers": [{
+				"ID":         270707228932004,
+				"StableID":   "n3Gzp92c7311CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f128329cb13212785e3bcba05925ed534e34f1470dda25ef5075fb572a08e948",
+				"DiscoKey":   "discokey:1715aa193935481b693c143f0b4f9b08a40045410d2bb14d6e048d1eb240594f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46077", "10.65.0.27:46077", "172.17.0.1:46077"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:48:45.602442975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5241017615229459,
+				"StableID":   "nz2udSefvh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5e28afe2fb82b1b5f57c6d4e41a36042d12e5c016925f315e3bbfcee6e41ff50",
+				"DiscoKey":   "discokey:43dd04a9d34fd18fca159eade3d415cf43c46456351f0f35e41a1560b0e49577",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:55227", "10.65.0.27:55227", "172.17.0.1:55227"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:48:46.754303841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1049312355666810,
+				"StableID":   "nwFof4fEC911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc53728607827afc2be28aa484caaa04575170d0fdabafc0ebafa8aeb672a305",
+				"DiscoKey":   "discokey:a17598314b2fbde477bf333119fbad8afe8cd24a50ec8cbe099959dee29b150d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:48:47.317747825Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8618900626808382,
+				"StableID":   "n7bSMTuWJA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:373ffc59db03ceb50783eab8c9e4d81e3d0ee3acb136420b41f273f7d5681600",
+				"DiscoKey":   "discokey:47fdbeb8243cbc5e5a2e56b8589c6c087b820b049b9264b27c1326a3e0749f50",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45966", "10.65.0.27:45966", "172.17.0.1:45966"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:48:47.852757924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8966004683536010,
+				"StableID":   "nby7Ftji1D21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d39bb162e947912611441512f0c6b232e20356c9275d778a6e08ee97999cd3e",
+				"KeyExpiry":  "2026-10-26T10:48:48Z",
+				"DiscoKey":   "discokey:096db25c741770c94e6af6d7d4d443c376fa97f36459c8fb15eb0f8d02e72820",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51269", "10.65.0.27:51269", "172.17.0.1:51269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:48:48.369461548Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7606923754461916,
+				"StableID":   "nHmiVJzBQ221CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b195ac3af8195b0d3c1a3eb04c24957789021c2f4b66295769555e855e9ac421",
+				"KeyExpiry":  "2026-10-26T10:48:48Z",
+				"DiscoKey":   "discokey:5f0c0c7eb96afee2248b48ba8ba648d833392050d61fdd174564c9e4791b1614",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45318", "10.65.0.27:45318", "172.17.0.1:45318"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:48:48.943478556Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4776435348089182,
+				"StableID":   "nXMRairFJe11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:eb8351b9fe077cbd643804abbfa463274eaef53853fca5cd9d6989401762955c",
+				"KeyExpiry":  "2026-10-26T10:48:49Z",
+				"DiscoKey":   "discokey:e55eb259f6421ca179c60170e82ed26d599dc1f290136fc68f580ee672427a57",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50443", "10.65.0.27:50443", "172.17.0.1:50443"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:48:49.501395367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4342606674238656": {
+				"ID":          4342606674238656,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7606923754461916,
+				"StableID":   "nHmiVJzBQ221CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b195ac3af8195b0d3c1a3eb04c24957789021c2f4b66295769555e855e9ac421",
+				"KeyExpiry":  "2026-10-26T10:48:48Z",
+				"DiscoKey":   "discokey:5f0c0c7eb96afee2248b48ba8ba648d833392050d61fdd174564c9e4791b1614",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45318", "10.65.0.27:45318", "172.17.0.1:45318"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:48:48.943478556Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b195ac3af8195b0d3c1a3eb04c24957789021c2f4b66295769555e855e9ac421",
+			"MachineKey": "mkey:e274d47e9604cc8f84e85d511c7598ea391d8ec73ef46881e22db448d2577555",
+			"Peers": [{
+				"ID":         270707228932004,
+				"StableID":   "n3Gzp92c7311CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f128329cb13212785e3bcba05925ed534e34f1470dda25ef5075fb572a08e948",
+				"DiscoKey":   "discokey:1715aa193935481b693c143f0b4f9b08a40045410d2bb14d6e048d1eb240594f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46077", "10.65.0.27:46077", "172.17.0.1:46077"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:48:45.602442975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4342606674238656,
+				"StableID":   "njcBFzumua11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea26e145d6422a5330edc06d9d2fb9a934aa3913c21e6a9899da8d68fc35c0e",
+				"DiscoKey":   "discokey:313c0b46220ada3063d0da103334473d8ebbd5f9b4f8ff51f1c3a5f225766953",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58144", "10.65.0.27:58144", "172.17.0.1:58144"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:48:46.239991286Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5241017615229459,
+				"StableID":   "nz2udSefvh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5e28afe2fb82b1b5f57c6d4e41a36042d12e5c016925f315e3bbfcee6e41ff50",
+				"DiscoKey":   "discokey:43dd04a9d34fd18fca159eade3d415cf43c46456351f0f35e41a1560b0e49577",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:55227", "10.65.0.27:55227", "172.17.0.1:55227"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:48:46.754303841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1049312355666810,
+				"StableID":   "nwFof4fEC911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc53728607827afc2be28aa484caaa04575170d0fdabafc0ebafa8aeb672a305",
+				"DiscoKey":   "discokey:a17598314b2fbde477bf333119fbad8afe8cd24a50ec8cbe099959dee29b150d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:48:47.317747825Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8618900626808382,
+				"StableID":   "n7bSMTuWJA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:373ffc59db03ceb50783eab8c9e4d81e3d0ee3acb136420b41f273f7d5681600",
+				"DiscoKey":   "discokey:47fdbeb8243cbc5e5a2e56b8589c6c087b820b049b9264b27c1326a3e0749f50",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45966", "10.65.0.27:45966", "172.17.0.1:45966"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:48:47.852757924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8966004683536010,
+				"StableID":   "nby7Ftji1D21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d39bb162e947912611441512f0c6b232e20356c9275d778a6e08ee97999cd3e",
+				"KeyExpiry":  "2026-10-26T10:48:48Z",
+				"DiscoKey":   "discokey:096db25c741770c94e6af6d7d4d443c376fa97f36459c8fb15eb0f8d02e72820",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51269", "10.65.0.27:51269", "172.17.0.1:51269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:48:48.369461548Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4776435348089182,
+				"StableID":   "nXMRairFJe11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:eb8351b9fe077cbd643804abbfa463274eaef53853fca5cd9d6989401762955c",
+				"KeyExpiry":  "2026-10-26T10:48:49Z",
+				"DiscoKey":   "discokey:e55eb259f6421ca179c60170e82ed26d599dc1f290136fc68f580ee672427a57",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50443", "10.65.0.27:50443", "172.17.0.1:50443"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:48:49.501395367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5241017615229459,
+				"StableID":   "nz2udSefvh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       5241017615229459,
+				"Key":        "nodekey:5e28afe2fb82b1b5f57c6d4e41a36042d12e5c016925f315e3bbfcee6e41ff50",
+				"DiscoKey":   "discokey:43dd04a9d34fd18fca159eade3d415cf43c46456351f0f35e41a1560b0e49577",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:55227", "10.65.0.27:55227", "172.17.0.1:55227"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:48:46.754303841Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5e28afe2fb82b1b5f57c6d4e41a36042d12e5c016925f315e3bbfcee6e41ff50",
+			"MachineKey": "mkey:d1f03862a7b3aa5f4756592dcb8589ff0f6d74f40347f9fa251e528d8e06a212",
+			"Peers": [{
+				"ID":         270707228932004,
+				"StableID":   "n3Gzp92c7311CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f128329cb13212785e3bcba05925ed534e34f1470dda25ef5075fb572a08e948",
+				"DiscoKey":   "discokey:1715aa193935481b693c143f0b4f9b08a40045410d2bb14d6e048d1eb240594f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46077", "10.65.0.27:46077", "172.17.0.1:46077"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:48:45.602442975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4342606674238656,
+				"StableID":   "njcBFzumua11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea26e145d6422a5330edc06d9d2fb9a934aa3913c21e6a9899da8d68fc35c0e",
+				"DiscoKey":   "discokey:313c0b46220ada3063d0da103334473d8ebbd5f9b4f8ff51f1c3a5f225766953",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58144", "10.65.0.27:58144", "172.17.0.1:58144"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:48:46.239991286Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1049312355666810,
+				"StableID":   "nwFof4fEC911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc53728607827afc2be28aa484caaa04575170d0fdabafc0ebafa8aeb672a305",
+				"DiscoKey":   "discokey:a17598314b2fbde477bf333119fbad8afe8cd24a50ec8cbe099959dee29b150d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:48:47.317747825Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8618900626808382,
+				"StableID":   "n7bSMTuWJA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:373ffc59db03ceb50783eab8c9e4d81e3d0ee3acb136420b41f273f7d5681600",
+				"DiscoKey":   "discokey:47fdbeb8243cbc5e5a2e56b8589c6c087b820b049b9264b27c1326a3e0749f50",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45966", "10.65.0.27:45966", "172.17.0.1:45966"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:48:47.852757924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8966004683536010,
+				"StableID":   "nby7Ftji1D21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d39bb162e947912611441512f0c6b232e20356c9275d778a6e08ee97999cd3e",
+				"KeyExpiry":  "2026-10-26T10:48:48Z",
+				"DiscoKey":   "discokey:096db25c741770c94e6af6d7d4d443c376fa97f36459c8fb15eb0f8d02e72820",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51269", "10.65.0.27:51269", "172.17.0.1:51269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:48:48.369461548Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7606923754461916,
+				"StableID":   "nHmiVJzBQ221CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b195ac3af8195b0d3c1a3eb04c24957789021c2f4b66295769555e855e9ac421",
+				"KeyExpiry":  "2026-10-26T10:48:48Z",
+				"DiscoKey":   "discokey:5f0c0c7eb96afee2248b48ba8ba648d833392050d61fdd174564c9e4791b1614",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45318", "10.65.0.27:45318", "172.17.0.1:45318"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:48:48.943478556Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4776435348089182,
+				"StableID":   "nXMRairFJe11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:eb8351b9fe077cbd643804abbfa463274eaef53853fca5cd9d6989401762955c",
+				"KeyExpiry":  "2026-10-26T10:48:49Z",
+				"DiscoKey":   "discokey:e55eb259f6421ca179c60170e82ed26d599dc1f290136fc68f580ee672427a57",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50443", "10.65.0.27:50443", "172.17.0.1:50443"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:48:49.501395367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5241017615229459": {
+				"ID":          5241017615229459,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-dst-unknown-autogroup-self-with-tag-src.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-dst-unknown-autogroup-self-with-tag-src.hujson
@@ -1,0 +1,8843 @@
+// policytest-dst-unknown-autogroup-self-with-tag-src
+//
+// tests block dst-unknown: autogroup:self dst paired with tag src
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:49:11Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-dst-unknown-autogroup-self-with-tag-src",
+	"description":    "tests block dst-unknown: autogroup:self dst paired with tag src",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:49:11.251620197Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                     \n  \n                                                                 \n                                                                      \n{\n\t\"id\":          \"policytest-dst-unknown-autogroup-self-with-tag-src\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block dst-unknown: autogroup:self dst paired with tag src\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"tag:client\"], \"dst\": [\"webserver:80\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"tag:client\", \"accept\": [\"autogroup:self:22\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-dst-unknown-autogroup-self-with-tag-src.hujson",
+		"full_policy": {
+			"acls": [{"action": "accept", "dst": ["webserver:80"], "src": ["tag:client"]}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["autogroup:self:22"], "src": "tag:client"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2009225751901329,
+				"StableID":   "ncGfRJxygG11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       2009225751901329,
+				"Key":        "nodekey:3542e51455d0708e6e81d5e88331c0c19ea2500a09cbf005d9c088517d05eb63",
+				"DiscoKey":   "discokey:48b96c95a9e8b3904c18862c5a7919eeaf742938683c113c6afc85478be0c126",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45495", "10.65.0.27:45495", "172.17.0.1:45495"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:49:25.301006848Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3542e51455d0708e6e81d5e88331c0c19ea2500a09cbf005d9c088517d05eb63",
+			"MachineKey": "mkey:20dc8ba93633d6cf785afc11d461b061348a40a6b937725801a8798cfd5a985d",
+			"Peers": [{
+				"ID":         159988860796897,
+				"StableID":   "nGiomtdTF211CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c0a45cc68117055326be2ef9e06c97a0e2b2f7d57456d25a0392ba05f146a03",
+				"DiscoKey":   "discokey:7e355ec46d8478caa95e9eb6fb9b585ca113ee6d13ffeb1fbb6731c28d00a60b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35691", "10.65.0.27:35691", "172.17.0.1:35691"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:49:16.221732817Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3531612796423214,
+				"StableID":   "nFV3PpUUaU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ac224bcb24be89e702952945ece40aeec4db11a50e7c4b11b7684b86426200c",
+				"DiscoKey":   "discokey:c5e7bebe37398cf3b8f195d10d6654f28a733117e8047dbb7eec0f05cccd2c63",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57312", "10.65.0.27:57312", "172.17.0.1:57312"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:49:20.490299792Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5120013337332502,
+				"StableID":   "nB1axx4syg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9170c1ea30ce67af7dc587c30face7b7ab6a5e9116a0f25521baedb8ffbba27d",
+				"DiscoKey":   "discokey:7672cdda3c90aaa2a25a96907a7ed05d8fa6dd64b5398f5b6a0e03bc10958b30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:58246", "10.65.0.27:58246", "172.17.0.1:58246"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:49:23.503350542Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4557058250060510,
+				"StableID":   "nVkQeBCuac11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6095b372ecdf79e61e443560f3a8d4dbf521dc3d89a1179d50182aba46f4ec46",
+				"DiscoKey":   "discokey:15951a5a7a2a70c806c2340a8703ebf754cbead6fb390c6ef5f8fb4f2907470f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53844", "10.65.0.27:53844", "172.17.0.1:53844"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:49:24.642331521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4924053709634750,
+				"StableID":   "nHN4hPY7Tf11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fd26dc2b44f7c6c0c9e1ba579d1a013305ddea69f854be8a8c5a094a33c26918",
+				"KeyExpiry":  "2026-10-26T10:49:25Z",
+				"DiscoKey":   "discokey:9dd44dcb4c6891734e9414d2e19d325020e2d8da52fa9181203d4e291157ea28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52295", "10.65.0.27:52295", "172.17.0.1:52295"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:49:25.853279817Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4416364600602414,
+				"StableID":   "nmzFdjQBVb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:339aeb5482d8ef2f31a2278de4742ec26d65819d77ad18beafde2ad016ed1342",
+				"KeyExpiry":  "2026-10-26T10:49:26Z",
+				"DiscoKey":   "discokey:9b4f69d8ff6b6d4cc2cd13d5f73956d3a4fc10b0f42a3aa04ef94a962278fc37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:36822", "10.65.0.27:36822", "172.17.0.1:36822"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:49:26.362174373Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7292318104624053,
+				"StableID":   "nAD4YCqhwy11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:194265138cd489f9772b01973659b200af47dc01b55f97d0bd551dc5490de839",
+				"KeyExpiry":  "2026-10-26T10:49:29Z",
+				"DiscoKey":   "discokey:be7a6011ff3109e7e5f9ae0d5675a1024c60113492a2ffbc3966314fb431b92a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:38828", "10.65.0.27:38828", "172.17.0.1:38828"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:49:29.718922311Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2009225751901329": {
+				"ID":          2009225751901329,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7292318104624053,
+				"StableID":   "nAD4YCqhwy11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:194265138cd489f9772b01973659b200af47dc01b55f97d0bd551dc5490de839",
+				"KeyExpiry":  "2026-10-26T10:49:29Z",
+				"DiscoKey":   "discokey:be7a6011ff3109e7e5f9ae0d5675a1024c60113492a2ffbc3966314fb431b92a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:38828", "10.65.0.27:38828", "172.17.0.1:38828"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:49:29.718922311Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:194265138cd489f9772b01973659b200af47dc01b55f97d0bd551dc5490de839",
+			"MachineKey": "mkey:feaa7f41a0a345b8fe51afc52dafe39bd5703d132afec68d95229e102079426c",
+			"Peers": [{
+				"ID":         159988860796897,
+				"StableID":   "nGiomtdTF211CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c0a45cc68117055326be2ef9e06c97a0e2b2f7d57456d25a0392ba05f146a03",
+				"DiscoKey":   "discokey:7e355ec46d8478caa95e9eb6fb9b585ca113ee6d13ffeb1fbb6731c28d00a60b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35691", "10.65.0.27:35691", "172.17.0.1:35691"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:49:16.221732817Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3531612796423214,
+				"StableID":   "nFV3PpUUaU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ac224bcb24be89e702952945ece40aeec4db11a50e7c4b11b7684b86426200c",
+				"DiscoKey":   "discokey:c5e7bebe37398cf3b8f195d10d6654f28a733117e8047dbb7eec0f05cccd2c63",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57312", "10.65.0.27:57312", "172.17.0.1:57312"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:49:20.490299792Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5120013337332502,
+				"StableID":   "nB1axx4syg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9170c1ea30ce67af7dc587c30face7b7ab6a5e9116a0f25521baedb8ffbba27d",
+				"DiscoKey":   "discokey:7672cdda3c90aaa2a25a96907a7ed05d8fa6dd64b5398f5b6a0e03bc10958b30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:58246", "10.65.0.27:58246", "172.17.0.1:58246"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:49:23.503350542Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4557058250060510,
+				"StableID":   "nVkQeBCuac11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6095b372ecdf79e61e443560f3a8d4dbf521dc3d89a1179d50182aba46f4ec46",
+				"DiscoKey":   "discokey:15951a5a7a2a70c806c2340a8703ebf754cbead6fb390c6ef5f8fb4f2907470f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53844", "10.65.0.27:53844", "172.17.0.1:53844"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:49:24.642331521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2009225751901329,
+				"StableID":   "ncGfRJxygG11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3542e51455d0708e6e81d5e88331c0c19ea2500a09cbf005d9c088517d05eb63",
+				"DiscoKey":   "discokey:48b96c95a9e8b3904c18862c5a7919eeaf742938683c113c6afc85478be0c126",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45495", "10.65.0.27:45495", "172.17.0.1:45495"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:49:25.301006848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4924053709634750,
+				"StableID":   "nHN4hPY7Tf11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fd26dc2b44f7c6c0c9e1ba579d1a013305ddea69f854be8a8c5a094a33c26918",
+				"KeyExpiry":  "2026-10-26T10:49:25Z",
+				"DiscoKey":   "discokey:9dd44dcb4c6891734e9414d2e19d325020e2d8da52fa9181203d4e291157ea28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52295", "10.65.0.27:52295", "172.17.0.1:52295"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:49:25.853279817Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4416364600602414,
+				"StableID":   "nmzFdjQBVb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:339aeb5482d8ef2f31a2278de4742ec26d65819d77ad18beafde2ad016ed1342",
+				"KeyExpiry":  "2026-10-26T10:49:26Z",
+				"DiscoKey":   "discokey:9b4f69d8ff6b6d4cc2cd13d5f73956d3a4fc10b0f42a3aa04ef94a962278fc37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:36822", "10.65.0.27:36822", "172.17.0.1:36822"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:49:26.362174373Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         159988860796897,
+				"StableID":   "nGiomtdTF211CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       159988860796897,
+				"Key":        "nodekey:1c0a45cc68117055326be2ef9e06c97a0e2b2f7d57456d25a0392ba05f146a03",
+				"DiscoKey":   "discokey:7e355ec46d8478caa95e9eb6fb9b585ca113ee6d13ffeb1fbb6731c28d00a60b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35691", "10.65.0.27:35691", "172.17.0.1:35691"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:49:16.221732817Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1c0a45cc68117055326be2ef9e06c97a0e2b2f7d57456d25a0392ba05f146a03",
+			"MachineKey": "mkey:e40f9f3fa945b7f1e4fd750a3ec0e2b1656aee85b585f1d94b13ab09dcb83450",
+			"Peers": [{
+				"ID":         3531612796423214,
+				"StableID":   "nFV3PpUUaU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ac224bcb24be89e702952945ece40aeec4db11a50e7c4b11b7684b86426200c",
+				"DiscoKey":   "discokey:c5e7bebe37398cf3b8f195d10d6654f28a733117e8047dbb7eec0f05cccd2c63",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57312", "10.65.0.27:57312", "172.17.0.1:57312"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:49:20.490299792Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5120013337332502,
+				"StableID":   "nB1axx4syg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9170c1ea30ce67af7dc587c30face7b7ab6a5e9116a0f25521baedb8ffbba27d",
+				"DiscoKey":   "discokey:7672cdda3c90aaa2a25a96907a7ed05d8fa6dd64b5398f5b6a0e03bc10958b30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:58246", "10.65.0.27:58246", "172.17.0.1:58246"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:49:23.503350542Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4557058250060510,
+				"StableID":   "nVkQeBCuac11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6095b372ecdf79e61e443560f3a8d4dbf521dc3d89a1179d50182aba46f4ec46",
+				"DiscoKey":   "discokey:15951a5a7a2a70c806c2340a8703ebf754cbead6fb390c6ef5f8fb4f2907470f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53844", "10.65.0.27:53844", "172.17.0.1:53844"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:49:24.642331521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2009225751901329,
+				"StableID":   "ncGfRJxygG11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3542e51455d0708e6e81d5e88331c0c19ea2500a09cbf005d9c088517d05eb63",
+				"DiscoKey":   "discokey:48b96c95a9e8b3904c18862c5a7919eeaf742938683c113c6afc85478be0c126",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45495", "10.65.0.27:45495", "172.17.0.1:45495"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:49:25.301006848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4924053709634750,
+				"StableID":   "nHN4hPY7Tf11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fd26dc2b44f7c6c0c9e1ba579d1a013305ddea69f854be8a8c5a094a33c26918",
+				"KeyExpiry":  "2026-10-26T10:49:25Z",
+				"DiscoKey":   "discokey:9dd44dcb4c6891734e9414d2e19d325020e2d8da52fa9181203d4e291157ea28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52295", "10.65.0.27:52295", "172.17.0.1:52295"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:49:25.853279817Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4416364600602414,
+				"StableID":   "nmzFdjQBVb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:339aeb5482d8ef2f31a2278de4742ec26d65819d77ad18beafde2ad016ed1342",
+				"KeyExpiry":  "2026-10-26T10:49:26Z",
+				"DiscoKey":   "discokey:9b4f69d8ff6b6d4cc2cd13d5f73956d3a4fc10b0f42a3aa04ef94a962278fc37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:36822", "10.65.0.27:36822", "172.17.0.1:36822"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:49:26.362174373Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7292318104624053,
+				"StableID":   "nAD4YCqhwy11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:194265138cd489f9772b01973659b200af47dc01b55f97d0bd551dc5490de839",
+				"KeyExpiry":  "2026-10-26T10:49:29Z",
+				"DiscoKey":   "discokey:be7a6011ff3109e7e5f9ae0d5675a1024c60113492a2ffbc3966314fb431b92a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:38828", "10.65.0.27:38828", "172.17.0.1:38828"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:49:29.718922311Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "159988860796897": {
+				"ID":          159988860796897,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4924053709634750,
+				"StableID":   "nHN4hPY7Tf11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fd26dc2b44f7c6c0c9e1ba579d1a013305ddea69f854be8a8c5a094a33c26918",
+				"KeyExpiry":  "2026-10-26T10:49:25Z",
+				"DiscoKey":   "discokey:9dd44dcb4c6891734e9414d2e19d325020e2d8da52fa9181203d4e291157ea28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52295", "10.65.0.27:52295", "172.17.0.1:52295"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:49:25.853279817Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fd26dc2b44f7c6c0c9e1ba579d1a013305ddea69f854be8a8c5a094a33c26918",
+			"MachineKey": "mkey:394c8437d85c6733beb0ee2e241536842510accd495a210261fa87822563c55a",
+			"Peers": [{
+				"ID":         159988860796897,
+				"StableID":   "nGiomtdTF211CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c0a45cc68117055326be2ef9e06c97a0e2b2f7d57456d25a0392ba05f146a03",
+				"DiscoKey":   "discokey:7e355ec46d8478caa95e9eb6fb9b585ca113ee6d13ffeb1fbb6731c28d00a60b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35691", "10.65.0.27:35691", "172.17.0.1:35691"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:49:16.221732817Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3531612796423214,
+				"StableID":   "nFV3PpUUaU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ac224bcb24be89e702952945ece40aeec4db11a50e7c4b11b7684b86426200c",
+				"DiscoKey":   "discokey:c5e7bebe37398cf3b8f195d10d6654f28a733117e8047dbb7eec0f05cccd2c63",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57312", "10.65.0.27:57312", "172.17.0.1:57312"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:49:20.490299792Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5120013337332502,
+				"StableID":   "nB1axx4syg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9170c1ea30ce67af7dc587c30face7b7ab6a5e9116a0f25521baedb8ffbba27d",
+				"DiscoKey":   "discokey:7672cdda3c90aaa2a25a96907a7ed05d8fa6dd64b5398f5b6a0e03bc10958b30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:58246", "10.65.0.27:58246", "172.17.0.1:58246"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:49:23.503350542Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4557058250060510,
+				"StableID":   "nVkQeBCuac11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6095b372ecdf79e61e443560f3a8d4dbf521dc3d89a1179d50182aba46f4ec46",
+				"DiscoKey":   "discokey:15951a5a7a2a70c806c2340a8703ebf754cbead6fb390c6ef5f8fb4f2907470f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53844", "10.65.0.27:53844", "172.17.0.1:53844"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:49:24.642331521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2009225751901329,
+				"StableID":   "ncGfRJxygG11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3542e51455d0708e6e81d5e88331c0c19ea2500a09cbf005d9c088517d05eb63",
+				"DiscoKey":   "discokey:48b96c95a9e8b3904c18862c5a7919eeaf742938683c113c6afc85478be0c126",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45495", "10.65.0.27:45495", "172.17.0.1:45495"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:49:25.301006848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4416364600602414,
+				"StableID":   "nmzFdjQBVb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:339aeb5482d8ef2f31a2278de4742ec26d65819d77ad18beafde2ad016ed1342",
+				"KeyExpiry":  "2026-10-26T10:49:26Z",
+				"DiscoKey":   "discokey:9b4f69d8ff6b6d4cc2cd13d5f73956d3a4fc10b0f42a3aa04ef94a962278fc37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:36822", "10.65.0.27:36822", "172.17.0.1:36822"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:49:26.362174373Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7292318104624053,
+				"StableID":   "nAD4YCqhwy11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:194265138cd489f9772b01973659b200af47dc01b55f97d0bd551dc5490de839",
+				"KeyExpiry":  "2026-10-26T10:49:29Z",
+				"DiscoKey":   "discokey:be7a6011ff3109e7e5f9ae0d5675a1024c60113492a2ffbc3966314fb431b92a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:38828", "10.65.0.27:38828", "172.17.0.1:38828"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:49:29.718922311Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4557058250060510,
+				"StableID":   "nVkQeBCuac11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       4557058250060510,
+				"Key":        "nodekey:6095b372ecdf79e61e443560f3a8d4dbf521dc3d89a1179d50182aba46f4ec46",
+				"DiscoKey":   "discokey:15951a5a7a2a70c806c2340a8703ebf754cbead6fb390c6ef5f8fb4f2907470f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53844", "10.65.0.27:53844", "172.17.0.1:53844"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:49:24.642331521Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6095b372ecdf79e61e443560f3a8d4dbf521dc3d89a1179d50182aba46f4ec46",
+			"MachineKey": "mkey:2b243cc8a7bbe059285a7521515cd2c0b996c43529ce4e35cf01a4868cdea425",
+			"Peers": [{
+				"ID":         159988860796897,
+				"StableID":   "nGiomtdTF211CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c0a45cc68117055326be2ef9e06c97a0e2b2f7d57456d25a0392ba05f146a03",
+				"DiscoKey":   "discokey:7e355ec46d8478caa95e9eb6fb9b585ca113ee6d13ffeb1fbb6731c28d00a60b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35691", "10.65.0.27:35691", "172.17.0.1:35691"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:49:16.221732817Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3531612796423214,
+				"StableID":   "nFV3PpUUaU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ac224bcb24be89e702952945ece40aeec4db11a50e7c4b11b7684b86426200c",
+				"DiscoKey":   "discokey:c5e7bebe37398cf3b8f195d10d6654f28a733117e8047dbb7eec0f05cccd2c63",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57312", "10.65.0.27:57312", "172.17.0.1:57312"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:49:20.490299792Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5120013337332502,
+				"StableID":   "nB1axx4syg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9170c1ea30ce67af7dc587c30face7b7ab6a5e9116a0f25521baedb8ffbba27d",
+				"DiscoKey":   "discokey:7672cdda3c90aaa2a25a96907a7ed05d8fa6dd64b5398f5b6a0e03bc10958b30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:58246", "10.65.0.27:58246", "172.17.0.1:58246"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:49:23.503350542Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2009225751901329,
+				"StableID":   "ncGfRJxygG11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3542e51455d0708e6e81d5e88331c0c19ea2500a09cbf005d9c088517d05eb63",
+				"DiscoKey":   "discokey:48b96c95a9e8b3904c18862c5a7919eeaf742938683c113c6afc85478be0c126",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45495", "10.65.0.27:45495", "172.17.0.1:45495"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:49:25.301006848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4924053709634750,
+				"StableID":   "nHN4hPY7Tf11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fd26dc2b44f7c6c0c9e1ba579d1a013305ddea69f854be8a8c5a094a33c26918",
+				"KeyExpiry":  "2026-10-26T10:49:25Z",
+				"DiscoKey":   "discokey:9dd44dcb4c6891734e9414d2e19d325020e2d8da52fa9181203d4e291157ea28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52295", "10.65.0.27:52295", "172.17.0.1:52295"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:49:25.853279817Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4416364600602414,
+				"StableID":   "nmzFdjQBVb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:339aeb5482d8ef2f31a2278de4742ec26d65819d77ad18beafde2ad016ed1342",
+				"KeyExpiry":  "2026-10-26T10:49:26Z",
+				"DiscoKey":   "discokey:9b4f69d8ff6b6d4cc2cd13d5f73956d3a4fc10b0f42a3aa04ef94a962278fc37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:36822", "10.65.0.27:36822", "172.17.0.1:36822"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:49:26.362174373Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7292318104624053,
+				"StableID":   "nAD4YCqhwy11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:194265138cd489f9772b01973659b200af47dc01b55f97d0bd551dc5490de839",
+				"KeyExpiry":  "2026-10-26T10:49:29Z",
+				"DiscoKey":   "discokey:be7a6011ff3109e7e5f9ae0d5675a1024c60113492a2ffbc3966314fb431b92a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:38828", "10.65.0.27:38828", "172.17.0.1:38828"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:49:29.718922311Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4557058250060510": {
+				"ID":          4557058250060510,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3531612796423214,
+				"StableID":   "nFV3PpUUaU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       3531612796423214,
+				"Key":        "nodekey:0ac224bcb24be89e702952945ece40aeec4db11a50e7c4b11b7684b86426200c",
+				"DiscoKey":   "discokey:c5e7bebe37398cf3b8f195d10d6654f28a733117e8047dbb7eec0f05cccd2c63",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57312", "10.65.0.27:57312", "172.17.0.1:57312"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:49:20.490299792Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0ac224bcb24be89e702952945ece40aeec4db11a50e7c4b11b7684b86426200c",
+			"MachineKey": "mkey:ca8cff23899ed21d03ca4a83b1456d17d572f7a20d02cbc69a4e11c733e60146",
+			"Peers": [{
+				"ID":         159988860796897,
+				"StableID":   "nGiomtdTF211CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c0a45cc68117055326be2ef9e06c97a0e2b2f7d57456d25a0392ba05f146a03",
+				"DiscoKey":   "discokey:7e355ec46d8478caa95e9eb6fb9b585ca113ee6d13ffeb1fbb6731c28d00a60b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35691", "10.65.0.27:35691", "172.17.0.1:35691"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:49:16.221732817Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5120013337332502,
+				"StableID":   "nB1axx4syg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9170c1ea30ce67af7dc587c30face7b7ab6a5e9116a0f25521baedb8ffbba27d",
+				"DiscoKey":   "discokey:7672cdda3c90aaa2a25a96907a7ed05d8fa6dd64b5398f5b6a0e03bc10958b30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:58246", "10.65.0.27:58246", "172.17.0.1:58246"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:49:23.503350542Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4557058250060510,
+				"StableID":   "nVkQeBCuac11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6095b372ecdf79e61e443560f3a8d4dbf521dc3d89a1179d50182aba46f4ec46",
+				"DiscoKey":   "discokey:15951a5a7a2a70c806c2340a8703ebf754cbead6fb390c6ef5f8fb4f2907470f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53844", "10.65.0.27:53844", "172.17.0.1:53844"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:49:24.642331521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2009225751901329,
+				"StableID":   "ncGfRJxygG11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3542e51455d0708e6e81d5e88331c0c19ea2500a09cbf005d9c088517d05eb63",
+				"DiscoKey":   "discokey:48b96c95a9e8b3904c18862c5a7919eeaf742938683c113c6afc85478be0c126",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45495", "10.65.0.27:45495", "172.17.0.1:45495"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:49:25.301006848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4924053709634750,
+				"StableID":   "nHN4hPY7Tf11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fd26dc2b44f7c6c0c9e1ba579d1a013305ddea69f854be8a8c5a094a33c26918",
+				"KeyExpiry":  "2026-10-26T10:49:25Z",
+				"DiscoKey":   "discokey:9dd44dcb4c6891734e9414d2e19d325020e2d8da52fa9181203d4e291157ea28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52295", "10.65.0.27:52295", "172.17.0.1:52295"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:49:25.853279817Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4416364600602414,
+				"StableID":   "nmzFdjQBVb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:339aeb5482d8ef2f31a2278de4742ec26d65819d77ad18beafde2ad016ed1342",
+				"KeyExpiry":  "2026-10-26T10:49:26Z",
+				"DiscoKey":   "discokey:9b4f69d8ff6b6d4cc2cd13d5f73956d3a4fc10b0f42a3aa04ef94a962278fc37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:36822", "10.65.0.27:36822", "172.17.0.1:36822"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:49:26.362174373Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7292318104624053,
+				"StableID":   "nAD4YCqhwy11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:194265138cd489f9772b01973659b200af47dc01b55f97d0bd551dc5490de839",
+				"KeyExpiry":  "2026-10-26T10:49:29Z",
+				"DiscoKey":   "discokey:be7a6011ff3109e7e5f9ae0d5675a1024c60113492a2ffbc3966314fb431b92a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:38828", "10.65.0.27:38828", "172.17.0.1:38828"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:49:29.718922311Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3531612796423214": {
+				"ID":          3531612796423214,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4416364600602414,
+				"StableID":   "nmzFdjQBVb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:339aeb5482d8ef2f31a2278de4742ec26d65819d77ad18beafde2ad016ed1342",
+				"KeyExpiry":  "2026-10-26T10:49:26Z",
+				"DiscoKey":   "discokey:9b4f69d8ff6b6d4cc2cd13d5f73956d3a4fc10b0f42a3aa04ef94a962278fc37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:36822", "10.65.0.27:36822", "172.17.0.1:36822"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:49:26.362174373Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:339aeb5482d8ef2f31a2278de4742ec26d65819d77ad18beafde2ad016ed1342",
+			"MachineKey": "mkey:c353ddba41695e10a5e0ced8853cf5012e83c0ce174bdb7d2cc3ccd25b23cd4c",
+			"Peers": [{
+				"ID":         159988860796897,
+				"StableID":   "nGiomtdTF211CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c0a45cc68117055326be2ef9e06c97a0e2b2f7d57456d25a0392ba05f146a03",
+				"DiscoKey":   "discokey:7e355ec46d8478caa95e9eb6fb9b585ca113ee6d13ffeb1fbb6731c28d00a60b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35691", "10.65.0.27:35691", "172.17.0.1:35691"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:49:16.221732817Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3531612796423214,
+				"StableID":   "nFV3PpUUaU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ac224bcb24be89e702952945ece40aeec4db11a50e7c4b11b7684b86426200c",
+				"DiscoKey":   "discokey:c5e7bebe37398cf3b8f195d10d6654f28a733117e8047dbb7eec0f05cccd2c63",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57312", "10.65.0.27:57312", "172.17.0.1:57312"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:49:20.490299792Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5120013337332502,
+				"StableID":   "nB1axx4syg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9170c1ea30ce67af7dc587c30face7b7ab6a5e9116a0f25521baedb8ffbba27d",
+				"DiscoKey":   "discokey:7672cdda3c90aaa2a25a96907a7ed05d8fa6dd64b5398f5b6a0e03bc10958b30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:58246", "10.65.0.27:58246", "172.17.0.1:58246"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:49:23.503350542Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4557058250060510,
+				"StableID":   "nVkQeBCuac11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6095b372ecdf79e61e443560f3a8d4dbf521dc3d89a1179d50182aba46f4ec46",
+				"DiscoKey":   "discokey:15951a5a7a2a70c806c2340a8703ebf754cbead6fb390c6ef5f8fb4f2907470f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53844", "10.65.0.27:53844", "172.17.0.1:53844"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:49:24.642331521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2009225751901329,
+				"StableID":   "ncGfRJxygG11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3542e51455d0708e6e81d5e88331c0c19ea2500a09cbf005d9c088517d05eb63",
+				"DiscoKey":   "discokey:48b96c95a9e8b3904c18862c5a7919eeaf742938683c113c6afc85478be0c126",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45495", "10.65.0.27:45495", "172.17.0.1:45495"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:49:25.301006848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4924053709634750,
+				"StableID":   "nHN4hPY7Tf11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fd26dc2b44f7c6c0c9e1ba579d1a013305ddea69f854be8a8c5a094a33c26918",
+				"KeyExpiry":  "2026-10-26T10:49:25Z",
+				"DiscoKey":   "discokey:9dd44dcb4c6891734e9414d2e19d325020e2d8da52fa9181203d4e291157ea28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52295", "10.65.0.27:52295", "172.17.0.1:52295"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:49:25.853279817Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7292318104624053,
+				"StableID":   "nAD4YCqhwy11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:194265138cd489f9772b01973659b200af47dc01b55f97d0bd551dc5490de839",
+				"KeyExpiry":  "2026-10-26T10:49:29Z",
+				"DiscoKey":   "discokey:be7a6011ff3109e7e5f9ae0d5675a1024c60113492a2ffbc3966314fb431b92a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:38828", "10.65.0.27:38828", "172.17.0.1:38828"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:49:29.718922311Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5120013337332502,
+				"StableID":   "nB1axx4syg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       5120013337332502,
+				"Key":        "nodekey:9170c1ea30ce67af7dc587c30face7b7ab6a5e9116a0f25521baedb8ffbba27d",
+				"DiscoKey":   "discokey:7672cdda3c90aaa2a25a96907a7ed05d8fa6dd64b5398f5b6a0e03bc10958b30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:58246", "10.65.0.27:58246", "172.17.0.1:58246"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:49:23.503350542Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9170c1ea30ce67af7dc587c30face7b7ab6a5e9116a0f25521baedb8ffbba27d",
+			"MachineKey": "mkey:9e4a7a582671e4c9faa9ddfdf4a60361340778d510412b2becf0dd3efc16063e",
+			"Peers": [{
+				"ID":         159988860796897,
+				"StableID":   "nGiomtdTF211CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c0a45cc68117055326be2ef9e06c97a0e2b2f7d57456d25a0392ba05f146a03",
+				"DiscoKey":   "discokey:7e355ec46d8478caa95e9eb6fb9b585ca113ee6d13ffeb1fbb6731c28d00a60b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35691", "10.65.0.27:35691", "172.17.0.1:35691"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:49:16.221732817Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3531612796423214,
+				"StableID":   "nFV3PpUUaU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ac224bcb24be89e702952945ece40aeec4db11a50e7c4b11b7684b86426200c",
+				"DiscoKey":   "discokey:c5e7bebe37398cf3b8f195d10d6654f28a733117e8047dbb7eec0f05cccd2c63",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57312", "10.65.0.27:57312", "172.17.0.1:57312"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:49:20.490299792Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4557058250060510,
+				"StableID":   "nVkQeBCuac11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6095b372ecdf79e61e443560f3a8d4dbf521dc3d89a1179d50182aba46f4ec46",
+				"DiscoKey":   "discokey:15951a5a7a2a70c806c2340a8703ebf754cbead6fb390c6ef5f8fb4f2907470f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53844", "10.65.0.27:53844", "172.17.0.1:53844"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:49:24.642331521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2009225751901329,
+				"StableID":   "ncGfRJxygG11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3542e51455d0708e6e81d5e88331c0c19ea2500a09cbf005d9c088517d05eb63",
+				"DiscoKey":   "discokey:48b96c95a9e8b3904c18862c5a7919eeaf742938683c113c6afc85478be0c126",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45495", "10.65.0.27:45495", "172.17.0.1:45495"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:49:25.301006848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4924053709634750,
+				"StableID":   "nHN4hPY7Tf11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fd26dc2b44f7c6c0c9e1ba579d1a013305ddea69f854be8a8c5a094a33c26918",
+				"KeyExpiry":  "2026-10-26T10:49:25Z",
+				"DiscoKey":   "discokey:9dd44dcb4c6891734e9414d2e19d325020e2d8da52fa9181203d4e291157ea28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52295", "10.65.0.27:52295", "172.17.0.1:52295"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:49:25.853279817Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4416364600602414,
+				"StableID":   "nmzFdjQBVb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:339aeb5482d8ef2f31a2278de4742ec26d65819d77ad18beafde2ad016ed1342",
+				"KeyExpiry":  "2026-10-26T10:49:26Z",
+				"DiscoKey":   "discokey:9b4f69d8ff6b6d4cc2cd13d5f73956d3a4fc10b0f42a3aa04ef94a962278fc37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:36822", "10.65.0.27:36822", "172.17.0.1:36822"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:49:26.362174373Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7292318104624053,
+				"StableID":   "nAD4YCqhwy11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:194265138cd489f9772b01973659b200af47dc01b55f97d0bd551dc5490de839",
+				"KeyExpiry":  "2026-10-26T10:49:29Z",
+				"DiscoKey":   "discokey:be7a6011ff3109e7e5f9ae0d5675a1024c60113492a2ffbc3966314fb431b92a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:38828", "10.65.0.27:38828", "172.17.0.1:38828"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:49:29.718922311Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5120013337332502": {
+				"ID":          5120013337332502,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-dst-unknown-cidr-shape.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-dst-unknown-cidr-shape.hujson
@@ -1,0 +1,8847 @@
+// policytest-dst-unknown-cidr-shape
+//
+// tests block dst-unknown: malformed CIDR shape (/33 on IPv4)
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:49:51Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-dst-unknown-cidr-shape",
+	"description":    "tests block dst-unknown: malformed CIDR shape (/33 on IPv4)",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:49:51.394851621Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                    \n  \n                                                                     \n                                 \n{\n\t\"id\":          \"policytest-dst-unknown-cidr-shape\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block dst-unknown: malformed CIDR shape (/33 on IPv4)\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"thor@example.org\"], \"dst\": [\"10.0.0.0/8:443\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"accept\": [\"10.0.0.0/33:443\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-dst-unknown-cidr-shape.hujson",
+		"full_policy": {
+			"acls": [{
+				"action": "accept",
+				"dst":    ["10.0.0.0/8:443"],
+				"src":    ["thor@example.org"]
+			}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["10.0.0.0/33:443"], "src": "thor@example.org"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6012375253115571,
+				"StableID":   "n43xhMu1xo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6012375253115571,
+				"Key":        "nodekey:7bec1f30b99410dd2848700fef56ff860ac25253a4f859fd3b55225b99466d76",
+				"DiscoKey":   "discokey:31f68ca63e77aee1f70b5bd9b893f6a2d9a51f369560b719bb7dc6a99e61c74e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57463", "10.65.0.27:57463", "172.17.0.1:57463"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:49:54.990417779Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7bec1f30b99410dd2848700fef56ff860ac25253a4f859fd3b55225b99466d76",
+			"MachineKey": "mkey:04c78e9c3d7b2c7a81b0c78cbf83591638d02a415a345af5fceca8d93ec21027",
+			"Peers": [{
+				"ID":         6842001185512055,
+				"StableID":   "nL52ScmkRv11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1f1fa2706da4acea906d31d0e052724e9dff0426fad5171995289423774a7601",
+				"DiscoKey":   "discokey:11f06a1d98bc74a6b406633556d3d16983638bfd341f902bb68fda617ba4ec1b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:40605", "10.65.0.27:40605", "172.17.0.1:40605"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:49:52.888733356Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6843132305453787,
+				"StableID":   "nE8PdwUGSv11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:527a8a0e13b62e6fea28ff24719b31397d2ddc4ef95dfdb7aff154763063ac45",
+				"DiscoKey":   "discokey:53105b2d7ab0f9edc71fb4f9baf0cfef78ea93cc788283a1030ad63c3e925f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:49359", "10.65.0.27:49359", "172.17.0.1:49359"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:49:53.421220372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2610668024355950,
+				"StableID":   "nVvyVgpNPM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4826492513b9dc49eebd376473f6f7ff5bf76b84fa9b5044fdacf0b03d502a69",
+				"DiscoKey":   "discokey:a488b8ee332058f05b8844421edbc7120557e3b907bf0102c5e412aeea86cf70",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50558", "10.65.0.27:50558", "172.17.0.1:50558"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:49:53.925046733Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4964120184466179,
+				"StableID":   "nLjUs82Gmf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b2ac9c49507e8539934305b8e5fd93595722370c6df8a16fc25ad20d179eee7f",
+				"DiscoKey":   "discokey:918c7f4efbf81cd5f78b6cd9397dcd93c39c55d2c55db0db5296dd50e5a33920",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38075", "10.65.0.27:38075", "172.17.0.1:38075"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:49:54.477493312Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5375157782122179,
+				"StableID":   "nL1uqFHRyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4d36306bbdbbbd98c360a4f94071a65735096798c5009ef44def37bbc82d131",
+				"KeyExpiry":  "2026-10-26T10:49:55Z",
+				"DiscoKey":   "discokey:9fc1de98087dd780c856921ddc2781f3c8ea6f9ff994890bbd0d248cfa21691b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53218", "10.65.0.27:53218", "172.17.0.1:53218"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:49:55.534038169Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4883812701413033,
+				"StableID":   "nxiPbjUt8f11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccdb66d043d4abe35e3b12e16776964ca13c1915f54683db79cd2ebd76aec93b",
+				"KeyExpiry":  "2026-10-26T10:49:56Z",
+				"DiscoKey":   "discokey:1630ec94d815c798651b4066a2544d1cd2838692b3f18f23b5a6e9cec376d57c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:35649", "10.65.0.27:35649", "172.17.0.1:35649"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:49:56.080450934Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2267631670759645,
+				"StableID":   "n2q6ceq1iJ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2e8fd597afee0b4eb21b55f867ae044073d719878ec733653e5fe1752ae1215f",
+				"KeyExpiry":  "2026-10-26T10:49:56Z",
+				"DiscoKey":   "discokey:d0264434a8a2ea0f70340a476e259dedf7a3fee3f25aa68a22744d725b47a147",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40092", "10.65.0.27:40092", "172.17.0.1:40092"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:49:56.635501976Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6012375253115571": {
+				"ID":          6012375253115571,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2267631670759645,
+				"StableID":   "n2q6ceq1iJ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2e8fd597afee0b4eb21b55f867ae044073d719878ec733653e5fe1752ae1215f",
+				"KeyExpiry":  "2026-10-26T10:49:56Z",
+				"DiscoKey":   "discokey:d0264434a8a2ea0f70340a476e259dedf7a3fee3f25aa68a22744d725b47a147",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40092", "10.65.0.27:40092", "172.17.0.1:40092"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:49:56.635501976Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2e8fd597afee0b4eb21b55f867ae044073d719878ec733653e5fe1752ae1215f",
+			"MachineKey": "mkey:b0e221674bf5e9cb1c3880ce90b458db82085bc66be5b2c2324dcdee6053487f",
+			"Peers": [{
+				"ID":         6842001185512055,
+				"StableID":   "nL52ScmkRv11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1f1fa2706da4acea906d31d0e052724e9dff0426fad5171995289423774a7601",
+				"DiscoKey":   "discokey:11f06a1d98bc74a6b406633556d3d16983638bfd341f902bb68fda617ba4ec1b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:40605", "10.65.0.27:40605", "172.17.0.1:40605"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:49:52.888733356Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6843132305453787,
+				"StableID":   "nE8PdwUGSv11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:527a8a0e13b62e6fea28ff24719b31397d2ddc4ef95dfdb7aff154763063ac45",
+				"DiscoKey":   "discokey:53105b2d7ab0f9edc71fb4f9baf0cfef78ea93cc788283a1030ad63c3e925f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:49359", "10.65.0.27:49359", "172.17.0.1:49359"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:49:53.421220372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2610668024355950,
+				"StableID":   "nVvyVgpNPM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4826492513b9dc49eebd376473f6f7ff5bf76b84fa9b5044fdacf0b03d502a69",
+				"DiscoKey":   "discokey:a488b8ee332058f05b8844421edbc7120557e3b907bf0102c5e412aeea86cf70",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50558", "10.65.0.27:50558", "172.17.0.1:50558"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:49:53.925046733Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4964120184466179,
+				"StableID":   "nLjUs82Gmf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b2ac9c49507e8539934305b8e5fd93595722370c6df8a16fc25ad20d179eee7f",
+				"DiscoKey":   "discokey:918c7f4efbf81cd5f78b6cd9397dcd93c39c55d2c55db0db5296dd50e5a33920",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38075", "10.65.0.27:38075", "172.17.0.1:38075"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:49:54.477493312Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6012375253115571,
+				"StableID":   "n43xhMu1xo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bec1f30b99410dd2848700fef56ff860ac25253a4f859fd3b55225b99466d76",
+				"DiscoKey":   "discokey:31f68ca63e77aee1f70b5bd9b893f6a2d9a51f369560b719bb7dc6a99e61c74e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57463", "10.65.0.27:57463", "172.17.0.1:57463"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:49:54.990417779Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5375157782122179,
+				"StableID":   "nL1uqFHRyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4d36306bbdbbbd98c360a4f94071a65735096798c5009ef44def37bbc82d131",
+				"KeyExpiry":  "2026-10-26T10:49:55Z",
+				"DiscoKey":   "discokey:9fc1de98087dd780c856921ddc2781f3c8ea6f9ff994890bbd0d248cfa21691b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53218", "10.65.0.27:53218", "172.17.0.1:53218"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:49:55.534038169Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4883812701413033,
+				"StableID":   "nxiPbjUt8f11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccdb66d043d4abe35e3b12e16776964ca13c1915f54683db79cd2ebd76aec93b",
+				"KeyExpiry":  "2026-10-26T10:49:56Z",
+				"DiscoKey":   "discokey:1630ec94d815c798651b4066a2544d1cd2838692b3f18f23b5a6e9cec376d57c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:35649", "10.65.0.27:35649", "172.17.0.1:35649"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:49:56.080450934Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6842001185512055,
+				"StableID":   "nL52ScmkRv11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       6842001185512055,
+				"Key":        "nodekey:1f1fa2706da4acea906d31d0e052724e9dff0426fad5171995289423774a7601",
+				"DiscoKey":   "discokey:11f06a1d98bc74a6b406633556d3d16983638bfd341f902bb68fda617ba4ec1b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:40605", "10.65.0.27:40605", "172.17.0.1:40605"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:49:52.888733356Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1f1fa2706da4acea906d31d0e052724e9dff0426fad5171995289423774a7601",
+			"MachineKey": "mkey:eb984a2eb99257dbd65438d41d41feb1ba1476bb669f74746c14a97ec1837d50",
+			"Peers": [{
+				"ID":         6843132305453787,
+				"StableID":   "nE8PdwUGSv11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:527a8a0e13b62e6fea28ff24719b31397d2ddc4ef95dfdb7aff154763063ac45",
+				"DiscoKey":   "discokey:53105b2d7ab0f9edc71fb4f9baf0cfef78ea93cc788283a1030ad63c3e925f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:49359", "10.65.0.27:49359", "172.17.0.1:49359"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:49:53.421220372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2610668024355950,
+				"StableID":   "nVvyVgpNPM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4826492513b9dc49eebd376473f6f7ff5bf76b84fa9b5044fdacf0b03d502a69",
+				"DiscoKey":   "discokey:a488b8ee332058f05b8844421edbc7120557e3b907bf0102c5e412aeea86cf70",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50558", "10.65.0.27:50558", "172.17.0.1:50558"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:49:53.925046733Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4964120184466179,
+				"StableID":   "nLjUs82Gmf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b2ac9c49507e8539934305b8e5fd93595722370c6df8a16fc25ad20d179eee7f",
+				"DiscoKey":   "discokey:918c7f4efbf81cd5f78b6cd9397dcd93c39c55d2c55db0db5296dd50e5a33920",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38075", "10.65.0.27:38075", "172.17.0.1:38075"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:49:54.477493312Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6012375253115571,
+				"StableID":   "n43xhMu1xo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bec1f30b99410dd2848700fef56ff860ac25253a4f859fd3b55225b99466d76",
+				"DiscoKey":   "discokey:31f68ca63e77aee1f70b5bd9b893f6a2d9a51f369560b719bb7dc6a99e61c74e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57463", "10.65.0.27:57463", "172.17.0.1:57463"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:49:54.990417779Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5375157782122179,
+				"StableID":   "nL1uqFHRyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4d36306bbdbbbd98c360a4f94071a65735096798c5009ef44def37bbc82d131",
+				"KeyExpiry":  "2026-10-26T10:49:55Z",
+				"DiscoKey":   "discokey:9fc1de98087dd780c856921ddc2781f3c8ea6f9ff994890bbd0d248cfa21691b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53218", "10.65.0.27:53218", "172.17.0.1:53218"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:49:55.534038169Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4883812701413033,
+				"StableID":   "nxiPbjUt8f11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccdb66d043d4abe35e3b12e16776964ca13c1915f54683db79cd2ebd76aec93b",
+				"KeyExpiry":  "2026-10-26T10:49:56Z",
+				"DiscoKey":   "discokey:1630ec94d815c798651b4066a2544d1cd2838692b3f18f23b5a6e9cec376d57c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:35649", "10.65.0.27:35649", "172.17.0.1:35649"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:49:56.080450934Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2267631670759645,
+				"StableID":   "n2q6ceq1iJ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2e8fd597afee0b4eb21b55f867ae044073d719878ec733653e5fe1752ae1215f",
+				"KeyExpiry":  "2026-10-26T10:49:56Z",
+				"DiscoKey":   "discokey:d0264434a8a2ea0f70340a476e259dedf7a3fee3f25aa68a22744d725b47a147",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40092", "10.65.0.27:40092", "172.17.0.1:40092"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:49:56.635501976Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6842001185512055": {
+				"ID":          6842001185512055,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5375157782122179,
+				"StableID":   "nL1uqFHRyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4d36306bbdbbbd98c360a4f94071a65735096798c5009ef44def37bbc82d131",
+				"KeyExpiry":  "2026-10-26T10:49:55Z",
+				"DiscoKey":   "discokey:9fc1de98087dd780c856921ddc2781f3c8ea6f9ff994890bbd0d248cfa21691b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53218", "10.65.0.27:53218", "172.17.0.1:53218"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:49:55.534038169Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a4d36306bbdbbbd98c360a4f94071a65735096798c5009ef44def37bbc82d131",
+			"MachineKey": "mkey:63dd5f48ab748165e76c2a220daa7d0f7092cd6ec30f605d13a1670c32a23965",
+			"Peers": [{
+				"ID":         6842001185512055,
+				"StableID":   "nL52ScmkRv11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1f1fa2706da4acea906d31d0e052724e9dff0426fad5171995289423774a7601",
+				"DiscoKey":   "discokey:11f06a1d98bc74a6b406633556d3d16983638bfd341f902bb68fda617ba4ec1b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:40605", "10.65.0.27:40605", "172.17.0.1:40605"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:49:52.888733356Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6843132305453787,
+				"StableID":   "nE8PdwUGSv11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:527a8a0e13b62e6fea28ff24719b31397d2ddc4ef95dfdb7aff154763063ac45",
+				"DiscoKey":   "discokey:53105b2d7ab0f9edc71fb4f9baf0cfef78ea93cc788283a1030ad63c3e925f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:49359", "10.65.0.27:49359", "172.17.0.1:49359"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:49:53.421220372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2610668024355950,
+				"StableID":   "nVvyVgpNPM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4826492513b9dc49eebd376473f6f7ff5bf76b84fa9b5044fdacf0b03d502a69",
+				"DiscoKey":   "discokey:a488b8ee332058f05b8844421edbc7120557e3b907bf0102c5e412aeea86cf70",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50558", "10.65.0.27:50558", "172.17.0.1:50558"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:49:53.925046733Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4964120184466179,
+				"StableID":   "nLjUs82Gmf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b2ac9c49507e8539934305b8e5fd93595722370c6df8a16fc25ad20d179eee7f",
+				"DiscoKey":   "discokey:918c7f4efbf81cd5f78b6cd9397dcd93c39c55d2c55db0db5296dd50e5a33920",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38075", "10.65.0.27:38075", "172.17.0.1:38075"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:49:54.477493312Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6012375253115571,
+				"StableID":   "n43xhMu1xo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bec1f30b99410dd2848700fef56ff860ac25253a4f859fd3b55225b99466d76",
+				"DiscoKey":   "discokey:31f68ca63e77aee1f70b5bd9b893f6a2d9a51f369560b719bb7dc6a99e61c74e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57463", "10.65.0.27:57463", "172.17.0.1:57463"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:49:54.990417779Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4883812701413033,
+				"StableID":   "nxiPbjUt8f11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccdb66d043d4abe35e3b12e16776964ca13c1915f54683db79cd2ebd76aec93b",
+				"KeyExpiry":  "2026-10-26T10:49:56Z",
+				"DiscoKey":   "discokey:1630ec94d815c798651b4066a2544d1cd2838692b3f18f23b5a6e9cec376d57c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:35649", "10.65.0.27:35649", "172.17.0.1:35649"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:49:56.080450934Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2267631670759645,
+				"StableID":   "n2q6ceq1iJ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2e8fd597afee0b4eb21b55f867ae044073d719878ec733653e5fe1752ae1215f",
+				"KeyExpiry":  "2026-10-26T10:49:56Z",
+				"DiscoKey":   "discokey:d0264434a8a2ea0f70340a476e259dedf7a3fee3f25aa68a22744d725b47a147",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40092", "10.65.0.27:40092", "172.17.0.1:40092"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:49:56.635501976Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4964120184466179,
+				"StableID":   "nLjUs82Gmf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       4964120184466179,
+				"Key":        "nodekey:b2ac9c49507e8539934305b8e5fd93595722370c6df8a16fc25ad20d179eee7f",
+				"DiscoKey":   "discokey:918c7f4efbf81cd5f78b6cd9397dcd93c39c55d2c55db0db5296dd50e5a33920",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38075", "10.65.0.27:38075", "172.17.0.1:38075"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:49:54.477493312Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b2ac9c49507e8539934305b8e5fd93595722370c6df8a16fc25ad20d179eee7f",
+			"MachineKey": "mkey:8954ad9e18bfe1012a916e90277469a4b86aff67b19e188441843d4b221e0454",
+			"Peers": [{
+				"ID":         6842001185512055,
+				"StableID":   "nL52ScmkRv11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1f1fa2706da4acea906d31d0e052724e9dff0426fad5171995289423774a7601",
+				"DiscoKey":   "discokey:11f06a1d98bc74a6b406633556d3d16983638bfd341f902bb68fda617ba4ec1b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:40605", "10.65.0.27:40605", "172.17.0.1:40605"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:49:52.888733356Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6843132305453787,
+				"StableID":   "nE8PdwUGSv11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:527a8a0e13b62e6fea28ff24719b31397d2ddc4ef95dfdb7aff154763063ac45",
+				"DiscoKey":   "discokey:53105b2d7ab0f9edc71fb4f9baf0cfef78ea93cc788283a1030ad63c3e925f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:49359", "10.65.0.27:49359", "172.17.0.1:49359"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:49:53.421220372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2610668024355950,
+				"StableID":   "nVvyVgpNPM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4826492513b9dc49eebd376473f6f7ff5bf76b84fa9b5044fdacf0b03d502a69",
+				"DiscoKey":   "discokey:a488b8ee332058f05b8844421edbc7120557e3b907bf0102c5e412aeea86cf70",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50558", "10.65.0.27:50558", "172.17.0.1:50558"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:49:53.925046733Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6012375253115571,
+				"StableID":   "n43xhMu1xo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bec1f30b99410dd2848700fef56ff860ac25253a4f859fd3b55225b99466d76",
+				"DiscoKey":   "discokey:31f68ca63e77aee1f70b5bd9b893f6a2d9a51f369560b719bb7dc6a99e61c74e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57463", "10.65.0.27:57463", "172.17.0.1:57463"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:49:54.990417779Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5375157782122179,
+				"StableID":   "nL1uqFHRyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4d36306bbdbbbd98c360a4f94071a65735096798c5009ef44def37bbc82d131",
+				"KeyExpiry":  "2026-10-26T10:49:55Z",
+				"DiscoKey":   "discokey:9fc1de98087dd780c856921ddc2781f3c8ea6f9ff994890bbd0d248cfa21691b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53218", "10.65.0.27:53218", "172.17.0.1:53218"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:49:55.534038169Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4883812701413033,
+				"StableID":   "nxiPbjUt8f11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccdb66d043d4abe35e3b12e16776964ca13c1915f54683db79cd2ebd76aec93b",
+				"KeyExpiry":  "2026-10-26T10:49:56Z",
+				"DiscoKey":   "discokey:1630ec94d815c798651b4066a2544d1cd2838692b3f18f23b5a6e9cec376d57c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:35649", "10.65.0.27:35649", "172.17.0.1:35649"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:49:56.080450934Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2267631670759645,
+				"StableID":   "n2q6ceq1iJ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2e8fd597afee0b4eb21b55f867ae044073d719878ec733653e5fe1752ae1215f",
+				"KeyExpiry":  "2026-10-26T10:49:56Z",
+				"DiscoKey":   "discokey:d0264434a8a2ea0f70340a476e259dedf7a3fee3f25aa68a22744d725b47a147",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40092", "10.65.0.27:40092", "172.17.0.1:40092"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:49:56.635501976Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4964120184466179": {
+				"ID":          4964120184466179,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6843132305453787,
+				"StableID":   "nE8PdwUGSv11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       6843132305453787,
+				"Key":        "nodekey:527a8a0e13b62e6fea28ff24719b31397d2ddc4ef95dfdb7aff154763063ac45",
+				"DiscoKey":   "discokey:53105b2d7ab0f9edc71fb4f9baf0cfef78ea93cc788283a1030ad63c3e925f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:49359", "10.65.0.27:49359", "172.17.0.1:49359"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:49:53.421220372Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:527a8a0e13b62e6fea28ff24719b31397d2ddc4ef95dfdb7aff154763063ac45",
+			"MachineKey": "mkey:725bcefc8e8b4bdb6c4e0f2190439e583624d405c3171516d576278ce7a60815",
+			"Peers": [{
+				"ID":         6842001185512055,
+				"StableID":   "nL52ScmkRv11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1f1fa2706da4acea906d31d0e052724e9dff0426fad5171995289423774a7601",
+				"DiscoKey":   "discokey:11f06a1d98bc74a6b406633556d3d16983638bfd341f902bb68fda617ba4ec1b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:40605", "10.65.0.27:40605", "172.17.0.1:40605"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:49:52.888733356Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2610668024355950,
+				"StableID":   "nVvyVgpNPM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4826492513b9dc49eebd376473f6f7ff5bf76b84fa9b5044fdacf0b03d502a69",
+				"DiscoKey":   "discokey:a488b8ee332058f05b8844421edbc7120557e3b907bf0102c5e412aeea86cf70",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50558", "10.65.0.27:50558", "172.17.0.1:50558"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:49:53.925046733Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4964120184466179,
+				"StableID":   "nLjUs82Gmf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b2ac9c49507e8539934305b8e5fd93595722370c6df8a16fc25ad20d179eee7f",
+				"DiscoKey":   "discokey:918c7f4efbf81cd5f78b6cd9397dcd93c39c55d2c55db0db5296dd50e5a33920",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38075", "10.65.0.27:38075", "172.17.0.1:38075"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:49:54.477493312Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6012375253115571,
+				"StableID":   "n43xhMu1xo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bec1f30b99410dd2848700fef56ff860ac25253a4f859fd3b55225b99466d76",
+				"DiscoKey":   "discokey:31f68ca63e77aee1f70b5bd9b893f6a2d9a51f369560b719bb7dc6a99e61c74e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57463", "10.65.0.27:57463", "172.17.0.1:57463"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:49:54.990417779Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5375157782122179,
+				"StableID":   "nL1uqFHRyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4d36306bbdbbbd98c360a4f94071a65735096798c5009ef44def37bbc82d131",
+				"KeyExpiry":  "2026-10-26T10:49:55Z",
+				"DiscoKey":   "discokey:9fc1de98087dd780c856921ddc2781f3c8ea6f9ff994890bbd0d248cfa21691b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53218", "10.65.0.27:53218", "172.17.0.1:53218"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:49:55.534038169Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4883812701413033,
+				"StableID":   "nxiPbjUt8f11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccdb66d043d4abe35e3b12e16776964ca13c1915f54683db79cd2ebd76aec93b",
+				"KeyExpiry":  "2026-10-26T10:49:56Z",
+				"DiscoKey":   "discokey:1630ec94d815c798651b4066a2544d1cd2838692b3f18f23b5a6e9cec376d57c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:35649", "10.65.0.27:35649", "172.17.0.1:35649"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:49:56.080450934Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2267631670759645,
+				"StableID":   "n2q6ceq1iJ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2e8fd597afee0b4eb21b55f867ae044073d719878ec733653e5fe1752ae1215f",
+				"KeyExpiry":  "2026-10-26T10:49:56Z",
+				"DiscoKey":   "discokey:d0264434a8a2ea0f70340a476e259dedf7a3fee3f25aa68a22744d725b47a147",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40092", "10.65.0.27:40092", "172.17.0.1:40092"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:49:56.635501976Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6843132305453787": {
+				"ID":          6843132305453787,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4883812701413033,
+				"StableID":   "nxiPbjUt8f11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccdb66d043d4abe35e3b12e16776964ca13c1915f54683db79cd2ebd76aec93b",
+				"KeyExpiry":  "2026-10-26T10:49:56Z",
+				"DiscoKey":   "discokey:1630ec94d815c798651b4066a2544d1cd2838692b3f18f23b5a6e9cec376d57c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:35649", "10.65.0.27:35649", "172.17.0.1:35649"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:49:56.080450934Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ccdb66d043d4abe35e3b12e16776964ca13c1915f54683db79cd2ebd76aec93b",
+			"MachineKey": "mkey:42be7c88b22e93701715117bfd712cc96861a7d3aa1f974e27a82245df233d5c",
+			"Peers": [{
+				"ID":         6842001185512055,
+				"StableID":   "nL52ScmkRv11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1f1fa2706da4acea906d31d0e052724e9dff0426fad5171995289423774a7601",
+				"DiscoKey":   "discokey:11f06a1d98bc74a6b406633556d3d16983638bfd341f902bb68fda617ba4ec1b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:40605", "10.65.0.27:40605", "172.17.0.1:40605"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:49:52.888733356Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6843132305453787,
+				"StableID":   "nE8PdwUGSv11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:527a8a0e13b62e6fea28ff24719b31397d2ddc4ef95dfdb7aff154763063ac45",
+				"DiscoKey":   "discokey:53105b2d7ab0f9edc71fb4f9baf0cfef78ea93cc788283a1030ad63c3e925f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:49359", "10.65.0.27:49359", "172.17.0.1:49359"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:49:53.421220372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2610668024355950,
+				"StableID":   "nVvyVgpNPM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4826492513b9dc49eebd376473f6f7ff5bf76b84fa9b5044fdacf0b03d502a69",
+				"DiscoKey":   "discokey:a488b8ee332058f05b8844421edbc7120557e3b907bf0102c5e412aeea86cf70",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50558", "10.65.0.27:50558", "172.17.0.1:50558"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:49:53.925046733Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4964120184466179,
+				"StableID":   "nLjUs82Gmf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b2ac9c49507e8539934305b8e5fd93595722370c6df8a16fc25ad20d179eee7f",
+				"DiscoKey":   "discokey:918c7f4efbf81cd5f78b6cd9397dcd93c39c55d2c55db0db5296dd50e5a33920",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38075", "10.65.0.27:38075", "172.17.0.1:38075"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:49:54.477493312Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6012375253115571,
+				"StableID":   "n43xhMu1xo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bec1f30b99410dd2848700fef56ff860ac25253a4f859fd3b55225b99466d76",
+				"DiscoKey":   "discokey:31f68ca63e77aee1f70b5bd9b893f6a2d9a51f369560b719bb7dc6a99e61c74e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57463", "10.65.0.27:57463", "172.17.0.1:57463"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:49:54.990417779Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5375157782122179,
+				"StableID":   "nL1uqFHRyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4d36306bbdbbbd98c360a4f94071a65735096798c5009ef44def37bbc82d131",
+				"KeyExpiry":  "2026-10-26T10:49:55Z",
+				"DiscoKey":   "discokey:9fc1de98087dd780c856921ddc2781f3c8ea6f9ff994890bbd0d248cfa21691b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53218", "10.65.0.27:53218", "172.17.0.1:53218"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:49:55.534038169Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2267631670759645,
+				"StableID":   "n2q6ceq1iJ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2e8fd597afee0b4eb21b55f867ae044073d719878ec733653e5fe1752ae1215f",
+				"KeyExpiry":  "2026-10-26T10:49:56Z",
+				"DiscoKey":   "discokey:d0264434a8a2ea0f70340a476e259dedf7a3fee3f25aa68a22744d725b47a147",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40092", "10.65.0.27:40092", "172.17.0.1:40092"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:49:56.635501976Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2610668024355950,
+				"StableID":   "nVvyVgpNPM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       2610668024355950,
+				"Key":        "nodekey:4826492513b9dc49eebd376473f6f7ff5bf76b84fa9b5044fdacf0b03d502a69",
+				"DiscoKey":   "discokey:a488b8ee332058f05b8844421edbc7120557e3b907bf0102c5e412aeea86cf70",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:50558", "10.65.0.27:50558", "172.17.0.1:50558"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:49:53.925046733Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4826492513b9dc49eebd376473f6f7ff5bf76b84fa9b5044fdacf0b03d502a69",
+			"MachineKey": "mkey:a982015edb2d7808b050b240112fe00ae9c00ff84794f66459128a15f615871e",
+			"Peers": [{
+				"ID":         6842001185512055,
+				"StableID":   "nL52ScmkRv11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1f1fa2706da4acea906d31d0e052724e9dff0426fad5171995289423774a7601",
+				"DiscoKey":   "discokey:11f06a1d98bc74a6b406633556d3d16983638bfd341f902bb68fda617ba4ec1b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:40605", "10.65.0.27:40605", "172.17.0.1:40605"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:49:52.888733356Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6843132305453787,
+				"StableID":   "nE8PdwUGSv11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:527a8a0e13b62e6fea28ff24719b31397d2ddc4ef95dfdb7aff154763063ac45",
+				"DiscoKey":   "discokey:53105b2d7ab0f9edc71fb4f9baf0cfef78ea93cc788283a1030ad63c3e925f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:49359", "10.65.0.27:49359", "172.17.0.1:49359"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:49:53.421220372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4964120184466179,
+				"StableID":   "nLjUs82Gmf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b2ac9c49507e8539934305b8e5fd93595722370c6df8a16fc25ad20d179eee7f",
+				"DiscoKey":   "discokey:918c7f4efbf81cd5f78b6cd9397dcd93c39c55d2c55db0db5296dd50e5a33920",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:38075", "10.65.0.27:38075", "172.17.0.1:38075"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:49:54.477493312Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6012375253115571,
+				"StableID":   "n43xhMu1xo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bec1f30b99410dd2848700fef56ff860ac25253a4f859fd3b55225b99466d76",
+				"DiscoKey":   "discokey:31f68ca63e77aee1f70b5bd9b893f6a2d9a51f369560b719bb7dc6a99e61c74e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57463", "10.65.0.27:57463", "172.17.0.1:57463"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:49:54.990417779Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5375157782122179,
+				"StableID":   "nL1uqFHRyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4d36306bbdbbbd98c360a4f94071a65735096798c5009ef44def37bbc82d131",
+				"KeyExpiry":  "2026-10-26T10:49:55Z",
+				"DiscoKey":   "discokey:9fc1de98087dd780c856921ddc2781f3c8ea6f9ff994890bbd0d248cfa21691b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53218", "10.65.0.27:53218", "172.17.0.1:53218"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:49:55.534038169Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4883812701413033,
+				"StableID":   "nxiPbjUt8f11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccdb66d043d4abe35e3b12e16776964ca13c1915f54683db79cd2ebd76aec93b",
+				"KeyExpiry":  "2026-10-26T10:49:56Z",
+				"DiscoKey":   "discokey:1630ec94d815c798651b4066a2544d1cd2838692b3f18f23b5a6e9cec376d57c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:35649", "10.65.0.27:35649", "172.17.0.1:35649"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:49:56.080450934Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2267631670759645,
+				"StableID":   "n2q6ceq1iJ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2e8fd597afee0b4eb21b55f867ae044073d719878ec733653e5fe1752ae1215f",
+				"KeyExpiry":  "2026-10-26T10:49:56Z",
+				"DiscoKey":   "discokey:d0264434a8a2ea0f70340a476e259dedf7a3fee3f25aa68a22744d725b47a147",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40092", "10.65.0.27:40092", "172.17.0.1:40092"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:49:56.635501976Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2610668024355950": {
+				"ID":          2610668024355950,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-dst-unknown-group.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-dst-unknown-group.hujson
@@ -1,0 +1,8847 @@
+// policytest-dst-unknown-group
+//
+// tests block dst-unknown: group used as destination
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:50:18Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-dst-unknown-group",
+	"description":    "tests block dst-unknown: group used as destination",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:50:18.333973165Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                               \n  \n                                                                      \n                                               \n{\n\t\"id\":          \"policytest-dst-unknown-group\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block dst-unknown: group used as destination\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"group:developers\"], \"dst\": [\"tag:server:22\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"group:developers\", \"accept\": [\"group:nonexistent:22\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-dst-unknown-group.hujson",
+		"full_policy": {
+			"acls": [{
+				"action": "accept",
+				"dst":    ["tag:server:22"],
+				"src":    ["group:developers"]
+			}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["group:nonexistent:22"], "src": "group:developers"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5076714345959160,
+				"StableID":   "n3vvMHgFeg11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       5076714345959160,
+				"Key":        "nodekey:883ece89bf64cae19b9bd86357c02395a14e279ed9f6398b06f109d0029b8c10",
+				"DiscoKey":   "discokey:8f0ab5567d7dc5e3dcdab508665eb55d9d6fee250a95f55ffd49259ecd1fd555",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:44330", "10.65.0.27:44330", "172.17.0.1:44330"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:50:21.967228184Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:883ece89bf64cae19b9bd86357c02395a14e279ed9f6398b06f109d0029b8c10",
+			"MachineKey": "mkey:e7817ef2486baf128a92edc7244e6a09979466cf3c310032087022375d3f1b73",
+			"Peers": [{
+				"ID":         554114001393793,
+				"StableID":   "nLU5qqdxK511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26e9199dcafe84751024081481d674ac60af5d66f31fac827f8c00bbb5713661",
+				"DiscoKey":   "discokey:92625c8a582613307fe7a2e91f24c9254482ca7291f988c29baaa4c4050a4a0e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41579", "10.65.0.27:41579", "172.17.0.1:41579"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:50:19.783721524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1657043148021718,
+				"StableID":   "nKXMiPiUwD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6eead39691234c90cdee3ceb471b838137c9474b389fce75484fac75ffc76e3e",
+				"DiscoKey":   "discokey:bcb4911a57b0c6a9e599434affa8d4ebce5f470579a3e4359d8a5b65f333dc62",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:45055", "10.65.0.27:45055", "172.17.0.1:45055"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:50:20.33229514Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2866306994367061,
+				"StableID":   "nvFLtQ2APP11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3d26fef3e24af0fbd32f9ba0962538dd030bc21aee1e450d41193642944294f",
+				"DiscoKey":   "discokey:f209afcfca1b67bc49ef124af241b6b6e6305af94973ea618ea5bf789611b825",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:51616", "10.65.0.27:51616", "172.17.0.1:51616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:50:20.874340795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         998842765349925,
+				"StableID":   "npAGoXuNo811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:37cdf08b99020523ec7360d75be9dd4f734ca35e00814aff4cb730c4cb5bc609",
+				"DiscoKey":   "discokey:337066a88eb6fcffa7b173f1435b47c02cbd7619c4bad7c309a4b61114af607c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49874", "10.65.0.27:49874", "172.17.0.1:49874"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:50:21.451386739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         277005748087120,
+				"StableID":   "nsx1QLUTA311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:87ade86d5411e5bb58afa831628a1984b89cdadf423639dac9e2db7243faf27c",
+				"KeyExpiry":  "2026-10-26T10:50:22Z",
+				"DiscoKey":   "discokey:3b0039490cdc1b79097c576595be3d781a6164dde94c3e55564b8bab63a4ef25",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53020", "10.65.0.27:53020", "172.17.0.1:53020"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:50:22.525307366Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8823899147463364,
+				"StableID":   "nD72eLsMuB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:77826812501dd6ecba439abcb1d566b0f1a04e6e89630f6f486c0fdb34d32425",
+				"KeyExpiry":  "2026-10-26T10:50:23Z",
+				"DiscoKey":   "discokey:a28d130d7634693029d995d5c5d918baddc531407a87cb3c3aec25df54aa6f0d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37667", "10.65.0.27:37667", "172.17.0.1:37667"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:50:23.06014Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1411089010459308,
+				"StableID":   "n5hoo6v52C11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dfb5e47db74fb50f5a2bea49c7ce404f6985580e548de47a101c107f5e871a",
+				"KeyExpiry":  "2026-10-26T10:50:23Z",
+				"DiscoKey":   "discokey:7bb9970e454bf63a371b0c33ee06f3e6fed9100275e9c087c242b1ca4face234",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55712", "10.65.0.27:55712", "172.17.0.1:55712"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:50:23.615594748Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5076714345959160": {
+				"ID":          5076714345959160,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1411089010459308,
+				"StableID":   "n5hoo6v52C11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dfb5e47db74fb50f5a2bea49c7ce404f6985580e548de47a101c107f5e871a",
+				"KeyExpiry":  "2026-10-26T10:50:23Z",
+				"DiscoKey":   "discokey:7bb9970e454bf63a371b0c33ee06f3e6fed9100275e9c087c242b1ca4face234",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55712", "10.65.0.27:55712", "172.17.0.1:55712"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:50:23.615594748Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a2dfb5e47db74fb50f5a2bea49c7ce404f6985580e548de47a101c107f5e871a",
+			"MachineKey": "mkey:592c2943b6990b3deb4303b3c26965252075685e60a974ac193fb20c734c6f2d",
+			"Peers": [{
+				"ID":         554114001393793,
+				"StableID":   "nLU5qqdxK511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26e9199dcafe84751024081481d674ac60af5d66f31fac827f8c00bbb5713661",
+				"DiscoKey":   "discokey:92625c8a582613307fe7a2e91f24c9254482ca7291f988c29baaa4c4050a4a0e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41579", "10.65.0.27:41579", "172.17.0.1:41579"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:50:19.783721524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1657043148021718,
+				"StableID":   "nKXMiPiUwD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6eead39691234c90cdee3ceb471b838137c9474b389fce75484fac75ffc76e3e",
+				"DiscoKey":   "discokey:bcb4911a57b0c6a9e599434affa8d4ebce5f470579a3e4359d8a5b65f333dc62",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:45055", "10.65.0.27:45055", "172.17.0.1:45055"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:50:20.33229514Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2866306994367061,
+				"StableID":   "nvFLtQ2APP11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3d26fef3e24af0fbd32f9ba0962538dd030bc21aee1e450d41193642944294f",
+				"DiscoKey":   "discokey:f209afcfca1b67bc49ef124af241b6b6e6305af94973ea618ea5bf789611b825",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:51616", "10.65.0.27:51616", "172.17.0.1:51616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:50:20.874340795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         998842765349925,
+				"StableID":   "npAGoXuNo811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:37cdf08b99020523ec7360d75be9dd4f734ca35e00814aff4cb730c4cb5bc609",
+				"DiscoKey":   "discokey:337066a88eb6fcffa7b173f1435b47c02cbd7619c4bad7c309a4b61114af607c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49874", "10.65.0.27:49874", "172.17.0.1:49874"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:50:21.451386739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5076714345959160,
+				"StableID":   "n3vvMHgFeg11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:883ece89bf64cae19b9bd86357c02395a14e279ed9f6398b06f109d0029b8c10",
+				"DiscoKey":   "discokey:8f0ab5567d7dc5e3dcdab508665eb55d9d6fee250a95f55ffd49259ecd1fd555",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:44330", "10.65.0.27:44330", "172.17.0.1:44330"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:50:21.967228184Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         277005748087120,
+				"StableID":   "nsx1QLUTA311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:87ade86d5411e5bb58afa831628a1984b89cdadf423639dac9e2db7243faf27c",
+				"KeyExpiry":  "2026-10-26T10:50:22Z",
+				"DiscoKey":   "discokey:3b0039490cdc1b79097c576595be3d781a6164dde94c3e55564b8bab63a4ef25",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53020", "10.65.0.27:53020", "172.17.0.1:53020"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:50:22.525307366Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8823899147463364,
+				"StableID":   "nD72eLsMuB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:77826812501dd6ecba439abcb1d566b0f1a04e6e89630f6f486c0fdb34d32425",
+				"KeyExpiry":  "2026-10-26T10:50:23Z",
+				"DiscoKey":   "discokey:a28d130d7634693029d995d5c5d918baddc531407a87cb3c3aec25df54aa6f0d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37667", "10.65.0.27:37667", "172.17.0.1:37667"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:50:23.06014Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         554114001393793,
+				"StableID":   "nLU5qqdxK511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       554114001393793,
+				"Key":        "nodekey:26e9199dcafe84751024081481d674ac60af5d66f31fac827f8c00bbb5713661",
+				"DiscoKey":   "discokey:92625c8a582613307fe7a2e91f24c9254482ca7291f988c29baaa4c4050a4a0e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41579", "10.65.0.27:41579", "172.17.0.1:41579"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:50:19.783721524Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:26e9199dcafe84751024081481d674ac60af5d66f31fac827f8c00bbb5713661",
+			"MachineKey": "mkey:2b5dd20c8abe33648230e1c6f538213b28e2337092e708998b96c95627630c41",
+			"Peers": [{
+				"ID":         1657043148021718,
+				"StableID":   "nKXMiPiUwD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6eead39691234c90cdee3ceb471b838137c9474b389fce75484fac75ffc76e3e",
+				"DiscoKey":   "discokey:bcb4911a57b0c6a9e599434affa8d4ebce5f470579a3e4359d8a5b65f333dc62",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:45055", "10.65.0.27:45055", "172.17.0.1:45055"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:50:20.33229514Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2866306994367061,
+				"StableID":   "nvFLtQ2APP11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3d26fef3e24af0fbd32f9ba0962538dd030bc21aee1e450d41193642944294f",
+				"DiscoKey":   "discokey:f209afcfca1b67bc49ef124af241b6b6e6305af94973ea618ea5bf789611b825",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:51616", "10.65.0.27:51616", "172.17.0.1:51616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:50:20.874340795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         998842765349925,
+				"StableID":   "npAGoXuNo811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:37cdf08b99020523ec7360d75be9dd4f734ca35e00814aff4cb730c4cb5bc609",
+				"DiscoKey":   "discokey:337066a88eb6fcffa7b173f1435b47c02cbd7619c4bad7c309a4b61114af607c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49874", "10.65.0.27:49874", "172.17.0.1:49874"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:50:21.451386739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5076714345959160,
+				"StableID":   "n3vvMHgFeg11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:883ece89bf64cae19b9bd86357c02395a14e279ed9f6398b06f109d0029b8c10",
+				"DiscoKey":   "discokey:8f0ab5567d7dc5e3dcdab508665eb55d9d6fee250a95f55ffd49259ecd1fd555",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:44330", "10.65.0.27:44330", "172.17.0.1:44330"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:50:21.967228184Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         277005748087120,
+				"StableID":   "nsx1QLUTA311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:87ade86d5411e5bb58afa831628a1984b89cdadf423639dac9e2db7243faf27c",
+				"KeyExpiry":  "2026-10-26T10:50:22Z",
+				"DiscoKey":   "discokey:3b0039490cdc1b79097c576595be3d781a6164dde94c3e55564b8bab63a4ef25",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53020", "10.65.0.27:53020", "172.17.0.1:53020"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:50:22.525307366Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8823899147463364,
+				"StableID":   "nD72eLsMuB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:77826812501dd6ecba439abcb1d566b0f1a04e6e89630f6f486c0fdb34d32425",
+				"KeyExpiry":  "2026-10-26T10:50:23Z",
+				"DiscoKey":   "discokey:a28d130d7634693029d995d5c5d918baddc531407a87cb3c3aec25df54aa6f0d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37667", "10.65.0.27:37667", "172.17.0.1:37667"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:50:23.06014Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1411089010459308,
+				"StableID":   "n5hoo6v52C11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dfb5e47db74fb50f5a2bea49c7ce404f6985580e548de47a101c107f5e871a",
+				"KeyExpiry":  "2026-10-26T10:50:23Z",
+				"DiscoKey":   "discokey:7bb9970e454bf63a371b0c33ee06f3e6fed9100275e9c087c242b1ca4face234",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55712", "10.65.0.27:55712", "172.17.0.1:55712"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:50:23.615594748Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "554114001393793": {
+				"ID":          554114001393793,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         277005748087120,
+				"StableID":   "nsx1QLUTA311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:87ade86d5411e5bb58afa831628a1984b89cdadf423639dac9e2db7243faf27c",
+				"KeyExpiry":  "2026-10-26T10:50:22Z",
+				"DiscoKey":   "discokey:3b0039490cdc1b79097c576595be3d781a6164dde94c3e55564b8bab63a4ef25",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53020", "10.65.0.27:53020", "172.17.0.1:53020"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:50:22.525307366Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:87ade86d5411e5bb58afa831628a1984b89cdadf423639dac9e2db7243faf27c",
+			"MachineKey": "mkey:ff846cb10d8334a956ded6d1d5ab4019d99e8ca26a9cfb72e2c99215e375c845",
+			"Peers": [{
+				"ID":         554114001393793,
+				"StableID":   "nLU5qqdxK511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26e9199dcafe84751024081481d674ac60af5d66f31fac827f8c00bbb5713661",
+				"DiscoKey":   "discokey:92625c8a582613307fe7a2e91f24c9254482ca7291f988c29baaa4c4050a4a0e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41579", "10.65.0.27:41579", "172.17.0.1:41579"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:50:19.783721524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1657043148021718,
+				"StableID":   "nKXMiPiUwD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6eead39691234c90cdee3ceb471b838137c9474b389fce75484fac75ffc76e3e",
+				"DiscoKey":   "discokey:bcb4911a57b0c6a9e599434affa8d4ebce5f470579a3e4359d8a5b65f333dc62",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:45055", "10.65.0.27:45055", "172.17.0.1:45055"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:50:20.33229514Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2866306994367061,
+				"StableID":   "nvFLtQ2APP11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3d26fef3e24af0fbd32f9ba0962538dd030bc21aee1e450d41193642944294f",
+				"DiscoKey":   "discokey:f209afcfca1b67bc49ef124af241b6b6e6305af94973ea618ea5bf789611b825",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:51616", "10.65.0.27:51616", "172.17.0.1:51616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:50:20.874340795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         998842765349925,
+				"StableID":   "npAGoXuNo811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:37cdf08b99020523ec7360d75be9dd4f734ca35e00814aff4cb730c4cb5bc609",
+				"DiscoKey":   "discokey:337066a88eb6fcffa7b173f1435b47c02cbd7619c4bad7c309a4b61114af607c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49874", "10.65.0.27:49874", "172.17.0.1:49874"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:50:21.451386739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5076714345959160,
+				"StableID":   "n3vvMHgFeg11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:883ece89bf64cae19b9bd86357c02395a14e279ed9f6398b06f109d0029b8c10",
+				"DiscoKey":   "discokey:8f0ab5567d7dc5e3dcdab508665eb55d9d6fee250a95f55ffd49259ecd1fd555",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:44330", "10.65.0.27:44330", "172.17.0.1:44330"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:50:21.967228184Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8823899147463364,
+				"StableID":   "nD72eLsMuB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:77826812501dd6ecba439abcb1d566b0f1a04e6e89630f6f486c0fdb34d32425",
+				"KeyExpiry":  "2026-10-26T10:50:23Z",
+				"DiscoKey":   "discokey:a28d130d7634693029d995d5c5d918baddc531407a87cb3c3aec25df54aa6f0d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37667", "10.65.0.27:37667", "172.17.0.1:37667"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:50:23.06014Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1411089010459308,
+				"StableID":   "n5hoo6v52C11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dfb5e47db74fb50f5a2bea49c7ce404f6985580e548de47a101c107f5e871a",
+				"KeyExpiry":  "2026-10-26T10:50:23Z",
+				"DiscoKey":   "discokey:7bb9970e454bf63a371b0c33ee06f3e6fed9100275e9c087c242b1ca4face234",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55712", "10.65.0.27:55712", "172.17.0.1:55712"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:50:23.615594748Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         998842765349925,
+				"StableID":   "npAGoXuNo811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       998842765349925,
+				"Key":        "nodekey:37cdf08b99020523ec7360d75be9dd4f734ca35e00814aff4cb730c4cb5bc609",
+				"DiscoKey":   "discokey:337066a88eb6fcffa7b173f1435b47c02cbd7619c4bad7c309a4b61114af607c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49874", "10.65.0.27:49874", "172.17.0.1:49874"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:50:21.451386739Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:37cdf08b99020523ec7360d75be9dd4f734ca35e00814aff4cb730c4cb5bc609",
+			"MachineKey": "mkey:0fcfbcc5b7044d8679eaae5bcb871124462702755c5a5994fb6c4a5a9a366a04",
+			"Peers": [{
+				"ID":         554114001393793,
+				"StableID":   "nLU5qqdxK511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26e9199dcafe84751024081481d674ac60af5d66f31fac827f8c00bbb5713661",
+				"DiscoKey":   "discokey:92625c8a582613307fe7a2e91f24c9254482ca7291f988c29baaa4c4050a4a0e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41579", "10.65.0.27:41579", "172.17.0.1:41579"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:50:19.783721524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1657043148021718,
+				"StableID":   "nKXMiPiUwD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6eead39691234c90cdee3ceb471b838137c9474b389fce75484fac75ffc76e3e",
+				"DiscoKey":   "discokey:bcb4911a57b0c6a9e599434affa8d4ebce5f470579a3e4359d8a5b65f333dc62",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:45055", "10.65.0.27:45055", "172.17.0.1:45055"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:50:20.33229514Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2866306994367061,
+				"StableID":   "nvFLtQ2APP11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3d26fef3e24af0fbd32f9ba0962538dd030bc21aee1e450d41193642944294f",
+				"DiscoKey":   "discokey:f209afcfca1b67bc49ef124af241b6b6e6305af94973ea618ea5bf789611b825",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:51616", "10.65.0.27:51616", "172.17.0.1:51616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:50:20.874340795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5076714345959160,
+				"StableID":   "n3vvMHgFeg11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:883ece89bf64cae19b9bd86357c02395a14e279ed9f6398b06f109d0029b8c10",
+				"DiscoKey":   "discokey:8f0ab5567d7dc5e3dcdab508665eb55d9d6fee250a95f55ffd49259ecd1fd555",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:44330", "10.65.0.27:44330", "172.17.0.1:44330"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:50:21.967228184Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         277005748087120,
+				"StableID":   "nsx1QLUTA311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:87ade86d5411e5bb58afa831628a1984b89cdadf423639dac9e2db7243faf27c",
+				"KeyExpiry":  "2026-10-26T10:50:22Z",
+				"DiscoKey":   "discokey:3b0039490cdc1b79097c576595be3d781a6164dde94c3e55564b8bab63a4ef25",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53020", "10.65.0.27:53020", "172.17.0.1:53020"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:50:22.525307366Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8823899147463364,
+				"StableID":   "nD72eLsMuB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:77826812501dd6ecba439abcb1d566b0f1a04e6e89630f6f486c0fdb34d32425",
+				"KeyExpiry":  "2026-10-26T10:50:23Z",
+				"DiscoKey":   "discokey:a28d130d7634693029d995d5c5d918baddc531407a87cb3c3aec25df54aa6f0d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37667", "10.65.0.27:37667", "172.17.0.1:37667"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:50:23.06014Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1411089010459308,
+				"StableID":   "n5hoo6v52C11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dfb5e47db74fb50f5a2bea49c7ce404f6985580e548de47a101c107f5e871a",
+				"KeyExpiry":  "2026-10-26T10:50:23Z",
+				"DiscoKey":   "discokey:7bb9970e454bf63a371b0c33ee06f3e6fed9100275e9c087c242b1ca4face234",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55712", "10.65.0.27:55712", "172.17.0.1:55712"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:50:23.615594748Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "998842765349925": {
+				"ID":          998842765349925,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1657043148021718,
+				"StableID":   "nKXMiPiUwD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1657043148021718,
+				"Key":        "nodekey:6eead39691234c90cdee3ceb471b838137c9474b389fce75484fac75ffc76e3e",
+				"DiscoKey":   "discokey:bcb4911a57b0c6a9e599434affa8d4ebce5f470579a3e4359d8a5b65f333dc62",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:45055", "10.65.0.27:45055", "172.17.0.1:45055"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:50:20.33229514Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6eead39691234c90cdee3ceb471b838137c9474b389fce75484fac75ffc76e3e",
+			"MachineKey": "mkey:1fd2dfb4c5ad586443d1d1c9c8bac0be5289160c6216e37a9d87981a91e30801",
+			"Peers": [{
+				"ID":         554114001393793,
+				"StableID":   "nLU5qqdxK511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26e9199dcafe84751024081481d674ac60af5d66f31fac827f8c00bbb5713661",
+				"DiscoKey":   "discokey:92625c8a582613307fe7a2e91f24c9254482ca7291f988c29baaa4c4050a4a0e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41579", "10.65.0.27:41579", "172.17.0.1:41579"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:50:19.783721524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2866306994367061,
+				"StableID":   "nvFLtQ2APP11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3d26fef3e24af0fbd32f9ba0962538dd030bc21aee1e450d41193642944294f",
+				"DiscoKey":   "discokey:f209afcfca1b67bc49ef124af241b6b6e6305af94973ea618ea5bf789611b825",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:51616", "10.65.0.27:51616", "172.17.0.1:51616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:50:20.874340795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         998842765349925,
+				"StableID":   "npAGoXuNo811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:37cdf08b99020523ec7360d75be9dd4f734ca35e00814aff4cb730c4cb5bc609",
+				"DiscoKey":   "discokey:337066a88eb6fcffa7b173f1435b47c02cbd7619c4bad7c309a4b61114af607c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49874", "10.65.0.27:49874", "172.17.0.1:49874"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:50:21.451386739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5076714345959160,
+				"StableID":   "n3vvMHgFeg11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:883ece89bf64cae19b9bd86357c02395a14e279ed9f6398b06f109d0029b8c10",
+				"DiscoKey":   "discokey:8f0ab5567d7dc5e3dcdab508665eb55d9d6fee250a95f55ffd49259ecd1fd555",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:44330", "10.65.0.27:44330", "172.17.0.1:44330"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:50:21.967228184Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         277005748087120,
+				"StableID":   "nsx1QLUTA311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:87ade86d5411e5bb58afa831628a1984b89cdadf423639dac9e2db7243faf27c",
+				"KeyExpiry":  "2026-10-26T10:50:22Z",
+				"DiscoKey":   "discokey:3b0039490cdc1b79097c576595be3d781a6164dde94c3e55564b8bab63a4ef25",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53020", "10.65.0.27:53020", "172.17.0.1:53020"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:50:22.525307366Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8823899147463364,
+				"StableID":   "nD72eLsMuB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:77826812501dd6ecba439abcb1d566b0f1a04e6e89630f6f486c0fdb34d32425",
+				"KeyExpiry":  "2026-10-26T10:50:23Z",
+				"DiscoKey":   "discokey:a28d130d7634693029d995d5c5d918baddc531407a87cb3c3aec25df54aa6f0d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37667", "10.65.0.27:37667", "172.17.0.1:37667"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:50:23.06014Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1411089010459308,
+				"StableID":   "n5hoo6v52C11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dfb5e47db74fb50f5a2bea49c7ce404f6985580e548de47a101c107f5e871a",
+				"KeyExpiry":  "2026-10-26T10:50:23Z",
+				"DiscoKey":   "discokey:7bb9970e454bf63a371b0c33ee06f3e6fed9100275e9c087c242b1ca4face234",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55712", "10.65.0.27:55712", "172.17.0.1:55712"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:50:23.615594748Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1657043148021718": {
+				"ID":          1657043148021718,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8823899147463364,
+				"StableID":   "nD72eLsMuB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:77826812501dd6ecba439abcb1d566b0f1a04e6e89630f6f486c0fdb34d32425",
+				"KeyExpiry":  "2026-10-26T10:50:23Z",
+				"DiscoKey":   "discokey:a28d130d7634693029d995d5c5d918baddc531407a87cb3c3aec25df54aa6f0d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37667", "10.65.0.27:37667", "172.17.0.1:37667"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:50:23.06014Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:77826812501dd6ecba439abcb1d566b0f1a04e6e89630f6f486c0fdb34d32425",
+			"MachineKey": "mkey:96f7515edad80744a571c8bd33dfe978ba156dd74b3248d9b724d2e31aa2ee40",
+			"Peers": [{
+				"ID":         554114001393793,
+				"StableID":   "nLU5qqdxK511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26e9199dcafe84751024081481d674ac60af5d66f31fac827f8c00bbb5713661",
+				"DiscoKey":   "discokey:92625c8a582613307fe7a2e91f24c9254482ca7291f988c29baaa4c4050a4a0e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41579", "10.65.0.27:41579", "172.17.0.1:41579"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:50:19.783721524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1657043148021718,
+				"StableID":   "nKXMiPiUwD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6eead39691234c90cdee3ceb471b838137c9474b389fce75484fac75ffc76e3e",
+				"DiscoKey":   "discokey:bcb4911a57b0c6a9e599434affa8d4ebce5f470579a3e4359d8a5b65f333dc62",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:45055", "10.65.0.27:45055", "172.17.0.1:45055"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:50:20.33229514Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2866306994367061,
+				"StableID":   "nvFLtQ2APP11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3d26fef3e24af0fbd32f9ba0962538dd030bc21aee1e450d41193642944294f",
+				"DiscoKey":   "discokey:f209afcfca1b67bc49ef124af241b6b6e6305af94973ea618ea5bf789611b825",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:51616", "10.65.0.27:51616", "172.17.0.1:51616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:50:20.874340795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         998842765349925,
+				"StableID":   "npAGoXuNo811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:37cdf08b99020523ec7360d75be9dd4f734ca35e00814aff4cb730c4cb5bc609",
+				"DiscoKey":   "discokey:337066a88eb6fcffa7b173f1435b47c02cbd7619c4bad7c309a4b61114af607c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49874", "10.65.0.27:49874", "172.17.0.1:49874"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:50:21.451386739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5076714345959160,
+				"StableID":   "n3vvMHgFeg11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:883ece89bf64cae19b9bd86357c02395a14e279ed9f6398b06f109d0029b8c10",
+				"DiscoKey":   "discokey:8f0ab5567d7dc5e3dcdab508665eb55d9d6fee250a95f55ffd49259ecd1fd555",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:44330", "10.65.0.27:44330", "172.17.0.1:44330"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:50:21.967228184Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         277005748087120,
+				"StableID":   "nsx1QLUTA311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:87ade86d5411e5bb58afa831628a1984b89cdadf423639dac9e2db7243faf27c",
+				"KeyExpiry":  "2026-10-26T10:50:22Z",
+				"DiscoKey":   "discokey:3b0039490cdc1b79097c576595be3d781a6164dde94c3e55564b8bab63a4ef25",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53020", "10.65.0.27:53020", "172.17.0.1:53020"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:50:22.525307366Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1411089010459308,
+				"StableID":   "n5hoo6v52C11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dfb5e47db74fb50f5a2bea49c7ce404f6985580e548de47a101c107f5e871a",
+				"KeyExpiry":  "2026-10-26T10:50:23Z",
+				"DiscoKey":   "discokey:7bb9970e454bf63a371b0c33ee06f3e6fed9100275e9c087c242b1ca4face234",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55712", "10.65.0.27:55712", "172.17.0.1:55712"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:50:23.615594748Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2866306994367061,
+				"StableID":   "nvFLtQ2APP11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       2866306994367061,
+				"Key":        "nodekey:b3d26fef3e24af0fbd32f9ba0962538dd030bc21aee1e450d41193642944294f",
+				"DiscoKey":   "discokey:f209afcfca1b67bc49ef124af241b6b6e6305af94973ea618ea5bf789611b825",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:51616", "10.65.0.27:51616", "172.17.0.1:51616"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:50:20.874340795Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b3d26fef3e24af0fbd32f9ba0962538dd030bc21aee1e450d41193642944294f",
+			"MachineKey": "mkey:070f61e6b8a16914d3712b47956eb6aa7085adc715d36cde08e622d5365f8527",
+			"Peers": [{
+				"ID":         554114001393793,
+				"StableID":   "nLU5qqdxK511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26e9199dcafe84751024081481d674ac60af5d66f31fac827f8c00bbb5713661",
+				"DiscoKey":   "discokey:92625c8a582613307fe7a2e91f24c9254482ca7291f988c29baaa4c4050a4a0e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41579", "10.65.0.27:41579", "172.17.0.1:41579"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:50:19.783721524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1657043148021718,
+				"StableID":   "nKXMiPiUwD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6eead39691234c90cdee3ceb471b838137c9474b389fce75484fac75ffc76e3e",
+				"DiscoKey":   "discokey:bcb4911a57b0c6a9e599434affa8d4ebce5f470579a3e4359d8a5b65f333dc62",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:45055", "10.65.0.27:45055", "172.17.0.1:45055"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:50:20.33229514Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         998842765349925,
+				"StableID":   "npAGoXuNo811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:37cdf08b99020523ec7360d75be9dd4f734ca35e00814aff4cb730c4cb5bc609",
+				"DiscoKey":   "discokey:337066a88eb6fcffa7b173f1435b47c02cbd7619c4bad7c309a4b61114af607c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49874", "10.65.0.27:49874", "172.17.0.1:49874"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:50:21.451386739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5076714345959160,
+				"StableID":   "n3vvMHgFeg11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:883ece89bf64cae19b9bd86357c02395a14e279ed9f6398b06f109d0029b8c10",
+				"DiscoKey":   "discokey:8f0ab5567d7dc5e3dcdab508665eb55d9d6fee250a95f55ffd49259ecd1fd555",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:44330", "10.65.0.27:44330", "172.17.0.1:44330"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:50:21.967228184Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         277005748087120,
+				"StableID":   "nsx1QLUTA311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:87ade86d5411e5bb58afa831628a1984b89cdadf423639dac9e2db7243faf27c",
+				"KeyExpiry":  "2026-10-26T10:50:22Z",
+				"DiscoKey":   "discokey:3b0039490cdc1b79097c576595be3d781a6164dde94c3e55564b8bab63a4ef25",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:53020", "10.65.0.27:53020", "172.17.0.1:53020"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:50:22.525307366Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8823899147463364,
+				"StableID":   "nD72eLsMuB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:77826812501dd6ecba439abcb1d566b0f1a04e6e89630f6f486c0fdb34d32425",
+				"KeyExpiry":  "2026-10-26T10:50:23Z",
+				"DiscoKey":   "discokey:a28d130d7634693029d995d5c5d918baddc531407a87cb3c3aec25df54aa6f0d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37667", "10.65.0.27:37667", "172.17.0.1:37667"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:50:23.06014Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1411089010459308,
+				"StableID":   "n5hoo6v52C11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dfb5e47db74fb50f5a2bea49c7ce404f6985580e548de47a101c107f5e871a",
+				"KeyExpiry":  "2026-10-26T10:50:23Z",
+				"DiscoKey":   "discokey:7bb9970e454bf63a371b0c33ee06f3e6fed9100275e9c087c242b1ca4face234",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55712", "10.65.0.27:55712", "172.17.0.1:55712"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:50:23.615594748Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2866306994367061": {
+				"ID":          2866306994367061,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-dst-unknown-host.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-dst-unknown-host.hujson
@@ -1,0 +1,8831 @@
+// policytest-dst-unknown-host
+//
+// tests block dst-unknown: host alias not declared in hosts
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:50:45Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-dst-unknown-host",
+	"description":    "tests block dst-unknown: host alias not declared in hosts",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:50:45.338157704Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                              \n  \n                                                                  \n                                               \n{\n\t\"id\":          \"policytest-dst-unknown-host\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block dst-unknown: host alias not declared in hosts\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"thor@example.org\"], \"dst\": [\"webserver:80\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"accept\": [\"phantomhost:80\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-dst-unknown-host.hujson",
+		"full_policy": {"acls": [
+			{"action": "accept", "dst": ["webserver:80"], "src": ["thor@example.org"]}
+		], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [{"accept": ["phantomhost:80"], "src": "thor@example.org"}]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7859566196267704,
+				"StableID":   "nb8mwdUcN421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       7859566196267704,
+				"Key":        "nodekey:0718c1702238482bb84c3ba7c00c26b6a1a25348f27de456eb86291fb5145466",
+				"DiscoKey":   "discokey:52bf9c35dd5145169bf1b7f7ddb5d40c4d1030b7676a54f2e288c8361de9ab4a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45334", "10.65.0.27:45334", "172.17.0.1:45334"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:50:49.090009891Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0718c1702238482bb84c3ba7c00c26b6a1a25348f27de456eb86291fb5145466",
+			"MachineKey": "mkey:f0f0c94b0881f3e8df3990bc49f0af628cf99a41e562f31b136965660a069e40",
+			"Peers": [{
+				"ID":         5851115018506260,
+				"StableID":   "njt2zSsygn11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8795895648026b7b48bba8f9ccaf1bbc38439131923eeadda3e7aaf1494da39",
+				"DiscoKey":   "discokey:07d07a021580ccadf8519f5ba6ed005dd0c737de61e5582c501c7737a39feb1a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:48608", "10.65.0.27:48608", "172.17.0.1:48608"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:50:46.901801471Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4553431150168809,
+				"StableID":   "nADPF5vFZc11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d37482d9102ad8615df30ffd8fa45c5438571fc8f92a8307cd937a4d85e504b",
+				"DiscoKey":   "discokey:24b7720969d40e55956559c9c8f8d39442817492b5b9fb5a7aab481bed2d0e6c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60836", "10.65.0.27:60836", "172.17.0.1:60836"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:50:47.467223453Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2411421521921547,
+				"StableID":   "nQ5JNMx8qK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71bacbc90327d18f2800fd9e3a26034fc0362c1b4cde939be949affb9c79904e",
+				"DiscoKey":   "discokey:43bc6907c41395639fb8061b99dfbc20ab0b3918032d565dd2251b776e99353e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:39725", "10.65.0.27:39725", "172.17.0.1:39725"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:50:47.966661672Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         708000112672819,
+				"StableID":   "nx7RXpxeX611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55f8d395140c1328afd0159d8294740673587f1cf8ae2664f1c467c7df6f6d76",
+				"DiscoKey":   "discokey:f6993174cdf951b288dc9d976761c299160e1fe45a8b74269c5f7e713c7f2c34",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43420", "10.65.0.27:43420", "172.17.0.1:43420"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:50:48.509944845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8880028195986157,
+				"StableID":   "nSFBTQHnLC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:98842d00aaef095270136086093a9041f8132f6d3f6f3a6c19b5dcb63defe465",
+				"KeyExpiry":  "2026-10-26T10:50:49Z",
+				"DiscoKey":   "discokey:ef602ba0aa2f14b4f79b6b94c2abb74d2914ed810a6af2e37da744af3a5aa245",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:50:49.595951433Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1053418310827838,
+				"StableID":   "nVJFsjW6E911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3ee5f4d9d2a0da04ffe07d950aa93d9afa20429c2aa8284061dec178cac4791d",
+				"KeyExpiry":  "2026-10-26T10:50:50Z",
+				"DiscoKey":   "discokey:c81c09bb0cf0a5274eb97e113a4e9fc534d8f37323fc173e9dc587befaa4ad08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52173", "10.65.0.27:52173", "172.17.0.1:52173"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:50:50.122330646Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4239824197730575,
+				"StableID":   "nJUwkYzD7a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:70e84c459645b51eaa8df87b48619fc9fae891dccd2dff4f17d770c71833b059",
+				"KeyExpiry":  "2026-10-26T10:50:50Z",
+				"DiscoKey":   "discokey:89b1a4f6cfae7ef81a1b2a9d65115833e88dfee40714dab31dcab32ea4119440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36237", "10.65.0.27:36237", "172.17.0.1:36237"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:50:50.676461566Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7859566196267704": {
+				"ID":          7859566196267704,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4239824197730575,
+				"StableID":   "nJUwkYzD7a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:70e84c459645b51eaa8df87b48619fc9fae891dccd2dff4f17d770c71833b059",
+				"KeyExpiry":  "2026-10-26T10:50:50Z",
+				"DiscoKey":   "discokey:89b1a4f6cfae7ef81a1b2a9d65115833e88dfee40714dab31dcab32ea4119440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36237", "10.65.0.27:36237", "172.17.0.1:36237"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:50:50.676461566Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:70e84c459645b51eaa8df87b48619fc9fae891dccd2dff4f17d770c71833b059",
+			"MachineKey": "mkey:7eba819db1a1adb44e42171cf26e79ec631abb959c5f6bba72064fa3e4389b47",
+			"Peers": [{
+				"ID":         5851115018506260,
+				"StableID":   "njt2zSsygn11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8795895648026b7b48bba8f9ccaf1bbc38439131923eeadda3e7aaf1494da39",
+				"DiscoKey":   "discokey:07d07a021580ccadf8519f5ba6ed005dd0c737de61e5582c501c7737a39feb1a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:48608", "10.65.0.27:48608", "172.17.0.1:48608"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:50:46.901801471Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4553431150168809,
+				"StableID":   "nADPF5vFZc11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d37482d9102ad8615df30ffd8fa45c5438571fc8f92a8307cd937a4d85e504b",
+				"DiscoKey":   "discokey:24b7720969d40e55956559c9c8f8d39442817492b5b9fb5a7aab481bed2d0e6c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60836", "10.65.0.27:60836", "172.17.0.1:60836"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:50:47.467223453Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2411421521921547,
+				"StableID":   "nQ5JNMx8qK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71bacbc90327d18f2800fd9e3a26034fc0362c1b4cde939be949affb9c79904e",
+				"DiscoKey":   "discokey:43bc6907c41395639fb8061b99dfbc20ab0b3918032d565dd2251b776e99353e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:39725", "10.65.0.27:39725", "172.17.0.1:39725"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:50:47.966661672Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         708000112672819,
+				"StableID":   "nx7RXpxeX611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55f8d395140c1328afd0159d8294740673587f1cf8ae2664f1c467c7df6f6d76",
+				"DiscoKey":   "discokey:f6993174cdf951b288dc9d976761c299160e1fe45a8b74269c5f7e713c7f2c34",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43420", "10.65.0.27:43420", "172.17.0.1:43420"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:50:48.509944845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7859566196267704,
+				"StableID":   "nb8mwdUcN421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0718c1702238482bb84c3ba7c00c26b6a1a25348f27de456eb86291fb5145466",
+				"DiscoKey":   "discokey:52bf9c35dd5145169bf1b7f7ddb5d40c4d1030b7676a54f2e288c8361de9ab4a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45334", "10.65.0.27:45334", "172.17.0.1:45334"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:50:49.090009891Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8880028195986157,
+				"StableID":   "nSFBTQHnLC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:98842d00aaef095270136086093a9041f8132f6d3f6f3a6c19b5dcb63defe465",
+				"KeyExpiry":  "2026-10-26T10:50:49Z",
+				"DiscoKey":   "discokey:ef602ba0aa2f14b4f79b6b94c2abb74d2914ed810a6af2e37da744af3a5aa245",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:50:49.595951433Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1053418310827838,
+				"StableID":   "nVJFsjW6E911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3ee5f4d9d2a0da04ffe07d950aa93d9afa20429c2aa8284061dec178cac4791d",
+				"KeyExpiry":  "2026-10-26T10:50:50Z",
+				"DiscoKey":   "discokey:c81c09bb0cf0a5274eb97e113a4e9fc534d8f37323fc173e9dc587befaa4ad08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52173", "10.65.0.27:52173", "172.17.0.1:52173"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:50:50.122330646Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5851115018506260,
+				"StableID":   "njt2zSsygn11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       5851115018506260,
+				"Key":        "nodekey:a8795895648026b7b48bba8f9ccaf1bbc38439131923eeadda3e7aaf1494da39",
+				"DiscoKey":   "discokey:07d07a021580ccadf8519f5ba6ed005dd0c737de61e5582c501c7737a39feb1a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:48608", "10.65.0.27:48608", "172.17.0.1:48608"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:50:46.901801471Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a8795895648026b7b48bba8f9ccaf1bbc38439131923eeadda3e7aaf1494da39",
+			"MachineKey": "mkey:7cc0cdbe310992bfd9e854b956257f970a387220e9064c9325c78d8e1c8dc378",
+			"Peers": [{
+				"ID":         4553431150168809,
+				"StableID":   "nADPF5vFZc11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d37482d9102ad8615df30ffd8fa45c5438571fc8f92a8307cd937a4d85e504b",
+				"DiscoKey":   "discokey:24b7720969d40e55956559c9c8f8d39442817492b5b9fb5a7aab481bed2d0e6c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60836", "10.65.0.27:60836", "172.17.0.1:60836"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:50:47.467223453Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2411421521921547,
+				"StableID":   "nQ5JNMx8qK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71bacbc90327d18f2800fd9e3a26034fc0362c1b4cde939be949affb9c79904e",
+				"DiscoKey":   "discokey:43bc6907c41395639fb8061b99dfbc20ab0b3918032d565dd2251b776e99353e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:39725", "10.65.0.27:39725", "172.17.0.1:39725"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:50:47.966661672Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         708000112672819,
+				"StableID":   "nx7RXpxeX611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55f8d395140c1328afd0159d8294740673587f1cf8ae2664f1c467c7df6f6d76",
+				"DiscoKey":   "discokey:f6993174cdf951b288dc9d976761c299160e1fe45a8b74269c5f7e713c7f2c34",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43420", "10.65.0.27:43420", "172.17.0.1:43420"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:50:48.509944845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7859566196267704,
+				"StableID":   "nb8mwdUcN421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0718c1702238482bb84c3ba7c00c26b6a1a25348f27de456eb86291fb5145466",
+				"DiscoKey":   "discokey:52bf9c35dd5145169bf1b7f7ddb5d40c4d1030b7676a54f2e288c8361de9ab4a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45334", "10.65.0.27:45334", "172.17.0.1:45334"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:50:49.090009891Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8880028195986157,
+				"StableID":   "nSFBTQHnLC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:98842d00aaef095270136086093a9041f8132f6d3f6f3a6c19b5dcb63defe465",
+				"KeyExpiry":  "2026-10-26T10:50:49Z",
+				"DiscoKey":   "discokey:ef602ba0aa2f14b4f79b6b94c2abb74d2914ed810a6af2e37da744af3a5aa245",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:50:49.595951433Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1053418310827838,
+				"StableID":   "nVJFsjW6E911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3ee5f4d9d2a0da04ffe07d950aa93d9afa20429c2aa8284061dec178cac4791d",
+				"KeyExpiry":  "2026-10-26T10:50:50Z",
+				"DiscoKey":   "discokey:c81c09bb0cf0a5274eb97e113a4e9fc534d8f37323fc173e9dc587befaa4ad08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52173", "10.65.0.27:52173", "172.17.0.1:52173"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:50:50.122330646Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4239824197730575,
+				"StableID":   "nJUwkYzD7a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:70e84c459645b51eaa8df87b48619fc9fae891dccd2dff4f17d770c71833b059",
+				"KeyExpiry":  "2026-10-26T10:50:50Z",
+				"DiscoKey":   "discokey:89b1a4f6cfae7ef81a1b2a9d65115833e88dfee40714dab31dcab32ea4119440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36237", "10.65.0.27:36237", "172.17.0.1:36237"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:50:50.676461566Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5851115018506260": {
+				"ID":          5851115018506260,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8880028195986157,
+				"StableID":   "nSFBTQHnLC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:98842d00aaef095270136086093a9041f8132f6d3f6f3a6c19b5dcb63defe465",
+				"KeyExpiry":  "2026-10-26T10:50:49Z",
+				"DiscoKey":   "discokey:ef602ba0aa2f14b4f79b6b94c2abb74d2914ed810a6af2e37da744af3a5aa245",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:50:49.595951433Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:98842d00aaef095270136086093a9041f8132f6d3f6f3a6c19b5dcb63defe465",
+			"MachineKey": "mkey:1225cf5c27ef6a806640f32d530cc94aaadba1fde50c9b89dd27ceb345d9f775",
+			"Peers": [{
+				"ID":         5851115018506260,
+				"StableID":   "njt2zSsygn11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8795895648026b7b48bba8f9ccaf1bbc38439131923eeadda3e7aaf1494da39",
+				"DiscoKey":   "discokey:07d07a021580ccadf8519f5ba6ed005dd0c737de61e5582c501c7737a39feb1a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:48608", "10.65.0.27:48608", "172.17.0.1:48608"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:50:46.901801471Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4553431150168809,
+				"StableID":   "nADPF5vFZc11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d37482d9102ad8615df30ffd8fa45c5438571fc8f92a8307cd937a4d85e504b",
+				"DiscoKey":   "discokey:24b7720969d40e55956559c9c8f8d39442817492b5b9fb5a7aab481bed2d0e6c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60836", "10.65.0.27:60836", "172.17.0.1:60836"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:50:47.467223453Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2411421521921547,
+				"StableID":   "nQ5JNMx8qK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71bacbc90327d18f2800fd9e3a26034fc0362c1b4cde939be949affb9c79904e",
+				"DiscoKey":   "discokey:43bc6907c41395639fb8061b99dfbc20ab0b3918032d565dd2251b776e99353e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:39725", "10.65.0.27:39725", "172.17.0.1:39725"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:50:47.966661672Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         708000112672819,
+				"StableID":   "nx7RXpxeX611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55f8d395140c1328afd0159d8294740673587f1cf8ae2664f1c467c7df6f6d76",
+				"DiscoKey":   "discokey:f6993174cdf951b288dc9d976761c299160e1fe45a8b74269c5f7e713c7f2c34",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43420", "10.65.0.27:43420", "172.17.0.1:43420"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:50:48.509944845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7859566196267704,
+				"StableID":   "nb8mwdUcN421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0718c1702238482bb84c3ba7c00c26b6a1a25348f27de456eb86291fb5145466",
+				"DiscoKey":   "discokey:52bf9c35dd5145169bf1b7f7ddb5d40c4d1030b7676a54f2e288c8361de9ab4a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45334", "10.65.0.27:45334", "172.17.0.1:45334"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:50:49.090009891Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1053418310827838,
+				"StableID":   "nVJFsjW6E911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3ee5f4d9d2a0da04ffe07d950aa93d9afa20429c2aa8284061dec178cac4791d",
+				"KeyExpiry":  "2026-10-26T10:50:50Z",
+				"DiscoKey":   "discokey:c81c09bb0cf0a5274eb97e113a4e9fc534d8f37323fc173e9dc587befaa4ad08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52173", "10.65.0.27:52173", "172.17.0.1:52173"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:50:50.122330646Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4239824197730575,
+				"StableID":   "nJUwkYzD7a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:70e84c459645b51eaa8df87b48619fc9fae891dccd2dff4f17d770c71833b059",
+				"KeyExpiry":  "2026-10-26T10:50:50Z",
+				"DiscoKey":   "discokey:89b1a4f6cfae7ef81a1b2a9d65115833e88dfee40714dab31dcab32ea4119440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36237", "10.65.0.27:36237", "172.17.0.1:36237"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:50:50.676461566Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         708000112672819,
+				"StableID":   "nx7RXpxeX611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       708000112672819,
+				"Key":        "nodekey:55f8d395140c1328afd0159d8294740673587f1cf8ae2664f1c467c7df6f6d76",
+				"DiscoKey":   "discokey:f6993174cdf951b288dc9d976761c299160e1fe45a8b74269c5f7e713c7f2c34",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43420", "10.65.0.27:43420", "172.17.0.1:43420"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:50:48.509944845Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:55f8d395140c1328afd0159d8294740673587f1cf8ae2664f1c467c7df6f6d76",
+			"MachineKey": "mkey:07d52c6f4036842f249e5caaa282054b686d2865135fbbaad5e910e62926ee39",
+			"Peers": [{
+				"ID":         5851115018506260,
+				"StableID":   "njt2zSsygn11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8795895648026b7b48bba8f9ccaf1bbc38439131923eeadda3e7aaf1494da39",
+				"DiscoKey":   "discokey:07d07a021580ccadf8519f5ba6ed005dd0c737de61e5582c501c7737a39feb1a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:48608", "10.65.0.27:48608", "172.17.0.1:48608"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:50:46.901801471Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4553431150168809,
+				"StableID":   "nADPF5vFZc11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d37482d9102ad8615df30ffd8fa45c5438571fc8f92a8307cd937a4d85e504b",
+				"DiscoKey":   "discokey:24b7720969d40e55956559c9c8f8d39442817492b5b9fb5a7aab481bed2d0e6c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60836", "10.65.0.27:60836", "172.17.0.1:60836"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:50:47.467223453Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2411421521921547,
+				"StableID":   "nQ5JNMx8qK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71bacbc90327d18f2800fd9e3a26034fc0362c1b4cde939be949affb9c79904e",
+				"DiscoKey":   "discokey:43bc6907c41395639fb8061b99dfbc20ab0b3918032d565dd2251b776e99353e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:39725", "10.65.0.27:39725", "172.17.0.1:39725"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:50:47.966661672Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7859566196267704,
+				"StableID":   "nb8mwdUcN421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0718c1702238482bb84c3ba7c00c26b6a1a25348f27de456eb86291fb5145466",
+				"DiscoKey":   "discokey:52bf9c35dd5145169bf1b7f7ddb5d40c4d1030b7676a54f2e288c8361de9ab4a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45334", "10.65.0.27:45334", "172.17.0.1:45334"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:50:49.090009891Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8880028195986157,
+				"StableID":   "nSFBTQHnLC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:98842d00aaef095270136086093a9041f8132f6d3f6f3a6c19b5dcb63defe465",
+				"KeyExpiry":  "2026-10-26T10:50:49Z",
+				"DiscoKey":   "discokey:ef602ba0aa2f14b4f79b6b94c2abb74d2914ed810a6af2e37da744af3a5aa245",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:50:49.595951433Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1053418310827838,
+				"StableID":   "nVJFsjW6E911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3ee5f4d9d2a0da04ffe07d950aa93d9afa20429c2aa8284061dec178cac4791d",
+				"KeyExpiry":  "2026-10-26T10:50:50Z",
+				"DiscoKey":   "discokey:c81c09bb0cf0a5274eb97e113a4e9fc534d8f37323fc173e9dc587befaa4ad08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52173", "10.65.0.27:52173", "172.17.0.1:52173"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:50:50.122330646Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4239824197730575,
+				"StableID":   "nJUwkYzD7a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:70e84c459645b51eaa8df87b48619fc9fae891dccd2dff4f17d770c71833b059",
+				"KeyExpiry":  "2026-10-26T10:50:50Z",
+				"DiscoKey":   "discokey:89b1a4f6cfae7ef81a1b2a9d65115833e88dfee40714dab31dcab32ea4119440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36237", "10.65.0.27:36237", "172.17.0.1:36237"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:50:50.676461566Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "708000112672819": {
+				"ID":          708000112672819,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4553431150168809,
+				"StableID":   "nADPF5vFZc11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       4553431150168809,
+				"Key":        "nodekey:8d37482d9102ad8615df30ffd8fa45c5438571fc8f92a8307cd937a4d85e504b",
+				"DiscoKey":   "discokey:24b7720969d40e55956559c9c8f8d39442817492b5b9fb5a7aab481bed2d0e6c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60836", "10.65.0.27:60836", "172.17.0.1:60836"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:50:47.467223453Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8d37482d9102ad8615df30ffd8fa45c5438571fc8f92a8307cd937a4d85e504b",
+			"MachineKey": "mkey:ffad6a98503a6236f5b7c7600423760ed7cb993700832aade43868f109a2e831",
+			"Peers": [{
+				"ID":         5851115018506260,
+				"StableID":   "njt2zSsygn11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8795895648026b7b48bba8f9ccaf1bbc38439131923eeadda3e7aaf1494da39",
+				"DiscoKey":   "discokey:07d07a021580ccadf8519f5ba6ed005dd0c737de61e5582c501c7737a39feb1a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:48608", "10.65.0.27:48608", "172.17.0.1:48608"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:50:46.901801471Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2411421521921547,
+				"StableID":   "nQ5JNMx8qK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71bacbc90327d18f2800fd9e3a26034fc0362c1b4cde939be949affb9c79904e",
+				"DiscoKey":   "discokey:43bc6907c41395639fb8061b99dfbc20ab0b3918032d565dd2251b776e99353e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:39725", "10.65.0.27:39725", "172.17.0.1:39725"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:50:47.966661672Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         708000112672819,
+				"StableID":   "nx7RXpxeX611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55f8d395140c1328afd0159d8294740673587f1cf8ae2664f1c467c7df6f6d76",
+				"DiscoKey":   "discokey:f6993174cdf951b288dc9d976761c299160e1fe45a8b74269c5f7e713c7f2c34",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43420", "10.65.0.27:43420", "172.17.0.1:43420"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:50:48.509944845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7859566196267704,
+				"StableID":   "nb8mwdUcN421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0718c1702238482bb84c3ba7c00c26b6a1a25348f27de456eb86291fb5145466",
+				"DiscoKey":   "discokey:52bf9c35dd5145169bf1b7f7ddb5d40c4d1030b7676a54f2e288c8361de9ab4a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45334", "10.65.0.27:45334", "172.17.0.1:45334"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:50:49.090009891Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8880028195986157,
+				"StableID":   "nSFBTQHnLC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:98842d00aaef095270136086093a9041f8132f6d3f6f3a6c19b5dcb63defe465",
+				"KeyExpiry":  "2026-10-26T10:50:49Z",
+				"DiscoKey":   "discokey:ef602ba0aa2f14b4f79b6b94c2abb74d2914ed810a6af2e37da744af3a5aa245",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:50:49.595951433Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1053418310827838,
+				"StableID":   "nVJFsjW6E911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3ee5f4d9d2a0da04ffe07d950aa93d9afa20429c2aa8284061dec178cac4791d",
+				"KeyExpiry":  "2026-10-26T10:50:50Z",
+				"DiscoKey":   "discokey:c81c09bb0cf0a5274eb97e113a4e9fc534d8f37323fc173e9dc587befaa4ad08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52173", "10.65.0.27:52173", "172.17.0.1:52173"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:50:50.122330646Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4239824197730575,
+				"StableID":   "nJUwkYzD7a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:70e84c459645b51eaa8df87b48619fc9fae891dccd2dff4f17d770c71833b059",
+				"KeyExpiry":  "2026-10-26T10:50:50Z",
+				"DiscoKey":   "discokey:89b1a4f6cfae7ef81a1b2a9d65115833e88dfee40714dab31dcab32ea4119440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36237", "10.65.0.27:36237", "172.17.0.1:36237"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:50:50.676461566Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4553431150168809": {
+				"ID":          4553431150168809,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1053418310827838,
+				"StableID":   "nVJFsjW6E911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3ee5f4d9d2a0da04ffe07d950aa93d9afa20429c2aa8284061dec178cac4791d",
+				"KeyExpiry":  "2026-10-26T10:50:50Z",
+				"DiscoKey":   "discokey:c81c09bb0cf0a5274eb97e113a4e9fc534d8f37323fc173e9dc587befaa4ad08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52173", "10.65.0.27:52173", "172.17.0.1:52173"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:50:50.122330646Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3ee5f4d9d2a0da04ffe07d950aa93d9afa20429c2aa8284061dec178cac4791d",
+			"MachineKey": "mkey:aba56327544ddc43c03ee717caa4da3b93211f5eb015bd7b748737307f62eb4e",
+			"Peers": [{
+				"ID":         5851115018506260,
+				"StableID":   "njt2zSsygn11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8795895648026b7b48bba8f9ccaf1bbc38439131923eeadda3e7aaf1494da39",
+				"DiscoKey":   "discokey:07d07a021580ccadf8519f5ba6ed005dd0c737de61e5582c501c7737a39feb1a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:48608", "10.65.0.27:48608", "172.17.0.1:48608"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:50:46.901801471Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4553431150168809,
+				"StableID":   "nADPF5vFZc11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d37482d9102ad8615df30ffd8fa45c5438571fc8f92a8307cd937a4d85e504b",
+				"DiscoKey":   "discokey:24b7720969d40e55956559c9c8f8d39442817492b5b9fb5a7aab481bed2d0e6c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60836", "10.65.0.27:60836", "172.17.0.1:60836"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:50:47.467223453Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2411421521921547,
+				"StableID":   "nQ5JNMx8qK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71bacbc90327d18f2800fd9e3a26034fc0362c1b4cde939be949affb9c79904e",
+				"DiscoKey":   "discokey:43bc6907c41395639fb8061b99dfbc20ab0b3918032d565dd2251b776e99353e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:39725", "10.65.0.27:39725", "172.17.0.1:39725"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:50:47.966661672Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         708000112672819,
+				"StableID":   "nx7RXpxeX611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55f8d395140c1328afd0159d8294740673587f1cf8ae2664f1c467c7df6f6d76",
+				"DiscoKey":   "discokey:f6993174cdf951b288dc9d976761c299160e1fe45a8b74269c5f7e713c7f2c34",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43420", "10.65.0.27:43420", "172.17.0.1:43420"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:50:48.509944845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7859566196267704,
+				"StableID":   "nb8mwdUcN421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0718c1702238482bb84c3ba7c00c26b6a1a25348f27de456eb86291fb5145466",
+				"DiscoKey":   "discokey:52bf9c35dd5145169bf1b7f7ddb5d40c4d1030b7676a54f2e288c8361de9ab4a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45334", "10.65.0.27:45334", "172.17.0.1:45334"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:50:49.090009891Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8880028195986157,
+				"StableID":   "nSFBTQHnLC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:98842d00aaef095270136086093a9041f8132f6d3f6f3a6c19b5dcb63defe465",
+				"KeyExpiry":  "2026-10-26T10:50:49Z",
+				"DiscoKey":   "discokey:ef602ba0aa2f14b4f79b6b94c2abb74d2914ed810a6af2e37da744af3a5aa245",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:50:49.595951433Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4239824197730575,
+				"StableID":   "nJUwkYzD7a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:70e84c459645b51eaa8df87b48619fc9fae891dccd2dff4f17d770c71833b059",
+				"KeyExpiry":  "2026-10-26T10:50:50Z",
+				"DiscoKey":   "discokey:89b1a4f6cfae7ef81a1b2a9d65115833e88dfee40714dab31dcab32ea4119440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36237", "10.65.0.27:36237", "172.17.0.1:36237"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:50:50.676461566Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2411421521921547,
+				"StableID":   "nQ5JNMx8qK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       2411421521921547,
+				"Key":        "nodekey:71bacbc90327d18f2800fd9e3a26034fc0362c1b4cde939be949affb9c79904e",
+				"DiscoKey":   "discokey:43bc6907c41395639fb8061b99dfbc20ab0b3918032d565dd2251b776e99353e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:39725", "10.65.0.27:39725", "172.17.0.1:39725"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:50:47.966661672Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:71bacbc90327d18f2800fd9e3a26034fc0362c1b4cde939be949affb9c79904e",
+			"MachineKey": "mkey:4667d957b5a4d5c8b7d68264723479202f8207f51562306da877e791df6bc208",
+			"Peers": [{
+				"ID":         5851115018506260,
+				"StableID":   "njt2zSsygn11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8795895648026b7b48bba8f9ccaf1bbc38439131923eeadda3e7aaf1494da39",
+				"DiscoKey":   "discokey:07d07a021580ccadf8519f5ba6ed005dd0c737de61e5582c501c7737a39feb1a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:48608", "10.65.0.27:48608", "172.17.0.1:48608"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:50:46.901801471Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4553431150168809,
+				"StableID":   "nADPF5vFZc11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d37482d9102ad8615df30ffd8fa45c5438571fc8f92a8307cd937a4d85e504b",
+				"DiscoKey":   "discokey:24b7720969d40e55956559c9c8f8d39442817492b5b9fb5a7aab481bed2d0e6c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60836", "10.65.0.27:60836", "172.17.0.1:60836"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:50:47.467223453Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         708000112672819,
+				"StableID":   "nx7RXpxeX611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55f8d395140c1328afd0159d8294740673587f1cf8ae2664f1c467c7df6f6d76",
+				"DiscoKey":   "discokey:f6993174cdf951b288dc9d976761c299160e1fe45a8b74269c5f7e713c7f2c34",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43420", "10.65.0.27:43420", "172.17.0.1:43420"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:50:48.509944845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7859566196267704,
+				"StableID":   "nb8mwdUcN421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0718c1702238482bb84c3ba7c00c26b6a1a25348f27de456eb86291fb5145466",
+				"DiscoKey":   "discokey:52bf9c35dd5145169bf1b7f7ddb5d40c4d1030b7676a54f2e288c8361de9ab4a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45334", "10.65.0.27:45334", "172.17.0.1:45334"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:50:49.090009891Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8880028195986157,
+				"StableID":   "nSFBTQHnLC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:98842d00aaef095270136086093a9041f8132f6d3f6f3a6c19b5dcb63defe465",
+				"KeyExpiry":  "2026-10-26T10:50:49Z",
+				"DiscoKey":   "discokey:ef602ba0aa2f14b4f79b6b94c2abb74d2914ed810a6af2e37da744af3a5aa245",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:50:49.595951433Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1053418310827838,
+				"StableID":   "nVJFsjW6E911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3ee5f4d9d2a0da04ffe07d950aa93d9afa20429c2aa8284061dec178cac4791d",
+				"KeyExpiry":  "2026-10-26T10:50:50Z",
+				"DiscoKey":   "discokey:c81c09bb0cf0a5274eb97e113a4e9fc534d8f37323fc173e9dc587befaa4ad08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52173", "10.65.0.27:52173", "172.17.0.1:52173"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:50:50.122330646Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4239824197730575,
+				"StableID":   "nJUwkYzD7a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:70e84c459645b51eaa8df87b48619fc9fae891dccd2dff4f17d770c71833b059",
+				"KeyExpiry":  "2026-10-26T10:50:50Z",
+				"DiscoKey":   "discokey:89b1a4f6cfae7ef81a1b2a9d65115833e88dfee40714dab31dcab32ea4119440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36237", "10.65.0.27:36237", "172.17.0.1:36237"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:50:50.676461566Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2411421521921547": {
+				"ID":          2411421521921547,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-dst-unknown-tag.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-dst-unknown-tag.hujson
@@ -1,0 +1,8841 @@
+// policytest-dst-unknown-tag
+//
+// tests block dst-unknown: tag not declared in tagOwners
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:51:12Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-dst-unknown-tag",
+	"description":    "tests block dst-unknown: tag not declared in tagOwners",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:51:12.392490123Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                             \n  \n                                                                    \n                                   \n{\n\t\"id\":          \"policytest-dst-unknown-tag\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block dst-unknown: tag not declared in tagOwners\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"thor@example.org\"], \"dst\": [\"tag:server:22\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"accept\": [\"tag:phantom:22\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-dst-unknown-tag.hujson",
+		"full_policy": {"acls": [{
+			"action": "accept",
+			"dst":    ["tag:server:22"],
+			"src":    ["thor@example.org"]
+		}], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [{"accept": ["tag:phantom:22"], "src": "thor@example.org"}]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6903357444160319,
+				"StableID":   "ngFQueVYuv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6903357444160319,
+				"Key":        "nodekey:4708b632722beb4bacebe536d21ee3adb7b2a1c15a0d9a599bd042be2a7f5f62",
+				"DiscoKey":   "discokey:8eadea401feb8011fb08bd67c9d0620f34f82058ddf10f44f5795cdecffbd85d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39055", "10.65.0.27:39055", "172.17.0.1:39055"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:51:15.98002073Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4708b632722beb4bacebe536d21ee3adb7b2a1c15a0d9a599bd042be2a7f5f62",
+			"MachineKey": "mkey:71c1d966b5cc833d950a0682f1f5ad9994259a50534579574481aacb3a3efe53",
+			"Peers": [{
+				"ID":         3784782026058228,
+				"StableID":   "nKUQGko8ZW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51934a2de6e0f0a83bc23e8a4636c80dbd43280d2c0f483a2abba96576d48c3b",
+				"DiscoKey":   "discokey:e38c198cc17bd769ce465790302189881f67b572d94bd1296ad9fc9e7e03d052",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:49719", "10.65.0.27:49719", "172.17.0.1:49719"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:51:13.820997769Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1719303245599320,
+				"StableID":   "nq7WLVBgRE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f088d3674a49608ae75fcaa669f65ca74059332716f8a5856aaea4cf09995a03",
+				"DiscoKey":   "discokey:7608cf95a7b425990f185b78cd3127f41e294298be9a70cfba11aff7bb78c542",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58234", "10.65.0.27:58234", "172.17.0.1:58234"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:51:14.364113905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4840310672134031,
+				"StableID":   "nx1REikBoe11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:854e2ce50518e395dff7be4688097f86adb500b75e4d56a88bd346c3ed9ace25",
+				"DiscoKey":   "discokey:7f057096c9b8bdd90c07c140f97b06731dce81772df1edd9eb75a2dd4aa65142",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:48023", "10.65.0.27:48023", "172.17.0.1:48023"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:51:14.907734971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         271398802519235,
+				"StableID":   "nWgPpoBv7311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23d3349a2dfef1b7da608608e4afd1caaa89eb4cc5a1e6fed1ee132299cc2a2f",
+				"DiscoKey":   "discokey:5579b7fa0a9c66612ef8471ce65ce6d79e9c44578f16d35464cfc3463fb3f572",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55658", "10.65.0.27:55658", "172.17.0.1:55658"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:51:15.447239849Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2248819110001156,
+				"StableID":   "n17q2ZfVZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e480b2d67151cc66dc60b21e1c6c8575afb4c947e9bf07649c58933d1ec50b4b",
+				"KeyExpiry":  "2026-10-26T10:51:16Z",
+				"DiscoKey":   "discokey:5df7c5e0a8e2ef91c67717a45bcdde4f95ba3d7d7252fb82c62738aa9650040c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58054", "10.65.0.27:58054", "172.17.0.1:58054"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:51:16.51166619Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7187277700115296,
+				"StableID":   "ndVcgfb88y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c825ed675cdf0977d4ad8e36ea4366426ddda2cb5b1ce5ffd64166a122e1cd72",
+				"KeyExpiry":  "2026-10-26T10:51:17Z",
+				"DiscoKey":   "discokey:a312c0440244a3553fcb37ae791e07de0c573c1f1f43e8e11078928257fc2b6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37555", "10.65.0.27:37555", "172.17.0.1:37555"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:51:17.07397491Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2177883883156765,
+				"StableID":   "nWTcwMKN1J11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6107283aa8f6cd60c4ea290315c7db25088ee80a748f71046b5afb31e1383153",
+				"KeyExpiry":  "2026-10-26T10:51:17Z",
+				"DiscoKey":   "discokey:9f5c2fe66e948d809cd572d97d04a12bb76daa4cb458f2b1c89d77411f50006a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53597", "10.65.0.27:53597", "172.17.0.1:53597"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:51:17.601412523Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6903357444160319": {
+				"ID":          6903357444160319,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2177883883156765,
+				"StableID":   "nWTcwMKN1J11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6107283aa8f6cd60c4ea290315c7db25088ee80a748f71046b5afb31e1383153",
+				"KeyExpiry":  "2026-10-26T10:51:17Z",
+				"DiscoKey":   "discokey:9f5c2fe66e948d809cd572d97d04a12bb76daa4cb458f2b1c89d77411f50006a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53597", "10.65.0.27:53597", "172.17.0.1:53597"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:51:17.601412523Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6107283aa8f6cd60c4ea290315c7db25088ee80a748f71046b5afb31e1383153",
+			"MachineKey": "mkey:1c6ddd4d91b6fcca7791b7619c296f3bf2d182c3ffa36b97a773dc8df222187d",
+			"Peers": [{
+				"ID":         3784782026058228,
+				"StableID":   "nKUQGko8ZW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51934a2de6e0f0a83bc23e8a4636c80dbd43280d2c0f483a2abba96576d48c3b",
+				"DiscoKey":   "discokey:e38c198cc17bd769ce465790302189881f67b572d94bd1296ad9fc9e7e03d052",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:49719", "10.65.0.27:49719", "172.17.0.1:49719"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:51:13.820997769Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1719303245599320,
+				"StableID":   "nq7WLVBgRE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f088d3674a49608ae75fcaa669f65ca74059332716f8a5856aaea4cf09995a03",
+				"DiscoKey":   "discokey:7608cf95a7b425990f185b78cd3127f41e294298be9a70cfba11aff7bb78c542",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58234", "10.65.0.27:58234", "172.17.0.1:58234"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:51:14.364113905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4840310672134031,
+				"StableID":   "nx1REikBoe11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:854e2ce50518e395dff7be4688097f86adb500b75e4d56a88bd346c3ed9ace25",
+				"DiscoKey":   "discokey:7f057096c9b8bdd90c07c140f97b06731dce81772df1edd9eb75a2dd4aa65142",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:48023", "10.65.0.27:48023", "172.17.0.1:48023"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:51:14.907734971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         271398802519235,
+				"StableID":   "nWgPpoBv7311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23d3349a2dfef1b7da608608e4afd1caaa89eb4cc5a1e6fed1ee132299cc2a2f",
+				"DiscoKey":   "discokey:5579b7fa0a9c66612ef8471ce65ce6d79e9c44578f16d35464cfc3463fb3f572",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55658", "10.65.0.27:55658", "172.17.0.1:55658"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:51:15.447239849Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6903357444160319,
+				"StableID":   "ngFQueVYuv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4708b632722beb4bacebe536d21ee3adb7b2a1c15a0d9a599bd042be2a7f5f62",
+				"DiscoKey":   "discokey:8eadea401feb8011fb08bd67c9d0620f34f82058ddf10f44f5795cdecffbd85d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39055", "10.65.0.27:39055", "172.17.0.1:39055"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:51:15.98002073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2248819110001156,
+				"StableID":   "n17q2ZfVZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e480b2d67151cc66dc60b21e1c6c8575afb4c947e9bf07649c58933d1ec50b4b",
+				"KeyExpiry":  "2026-10-26T10:51:16Z",
+				"DiscoKey":   "discokey:5df7c5e0a8e2ef91c67717a45bcdde4f95ba3d7d7252fb82c62738aa9650040c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58054", "10.65.0.27:58054", "172.17.0.1:58054"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:51:16.51166619Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7187277700115296,
+				"StableID":   "ndVcgfb88y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c825ed675cdf0977d4ad8e36ea4366426ddda2cb5b1ce5ffd64166a122e1cd72",
+				"KeyExpiry":  "2026-10-26T10:51:17Z",
+				"DiscoKey":   "discokey:a312c0440244a3553fcb37ae791e07de0c573c1f1f43e8e11078928257fc2b6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37555", "10.65.0.27:37555", "172.17.0.1:37555"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:51:17.07397491Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3784782026058228,
+				"StableID":   "nKUQGko8ZW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       3784782026058228,
+				"Key":        "nodekey:51934a2de6e0f0a83bc23e8a4636c80dbd43280d2c0f483a2abba96576d48c3b",
+				"DiscoKey":   "discokey:e38c198cc17bd769ce465790302189881f67b572d94bd1296ad9fc9e7e03d052",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:49719", "10.65.0.27:49719", "172.17.0.1:49719"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:51:13.820997769Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:51934a2de6e0f0a83bc23e8a4636c80dbd43280d2c0f483a2abba96576d48c3b",
+			"MachineKey": "mkey:d660141ca7ba2a6afeef398325c8926d49e4669b55862ba1f77cab163e1aa42d",
+			"Peers": [{
+				"ID":         1719303245599320,
+				"StableID":   "nq7WLVBgRE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f088d3674a49608ae75fcaa669f65ca74059332716f8a5856aaea4cf09995a03",
+				"DiscoKey":   "discokey:7608cf95a7b425990f185b78cd3127f41e294298be9a70cfba11aff7bb78c542",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58234", "10.65.0.27:58234", "172.17.0.1:58234"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:51:14.364113905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4840310672134031,
+				"StableID":   "nx1REikBoe11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:854e2ce50518e395dff7be4688097f86adb500b75e4d56a88bd346c3ed9ace25",
+				"DiscoKey":   "discokey:7f057096c9b8bdd90c07c140f97b06731dce81772df1edd9eb75a2dd4aa65142",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:48023", "10.65.0.27:48023", "172.17.0.1:48023"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:51:14.907734971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         271398802519235,
+				"StableID":   "nWgPpoBv7311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23d3349a2dfef1b7da608608e4afd1caaa89eb4cc5a1e6fed1ee132299cc2a2f",
+				"DiscoKey":   "discokey:5579b7fa0a9c66612ef8471ce65ce6d79e9c44578f16d35464cfc3463fb3f572",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55658", "10.65.0.27:55658", "172.17.0.1:55658"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:51:15.447239849Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6903357444160319,
+				"StableID":   "ngFQueVYuv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4708b632722beb4bacebe536d21ee3adb7b2a1c15a0d9a599bd042be2a7f5f62",
+				"DiscoKey":   "discokey:8eadea401feb8011fb08bd67c9d0620f34f82058ddf10f44f5795cdecffbd85d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39055", "10.65.0.27:39055", "172.17.0.1:39055"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:51:15.98002073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2248819110001156,
+				"StableID":   "n17q2ZfVZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e480b2d67151cc66dc60b21e1c6c8575afb4c947e9bf07649c58933d1ec50b4b",
+				"KeyExpiry":  "2026-10-26T10:51:16Z",
+				"DiscoKey":   "discokey:5df7c5e0a8e2ef91c67717a45bcdde4f95ba3d7d7252fb82c62738aa9650040c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58054", "10.65.0.27:58054", "172.17.0.1:58054"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:51:16.51166619Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7187277700115296,
+				"StableID":   "ndVcgfb88y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c825ed675cdf0977d4ad8e36ea4366426ddda2cb5b1ce5ffd64166a122e1cd72",
+				"KeyExpiry":  "2026-10-26T10:51:17Z",
+				"DiscoKey":   "discokey:a312c0440244a3553fcb37ae791e07de0c573c1f1f43e8e11078928257fc2b6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37555", "10.65.0.27:37555", "172.17.0.1:37555"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:51:17.07397491Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2177883883156765,
+				"StableID":   "nWTcwMKN1J11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6107283aa8f6cd60c4ea290315c7db25088ee80a748f71046b5afb31e1383153",
+				"KeyExpiry":  "2026-10-26T10:51:17Z",
+				"DiscoKey":   "discokey:9f5c2fe66e948d809cd572d97d04a12bb76daa4cb458f2b1c89d77411f50006a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53597", "10.65.0.27:53597", "172.17.0.1:53597"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:51:17.601412523Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3784782026058228": {
+				"ID":          3784782026058228,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2248819110001156,
+				"StableID":   "n17q2ZfVZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e480b2d67151cc66dc60b21e1c6c8575afb4c947e9bf07649c58933d1ec50b4b",
+				"KeyExpiry":  "2026-10-26T10:51:16Z",
+				"DiscoKey":   "discokey:5df7c5e0a8e2ef91c67717a45bcdde4f95ba3d7d7252fb82c62738aa9650040c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58054", "10.65.0.27:58054", "172.17.0.1:58054"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:51:16.51166619Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e480b2d67151cc66dc60b21e1c6c8575afb4c947e9bf07649c58933d1ec50b4b",
+			"MachineKey": "mkey:a4e8d814481fe48b12b0ddf996a69f782d07b41e42d65c6b97923443508d8e38",
+			"Peers": [{
+				"ID":         3784782026058228,
+				"StableID":   "nKUQGko8ZW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51934a2de6e0f0a83bc23e8a4636c80dbd43280d2c0f483a2abba96576d48c3b",
+				"DiscoKey":   "discokey:e38c198cc17bd769ce465790302189881f67b572d94bd1296ad9fc9e7e03d052",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:49719", "10.65.0.27:49719", "172.17.0.1:49719"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:51:13.820997769Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1719303245599320,
+				"StableID":   "nq7WLVBgRE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f088d3674a49608ae75fcaa669f65ca74059332716f8a5856aaea4cf09995a03",
+				"DiscoKey":   "discokey:7608cf95a7b425990f185b78cd3127f41e294298be9a70cfba11aff7bb78c542",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58234", "10.65.0.27:58234", "172.17.0.1:58234"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:51:14.364113905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4840310672134031,
+				"StableID":   "nx1REikBoe11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:854e2ce50518e395dff7be4688097f86adb500b75e4d56a88bd346c3ed9ace25",
+				"DiscoKey":   "discokey:7f057096c9b8bdd90c07c140f97b06731dce81772df1edd9eb75a2dd4aa65142",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:48023", "10.65.0.27:48023", "172.17.0.1:48023"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:51:14.907734971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         271398802519235,
+				"StableID":   "nWgPpoBv7311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23d3349a2dfef1b7da608608e4afd1caaa89eb4cc5a1e6fed1ee132299cc2a2f",
+				"DiscoKey":   "discokey:5579b7fa0a9c66612ef8471ce65ce6d79e9c44578f16d35464cfc3463fb3f572",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55658", "10.65.0.27:55658", "172.17.0.1:55658"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:51:15.447239849Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6903357444160319,
+				"StableID":   "ngFQueVYuv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4708b632722beb4bacebe536d21ee3adb7b2a1c15a0d9a599bd042be2a7f5f62",
+				"DiscoKey":   "discokey:8eadea401feb8011fb08bd67c9d0620f34f82058ddf10f44f5795cdecffbd85d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39055", "10.65.0.27:39055", "172.17.0.1:39055"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:51:15.98002073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7187277700115296,
+				"StableID":   "ndVcgfb88y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c825ed675cdf0977d4ad8e36ea4366426ddda2cb5b1ce5ffd64166a122e1cd72",
+				"KeyExpiry":  "2026-10-26T10:51:17Z",
+				"DiscoKey":   "discokey:a312c0440244a3553fcb37ae791e07de0c573c1f1f43e8e11078928257fc2b6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37555", "10.65.0.27:37555", "172.17.0.1:37555"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:51:17.07397491Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2177883883156765,
+				"StableID":   "nWTcwMKN1J11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6107283aa8f6cd60c4ea290315c7db25088ee80a748f71046b5afb31e1383153",
+				"KeyExpiry":  "2026-10-26T10:51:17Z",
+				"DiscoKey":   "discokey:9f5c2fe66e948d809cd572d97d04a12bb76daa4cb458f2b1c89d77411f50006a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53597", "10.65.0.27:53597", "172.17.0.1:53597"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:51:17.601412523Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         271398802519235,
+				"StableID":   "nWgPpoBv7311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       271398802519235,
+				"Key":        "nodekey:23d3349a2dfef1b7da608608e4afd1caaa89eb4cc5a1e6fed1ee132299cc2a2f",
+				"DiscoKey":   "discokey:5579b7fa0a9c66612ef8471ce65ce6d79e9c44578f16d35464cfc3463fb3f572",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55658", "10.65.0.27:55658", "172.17.0.1:55658"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:51:15.447239849Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:23d3349a2dfef1b7da608608e4afd1caaa89eb4cc5a1e6fed1ee132299cc2a2f",
+			"MachineKey": "mkey:9ecb292ab3bba94773392f060c8c5189eaeb5a67ffc3edfc84e0d7f056d17b12",
+			"Peers": [{
+				"ID":         3784782026058228,
+				"StableID":   "nKUQGko8ZW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51934a2de6e0f0a83bc23e8a4636c80dbd43280d2c0f483a2abba96576d48c3b",
+				"DiscoKey":   "discokey:e38c198cc17bd769ce465790302189881f67b572d94bd1296ad9fc9e7e03d052",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:49719", "10.65.0.27:49719", "172.17.0.1:49719"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:51:13.820997769Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1719303245599320,
+				"StableID":   "nq7WLVBgRE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f088d3674a49608ae75fcaa669f65ca74059332716f8a5856aaea4cf09995a03",
+				"DiscoKey":   "discokey:7608cf95a7b425990f185b78cd3127f41e294298be9a70cfba11aff7bb78c542",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58234", "10.65.0.27:58234", "172.17.0.1:58234"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:51:14.364113905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4840310672134031,
+				"StableID":   "nx1REikBoe11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:854e2ce50518e395dff7be4688097f86adb500b75e4d56a88bd346c3ed9ace25",
+				"DiscoKey":   "discokey:7f057096c9b8bdd90c07c140f97b06731dce81772df1edd9eb75a2dd4aa65142",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:48023", "10.65.0.27:48023", "172.17.0.1:48023"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:51:14.907734971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6903357444160319,
+				"StableID":   "ngFQueVYuv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4708b632722beb4bacebe536d21ee3adb7b2a1c15a0d9a599bd042be2a7f5f62",
+				"DiscoKey":   "discokey:8eadea401feb8011fb08bd67c9d0620f34f82058ddf10f44f5795cdecffbd85d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39055", "10.65.0.27:39055", "172.17.0.1:39055"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:51:15.98002073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2248819110001156,
+				"StableID":   "n17q2ZfVZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e480b2d67151cc66dc60b21e1c6c8575afb4c947e9bf07649c58933d1ec50b4b",
+				"KeyExpiry":  "2026-10-26T10:51:16Z",
+				"DiscoKey":   "discokey:5df7c5e0a8e2ef91c67717a45bcdde4f95ba3d7d7252fb82c62738aa9650040c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58054", "10.65.0.27:58054", "172.17.0.1:58054"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:51:16.51166619Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7187277700115296,
+				"StableID":   "ndVcgfb88y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c825ed675cdf0977d4ad8e36ea4366426ddda2cb5b1ce5ffd64166a122e1cd72",
+				"KeyExpiry":  "2026-10-26T10:51:17Z",
+				"DiscoKey":   "discokey:a312c0440244a3553fcb37ae791e07de0c573c1f1f43e8e11078928257fc2b6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37555", "10.65.0.27:37555", "172.17.0.1:37555"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:51:17.07397491Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2177883883156765,
+				"StableID":   "nWTcwMKN1J11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6107283aa8f6cd60c4ea290315c7db25088ee80a748f71046b5afb31e1383153",
+				"KeyExpiry":  "2026-10-26T10:51:17Z",
+				"DiscoKey":   "discokey:9f5c2fe66e948d809cd572d97d04a12bb76daa4cb458f2b1c89d77411f50006a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53597", "10.65.0.27:53597", "172.17.0.1:53597"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:51:17.601412523Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "271398802519235": {
+				"ID":          271398802519235,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1719303245599320,
+				"StableID":   "nq7WLVBgRE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1719303245599320,
+				"Key":        "nodekey:f088d3674a49608ae75fcaa669f65ca74059332716f8a5856aaea4cf09995a03",
+				"DiscoKey":   "discokey:7608cf95a7b425990f185b78cd3127f41e294298be9a70cfba11aff7bb78c542",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58234", "10.65.0.27:58234", "172.17.0.1:58234"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:51:14.364113905Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f088d3674a49608ae75fcaa669f65ca74059332716f8a5856aaea4cf09995a03",
+			"MachineKey": "mkey:83875f57faef32d1b2dc6d6bbec7ff2ebd5f9f3e9953c65d99236ab4e16e6b28",
+			"Peers": [{
+				"ID":         3784782026058228,
+				"StableID":   "nKUQGko8ZW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51934a2de6e0f0a83bc23e8a4636c80dbd43280d2c0f483a2abba96576d48c3b",
+				"DiscoKey":   "discokey:e38c198cc17bd769ce465790302189881f67b572d94bd1296ad9fc9e7e03d052",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:49719", "10.65.0.27:49719", "172.17.0.1:49719"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:51:13.820997769Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4840310672134031,
+				"StableID":   "nx1REikBoe11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:854e2ce50518e395dff7be4688097f86adb500b75e4d56a88bd346c3ed9ace25",
+				"DiscoKey":   "discokey:7f057096c9b8bdd90c07c140f97b06731dce81772df1edd9eb75a2dd4aa65142",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:48023", "10.65.0.27:48023", "172.17.0.1:48023"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:51:14.907734971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         271398802519235,
+				"StableID":   "nWgPpoBv7311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23d3349a2dfef1b7da608608e4afd1caaa89eb4cc5a1e6fed1ee132299cc2a2f",
+				"DiscoKey":   "discokey:5579b7fa0a9c66612ef8471ce65ce6d79e9c44578f16d35464cfc3463fb3f572",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55658", "10.65.0.27:55658", "172.17.0.1:55658"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:51:15.447239849Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6903357444160319,
+				"StableID":   "ngFQueVYuv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4708b632722beb4bacebe536d21ee3adb7b2a1c15a0d9a599bd042be2a7f5f62",
+				"DiscoKey":   "discokey:8eadea401feb8011fb08bd67c9d0620f34f82058ddf10f44f5795cdecffbd85d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39055", "10.65.0.27:39055", "172.17.0.1:39055"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:51:15.98002073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2248819110001156,
+				"StableID":   "n17q2ZfVZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e480b2d67151cc66dc60b21e1c6c8575afb4c947e9bf07649c58933d1ec50b4b",
+				"KeyExpiry":  "2026-10-26T10:51:16Z",
+				"DiscoKey":   "discokey:5df7c5e0a8e2ef91c67717a45bcdde4f95ba3d7d7252fb82c62738aa9650040c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58054", "10.65.0.27:58054", "172.17.0.1:58054"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:51:16.51166619Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7187277700115296,
+				"StableID":   "ndVcgfb88y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c825ed675cdf0977d4ad8e36ea4366426ddda2cb5b1ce5ffd64166a122e1cd72",
+				"KeyExpiry":  "2026-10-26T10:51:17Z",
+				"DiscoKey":   "discokey:a312c0440244a3553fcb37ae791e07de0c573c1f1f43e8e11078928257fc2b6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37555", "10.65.0.27:37555", "172.17.0.1:37555"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:51:17.07397491Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2177883883156765,
+				"StableID":   "nWTcwMKN1J11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6107283aa8f6cd60c4ea290315c7db25088ee80a748f71046b5afb31e1383153",
+				"KeyExpiry":  "2026-10-26T10:51:17Z",
+				"DiscoKey":   "discokey:9f5c2fe66e948d809cd572d97d04a12bb76daa4cb458f2b1c89d77411f50006a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53597", "10.65.0.27:53597", "172.17.0.1:53597"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:51:17.601412523Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1719303245599320": {
+				"ID":          1719303245599320,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7187277700115296,
+				"StableID":   "ndVcgfb88y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c825ed675cdf0977d4ad8e36ea4366426ddda2cb5b1ce5ffd64166a122e1cd72",
+				"KeyExpiry":  "2026-10-26T10:51:17Z",
+				"DiscoKey":   "discokey:a312c0440244a3553fcb37ae791e07de0c573c1f1f43e8e11078928257fc2b6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37555", "10.65.0.27:37555", "172.17.0.1:37555"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:51:17.07397491Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c825ed675cdf0977d4ad8e36ea4366426ddda2cb5b1ce5ffd64166a122e1cd72",
+			"MachineKey": "mkey:3b7a50b7114ebe6885272471dc8d584d32066006d3c55ae27943e686cb654d34",
+			"Peers": [{
+				"ID":         3784782026058228,
+				"StableID":   "nKUQGko8ZW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51934a2de6e0f0a83bc23e8a4636c80dbd43280d2c0f483a2abba96576d48c3b",
+				"DiscoKey":   "discokey:e38c198cc17bd769ce465790302189881f67b572d94bd1296ad9fc9e7e03d052",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:49719", "10.65.0.27:49719", "172.17.0.1:49719"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:51:13.820997769Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1719303245599320,
+				"StableID":   "nq7WLVBgRE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f088d3674a49608ae75fcaa669f65ca74059332716f8a5856aaea4cf09995a03",
+				"DiscoKey":   "discokey:7608cf95a7b425990f185b78cd3127f41e294298be9a70cfba11aff7bb78c542",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58234", "10.65.0.27:58234", "172.17.0.1:58234"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:51:14.364113905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4840310672134031,
+				"StableID":   "nx1REikBoe11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:854e2ce50518e395dff7be4688097f86adb500b75e4d56a88bd346c3ed9ace25",
+				"DiscoKey":   "discokey:7f057096c9b8bdd90c07c140f97b06731dce81772df1edd9eb75a2dd4aa65142",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:48023", "10.65.0.27:48023", "172.17.0.1:48023"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:51:14.907734971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         271398802519235,
+				"StableID":   "nWgPpoBv7311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23d3349a2dfef1b7da608608e4afd1caaa89eb4cc5a1e6fed1ee132299cc2a2f",
+				"DiscoKey":   "discokey:5579b7fa0a9c66612ef8471ce65ce6d79e9c44578f16d35464cfc3463fb3f572",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55658", "10.65.0.27:55658", "172.17.0.1:55658"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:51:15.447239849Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6903357444160319,
+				"StableID":   "ngFQueVYuv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4708b632722beb4bacebe536d21ee3adb7b2a1c15a0d9a599bd042be2a7f5f62",
+				"DiscoKey":   "discokey:8eadea401feb8011fb08bd67c9d0620f34f82058ddf10f44f5795cdecffbd85d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39055", "10.65.0.27:39055", "172.17.0.1:39055"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:51:15.98002073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2248819110001156,
+				"StableID":   "n17q2ZfVZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e480b2d67151cc66dc60b21e1c6c8575afb4c947e9bf07649c58933d1ec50b4b",
+				"KeyExpiry":  "2026-10-26T10:51:16Z",
+				"DiscoKey":   "discokey:5df7c5e0a8e2ef91c67717a45bcdde4f95ba3d7d7252fb82c62738aa9650040c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58054", "10.65.0.27:58054", "172.17.0.1:58054"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:51:16.51166619Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2177883883156765,
+				"StableID":   "nWTcwMKN1J11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6107283aa8f6cd60c4ea290315c7db25088ee80a748f71046b5afb31e1383153",
+				"KeyExpiry":  "2026-10-26T10:51:17Z",
+				"DiscoKey":   "discokey:9f5c2fe66e948d809cd572d97d04a12bb76daa4cb458f2b1c89d77411f50006a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53597", "10.65.0.27:53597", "172.17.0.1:53597"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:51:17.601412523Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4840310672134031,
+				"StableID":   "nx1REikBoe11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       4840310672134031,
+				"Key":        "nodekey:854e2ce50518e395dff7be4688097f86adb500b75e4d56a88bd346c3ed9ace25",
+				"DiscoKey":   "discokey:7f057096c9b8bdd90c07c140f97b06731dce81772df1edd9eb75a2dd4aa65142",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:48023", "10.65.0.27:48023", "172.17.0.1:48023"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:51:14.907734971Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:854e2ce50518e395dff7be4688097f86adb500b75e4d56a88bd346c3ed9ace25",
+			"MachineKey": "mkey:9cc9d447d0ab41b6b602f1ce1ff9e32d1ec54b9d64c2317393a5f2e31d99b850",
+			"Peers": [{
+				"ID":         3784782026058228,
+				"StableID":   "nKUQGko8ZW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51934a2de6e0f0a83bc23e8a4636c80dbd43280d2c0f483a2abba96576d48c3b",
+				"DiscoKey":   "discokey:e38c198cc17bd769ce465790302189881f67b572d94bd1296ad9fc9e7e03d052",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:49719", "10.65.0.27:49719", "172.17.0.1:49719"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:51:13.820997769Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1719303245599320,
+				"StableID":   "nq7WLVBgRE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f088d3674a49608ae75fcaa669f65ca74059332716f8a5856aaea4cf09995a03",
+				"DiscoKey":   "discokey:7608cf95a7b425990f185b78cd3127f41e294298be9a70cfba11aff7bb78c542",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58234", "10.65.0.27:58234", "172.17.0.1:58234"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:51:14.364113905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         271398802519235,
+				"StableID":   "nWgPpoBv7311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23d3349a2dfef1b7da608608e4afd1caaa89eb4cc5a1e6fed1ee132299cc2a2f",
+				"DiscoKey":   "discokey:5579b7fa0a9c66612ef8471ce65ce6d79e9c44578f16d35464cfc3463fb3f572",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55658", "10.65.0.27:55658", "172.17.0.1:55658"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:51:15.447239849Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6903357444160319,
+				"StableID":   "ngFQueVYuv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4708b632722beb4bacebe536d21ee3adb7b2a1c15a0d9a599bd042be2a7f5f62",
+				"DiscoKey":   "discokey:8eadea401feb8011fb08bd67c9d0620f34f82058ddf10f44f5795cdecffbd85d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39055", "10.65.0.27:39055", "172.17.0.1:39055"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:51:15.98002073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2248819110001156,
+				"StableID":   "n17q2ZfVZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e480b2d67151cc66dc60b21e1c6c8575afb4c947e9bf07649c58933d1ec50b4b",
+				"KeyExpiry":  "2026-10-26T10:51:16Z",
+				"DiscoKey":   "discokey:5df7c5e0a8e2ef91c67717a45bcdde4f95ba3d7d7252fb82c62738aa9650040c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58054", "10.65.0.27:58054", "172.17.0.1:58054"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:51:16.51166619Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7187277700115296,
+				"StableID":   "ndVcgfb88y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c825ed675cdf0977d4ad8e36ea4366426ddda2cb5b1ce5ffd64166a122e1cd72",
+				"KeyExpiry":  "2026-10-26T10:51:17Z",
+				"DiscoKey":   "discokey:a312c0440244a3553fcb37ae791e07de0c573c1f1f43e8e11078928257fc2b6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37555", "10.65.0.27:37555", "172.17.0.1:37555"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:51:17.07397491Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2177883883156765,
+				"StableID":   "nWTcwMKN1J11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6107283aa8f6cd60c4ea290315c7db25088ee80a748f71046b5afb31e1383153",
+				"KeyExpiry":  "2026-10-26T10:51:17Z",
+				"DiscoKey":   "discokey:9f5c2fe66e948d809cd572d97d04a12bb76daa4cb458f2b1c89d77411f50006a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53597", "10.65.0.27:53597", "172.17.0.1:53597"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:51:17.601412523Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4840310672134031": {
+				"ID":          4840310672134031,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-dst-unknown-user.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-dst-unknown-user.hujson
@@ -1,0 +1,8847 @@
+// policytest-dst-unknown-user
+//
+// tests block dst-unknown: user email used as destination
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:51:39Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-dst-unknown-user",
+	"description":    "tests block dst-unknown: user email used as destination",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:51:39.321951791Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                              \n  \n                                                                  \n                                                             \n{\n\t\"id\":          \"policytest-dst-unknown-user\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block dst-unknown: user email used as destination\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"thor@example.org\"], \"dst\": [\"tag:server:22\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"accept\": [\"odin@example.com:22\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-dst-unknown-user.hujson",
+		"full_policy": {
+			"acls": [{
+				"action": "accept",
+				"dst":    ["tag:server:22"],
+				"src":    ["thor@example.org"]
+			}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["odin@example.com:22"], "src": "thor@example.org"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         176164546492430,
+				"StableID":   "nsZ8jYYnN211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       176164546492430,
+				"Key":        "nodekey:26779fd383cb585b8c227cfc69f96bcf0a03563732d214d53de949c7c8ec1c77",
+				"DiscoKey":   "discokey:86095ff1d0d817c18ce8755f5b6732d7d1b044751f43f181674ea6d2de9f2103",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45849", "10.65.0.27:45849", "172.17.0.1:45849"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:51:42.944559498Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:26779fd383cb585b8c227cfc69f96bcf0a03563732d214d53de949c7c8ec1c77",
+			"MachineKey": "mkey:70489fa597198f281a1236abdf8761a678b4fc0d3d657d5245387d9ba2e47522",
+			"Peers": [{
+				"ID":         2974359144053362,
+				"StableID":   "nbd3MXN6EQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4edbea7a82b2580c811a0f737d0b71c1b4e69c172757160f91f43acf6d175b74",
+				"DiscoKey":   "discokey:4b5894141db06194a387b6ca9d9c9c9e67f35f6bd64e74d7818f9723607ea34b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44294", "10.65.0.27:44294", "172.17.0.1:44294"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:51:40.811678521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3484784650564706,
+				"StableID":   "nZrBVFPGDU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c7cbdb918d9bc67daf4ad9df755404b32704f997299032a35be8589b89b1a12",
+				"DiscoKey":   "discokey:6da4453a813976070d4d63dcb4966a675fdf48d7de827609e6ede1039c27be1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:48616", "10.65.0.27:48616", "172.17.0.1:48616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:51:41.336703888Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1627940801967577,
+				"StableID":   "nx8p3BFJiD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0620d48006948b373b375fd6281e59ea496aee1fe1a763b1338c0581f5d5c23",
+				"DiscoKey":   "discokey:6a5fb7853f84b19db283261ba402c5e33b28802123a863af8dacb386ac8fc052",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35468", "10.65.0.27:35468", "172.17.0.1:35468"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:51:41.859594546Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8126979752050320,
+				"StableID":   "njvv9gyiT621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c16625c4c7ae8da41aa7999037ee193324fbe8bf96cd4b7e096a4c3608f6d13",
+				"DiscoKey":   "discokey:75038a24622349706a194fa84b104619819d2262eadf7bc272ba3ca330910c49",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:51:42.417893595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2231664574400161,
+				"StableID":   "nSysTZ3jRJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f3d4c714fb6b8e66d54c14c28ca5e47ec1588ea525357d4b46975cba7915b69",
+				"KeyExpiry":  "2026-10-26T10:51:43Z",
+				"DiscoKey":   "discokey:0da8dbfb9694676f809dbfc35053539bc7ae9c09c78cc28ef8214107fc314659",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55880", "10.65.0.27:55880", "172.17.0.1:55880"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:51:43.467482007Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6863739608862152,
+				"StableID":   "nDmrTSobbv11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae62fc39cead6197a6d3118d971dee8e4b11fc18b234a12c0ea77c8f36630635",
+				"KeyExpiry":  "2026-10-26T10:51:44Z",
+				"DiscoKey":   "discokey:7b8bd44dad1f70c14824bdbd1ca20d66fa7a7a99e3e7986c9e65125c83bdbe32",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50783", "10.65.0.27:50783", "172.17.0.1:50783"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:51:44.002366524Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4102727985992706,
+				"StableID":   "nM6Sz1i83Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8879af2ec86eaff8bf5c2911537a327239306e93e41a01eb64244962f7ca277",
+				"KeyExpiry":  "2026-10-26T10:51:44Z",
+				"DiscoKey":   "discokey:3ad6292daf9298a2cb4848357ab47e2c2dd6cee55a86fd220ecfa0774f60bb42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:37220", "10.65.0.27:37220", "172.17.0.1:37220"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:51:44.555667138Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "176164546492430": {
+				"ID":          176164546492430,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4102727985992706,
+				"StableID":   "nM6Sz1i83Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8879af2ec86eaff8bf5c2911537a327239306e93e41a01eb64244962f7ca277",
+				"KeyExpiry":  "2026-10-26T10:51:44Z",
+				"DiscoKey":   "discokey:3ad6292daf9298a2cb4848357ab47e2c2dd6cee55a86fd220ecfa0774f60bb42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:37220", "10.65.0.27:37220", "172.17.0.1:37220"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:51:44.555667138Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e8879af2ec86eaff8bf5c2911537a327239306e93e41a01eb64244962f7ca277",
+			"MachineKey": "mkey:b2145a19bb434a74d26875dc3610b1e04d48c56331a51401bafa62ccea0cf005",
+			"Peers": [{
+				"ID":         2974359144053362,
+				"StableID":   "nbd3MXN6EQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4edbea7a82b2580c811a0f737d0b71c1b4e69c172757160f91f43acf6d175b74",
+				"DiscoKey":   "discokey:4b5894141db06194a387b6ca9d9c9c9e67f35f6bd64e74d7818f9723607ea34b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44294", "10.65.0.27:44294", "172.17.0.1:44294"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:51:40.811678521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3484784650564706,
+				"StableID":   "nZrBVFPGDU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c7cbdb918d9bc67daf4ad9df755404b32704f997299032a35be8589b89b1a12",
+				"DiscoKey":   "discokey:6da4453a813976070d4d63dcb4966a675fdf48d7de827609e6ede1039c27be1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:48616", "10.65.0.27:48616", "172.17.0.1:48616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:51:41.336703888Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1627940801967577,
+				"StableID":   "nx8p3BFJiD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0620d48006948b373b375fd6281e59ea496aee1fe1a763b1338c0581f5d5c23",
+				"DiscoKey":   "discokey:6a5fb7853f84b19db283261ba402c5e33b28802123a863af8dacb386ac8fc052",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35468", "10.65.0.27:35468", "172.17.0.1:35468"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:51:41.859594546Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8126979752050320,
+				"StableID":   "njvv9gyiT621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c16625c4c7ae8da41aa7999037ee193324fbe8bf96cd4b7e096a4c3608f6d13",
+				"DiscoKey":   "discokey:75038a24622349706a194fa84b104619819d2262eadf7bc272ba3ca330910c49",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:51:42.417893595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         176164546492430,
+				"StableID":   "nsZ8jYYnN211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26779fd383cb585b8c227cfc69f96bcf0a03563732d214d53de949c7c8ec1c77",
+				"DiscoKey":   "discokey:86095ff1d0d817c18ce8755f5b6732d7d1b044751f43f181674ea6d2de9f2103",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45849", "10.65.0.27:45849", "172.17.0.1:45849"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:51:42.944559498Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2231664574400161,
+				"StableID":   "nSysTZ3jRJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f3d4c714fb6b8e66d54c14c28ca5e47ec1588ea525357d4b46975cba7915b69",
+				"KeyExpiry":  "2026-10-26T10:51:43Z",
+				"DiscoKey":   "discokey:0da8dbfb9694676f809dbfc35053539bc7ae9c09c78cc28ef8214107fc314659",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55880", "10.65.0.27:55880", "172.17.0.1:55880"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:51:43.467482007Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6863739608862152,
+				"StableID":   "nDmrTSobbv11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae62fc39cead6197a6d3118d971dee8e4b11fc18b234a12c0ea77c8f36630635",
+				"KeyExpiry":  "2026-10-26T10:51:44Z",
+				"DiscoKey":   "discokey:7b8bd44dad1f70c14824bdbd1ca20d66fa7a7a99e3e7986c9e65125c83bdbe32",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50783", "10.65.0.27:50783", "172.17.0.1:50783"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:51:44.002366524Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2974359144053362,
+				"StableID":   "nbd3MXN6EQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       2974359144053362,
+				"Key":        "nodekey:4edbea7a82b2580c811a0f737d0b71c1b4e69c172757160f91f43acf6d175b74",
+				"DiscoKey":   "discokey:4b5894141db06194a387b6ca9d9c9c9e67f35f6bd64e74d7818f9723607ea34b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44294", "10.65.0.27:44294", "172.17.0.1:44294"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:51:40.811678521Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4edbea7a82b2580c811a0f737d0b71c1b4e69c172757160f91f43acf6d175b74",
+			"MachineKey": "mkey:b548417060f58b1107a60ff1a7d820c5a474c421cab039f347ef2c20b004a447",
+			"Peers": [{
+				"ID":         3484784650564706,
+				"StableID":   "nZrBVFPGDU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c7cbdb918d9bc67daf4ad9df755404b32704f997299032a35be8589b89b1a12",
+				"DiscoKey":   "discokey:6da4453a813976070d4d63dcb4966a675fdf48d7de827609e6ede1039c27be1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:48616", "10.65.0.27:48616", "172.17.0.1:48616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:51:41.336703888Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1627940801967577,
+				"StableID":   "nx8p3BFJiD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0620d48006948b373b375fd6281e59ea496aee1fe1a763b1338c0581f5d5c23",
+				"DiscoKey":   "discokey:6a5fb7853f84b19db283261ba402c5e33b28802123a863af8dacb386ac8fc052",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35468", "10.65.0.27:35468", "172.17.0.1:35468"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:51:41.859594546Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8126979752050320,
+				"StableID":   "njvv9gyiT621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c16625c4c7ae8da41aa7999037ee193324fbe8bf96cd4b7e096a4c3608f6d13",
+				"DiscoKey":   "discokey:75038a24622349706a194fa84b104619819d2262eadf7bc272ba3ca330910c49",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:51:42.417893595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         176164546492430,
+				"StableID":   "nsZ8jYYnN211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26779fd383cb585b8c227cfc69f96bcf0a03563732d214d53de949c7c8ec1c77",
+				"DiscoKey":   "discokey:86095ff1d0d817c18ce8755f5b6732d7d1b044751f43f181674ea6d2de9f2103",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45849", "10.65.0.27:45849", "172.17.0.1:45849"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:51:42.944559498Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2231664574400161,
+				"StableID":   "nSysTZ3jRJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f3d4c714fb6b8e66d54c14c28ca5e47ec1588ea525357d4b46975cba7915b69",
+				"KeyExpiry":  "2026-10-26T10:51:43Z",
+				"DiscoKey":   "discokey:0da8dbfb9694676f809dbfc35053539bc7ae9c09c78cc28ef8214107fc314659",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55880", "10.65.0.27:55880", "172.17.0.1:55880"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:51:43.467482007Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6863739608862152,
+				"StableID":   "nDmrTSobbv11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae62fc39cead6197a6d3118d971dee8e4b11fc18b234a12c0ea77c8f36630635",
+				"KeyExpiry":  "2026-10-26T10:51:44Z",
+				"DiscoKey":   "discokey:7b8bd44dad1f70c14824bdbd1ca20d66fa7a7a99e3e7986c9e65125c83bdbe32",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50783", "10.65.0.27:50783", "172.17.0.1:50783"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:51:44.002366524Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4102727985992706,
+				"StableID":   "nM6Sz1i83Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8879af2ec86eaff8bf5c2911537a327239306e93e41a01eb64244962f7ca277",
+				"KeyExpiry":  "2026-10-26T10:51:44Z",
+				"DiscoKey":   "discokey:3ad6292daf9298a2cb4848357ab47e2c2dd6cee55a86fd220ecfa0774f60bb42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:37220", "10.65.0.27:37220", "172.17.0.1:37220"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:51:44.555667138Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2974359144053362": {
+				"ID":          2974359144053362,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2231664574400161,
+				"StableID":   "nSysTZ3jRJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f3d4c714fb6b8e66d54c14c28ca5e47ec1588ea525357d4b46975cba7915b69",
+				"KeyExpiry":  "2026-10-26T10:51:43Z",
+				"DiscoKey":   "discokey:0da8dbfb9694676f809dbfc35053539bc7ae9c09c78cc28ef8214107fc314659",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55880", "10.65.0.27:55880", "172.17.0.1:55880"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:51:43.467482007Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0f3d4c714fb6b8e66d54c14c28ca5e47ec1588ea525357d4b46975cba7915b69",
+			"MachineKey": "mkey:5887a5b0919e513bfbe22d437aed192334017038a56ebb914776cd3e7deef57a",
+			"Peers": [{
+				"ID":         2974359144053362,
+				"StableID":   "nbd3MXN6EQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4edbea7a82b2580c811a0f737d0b71c1b4e69c172757160f91f43acf6d175b74",
+				"DiscoKey":   "discokey:4b5894141db06194a387b6ca9d9c9c9e67f35f6bd64e74d7818f9723607ea34b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44294", "10.65.0.27:44294", "172.17.0.1:44294"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:51:40.811678521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3484784650564706,
+				"StableID":   "nZrBVFPGDU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c7cbdb918d9bc67daf4ad9df755404b32704f997299032a35be8589b89b1a12",
+				"DiscoKey":   "discokey:6da4453a813976070d4d63dcb4966a675fdf48d7de827609e6ede1039c27be1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:48616", "10.65.0.27:48616", "172.17.0.1:48616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:51:41.336703888Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1627940801967577,
+				"StableID":   "nx8p3BFJiD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0620d48006948b373b375fd6281e59ea496aee1fe1a763b1338c0581f5d5c23",
+				"DiscoKey":   "discokey:6a5fb7853f84b19db283261ba402c5e33b28802123a863af8dacb386ac8fc052",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35468", "10.65.0.27:35468", "172.17.0.1:35468"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:51:41.859594546Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8126979752050320,
+				"StableID":   "njvv9gyiT621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c16625c4c7ae8da41aa7999037ee193324fbe8bf96cd4b7e096a4c3608f6d13",
+				"DiscoKey":   "discokey:75038a24622349706a194fa84b104619819d2262eadf7bc272ba3ca330910c49",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:51:42.417893595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         176164546492430,
+				"StableID":   "nsZ8jYYnN211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26779fd383cb585b8c227cfc69f96bcf0a03563732d214d53de949c7c8ec1c77",
+				"DiscoKey":   "discokey:86095ff1d0d817c18ce8755f5b6732d7d1b044751f43f181674ea6d2de9f2103",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45849", "10.65.0.27:45849", "172.17.0.1:45849"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:51:42.944559498Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6863739608862152,
+				"StableID":   "nDmrTSobbv11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae62fc39cead6197a6d3118d971dee8e4b11fc18b234a12c0ea77c8f36630635",
+				"KeyExpiry":  "2026-10-26T10:51:44Z",
+				"DiscoKey":   "discokey:7b8bd44dad1f70c14824bdbd1ca20d66fa7a7a99e3e7986c9e65125c83bdbe32",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50783", "10.65.0.27:50783", "172.17.0.1:50783"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:51:44.002366524Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4102727985992706,
+				"StableID":   "nM6Sz1i83Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8879af2ec86eaff8bf5c2911537a327239306e93e41a01eb64244962f7ca277",
+				"KeyExpiry":  "2026-10-26T10:51:44Z",
+				"DiscoKey":   "discokey:3ad6292daf9298a2cb4848357ab47e2c2dd6cee55a86fd220ecfa0774f60bb42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:37220", "10.65.0.27:37220", "172.17.0.1:37220"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:51:44.555667138Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8126979752050320,
+				"StableID":   "njvv9gyiT621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       8126979752050320,
+				"Key":        "nodekey:8c16625c4c7ae8da41aa7999037ee193324fbe8bf96cd4b7e096a4c3608f6d13",
+				"DiscoKey":   "discokey:75038a24622349706a194fa84b104619819d2262eadf7bc272ba3ca330910c49",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:51:42.417893595Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8c16625c4c7ae8da41aa7999037ee193324fbe8bf96cd4b7e096a4c3608f6d13",
+			"MachineKey": "mkey:a45de12b6eda45726f6373ffefbb6fb3af668e842e8f97592e2c2a7e0817880d",
+			"Peers": [{
+				"ID":         2974359144053362,
+				"StableID":   "nbd3MXN6EQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4edbea7a82b2580c811a0f737d0b71c1b4e69c172757160f91f43acf6d175b74",
+				"DiscoKey":   "discokey:4b5894141db06194a387b6ca9d9c9c9e67f35f6bd64e74d7818f9723607ea34b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44294", "10.65.0.27:44294", "172.17.0.1:44294"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:51:40.811678521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3484784650564706,
+				"StableID":   "nZrBVFPGDU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c7cbdb918d9bc67daf4ad9df755404b32704f997299032a35be8589b89b1a12",
+				"DiscoKey":   "discokey:6da4453a813976070d4d63dcb4966a675fdf48d7de827609e6ede1039c27be1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:48616", "10.65.0.27:48616", "172.17.0.1:48616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:51:41.336703888Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1627940801967577,
+				"StableID":   "nx8p3BFJiD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0620d48006948b373b375fd6281e59ea496aee1fe1a763b1338c0581f5d5c23",
+				"DiscoKey":   "discokey:6a5fb7853f84b19db283261ba402c5e33b28802123a863af8dacb386ac8fc052",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35468", "10.65.0.27:35468", "172.17.0.1:35468"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:51:41.859594546Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         176164546492430,
+				"StableID":   "nsZ8jYYnN211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26779fd383cb585b8c227cfc69f96bcf0a03563732d214d53de949c7c8ec1c77",
+				"DiscoKey":   "discokey:86095ff1d0d817c18ce8755f5b6732d7d1b044751f43f181674ea6d2de9f2103",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45849", "10.65.0.27:45849", "172.17.0.1:45849"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:51:42.944559498Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2231664574400161,
+				"StableID":   "nSysTZ3jRJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f3d4c714fb6b8e66d54c14c28ca5e47ec1588ea525357d4b46975cba7915b69",
+				"KeyExpiry":  "2026-10-26T10:51:43Z",
+				"DiscoKey":   "discokey:0da8dbfb9694676f809dbfc35053539bc7ae9c09c78cc28ef8214107fc314659",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55880", "10.65.0.27:55880", "172.17.0.1:55880"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:51:43.467482007Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6863739608862152,
+				"StableID":   "nDmrTSobbv11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae62fc39cead6197a6d3118d971dee8e4b11fc18b234a12c0ea77c8f36630635",
+				"KeyExpiry":  "2026-10-26T10:51:44Z",
+				"DiscoKey":   "discokey:7b8bd44dad1f70c14824bdbd1ca20d66fa7a7a99e3e7986c9e65125c83bdbe32",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50783", "10.65.0.27:50783", "172.17.0.1:50783"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:51:44.002366524Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4102727985992706,
+				"StableID":   "nM6Sz1i83Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8879af2ec86eaff8bf5c2911537a327239306e93e41a01eb64244962f7ca277",
+				"KeyExpiry":  "2026-10-26T10:51:44Z",
+				"DiscoKey":   "discokey:3ad6292daf9298a2cb4848357ab47e2c2dd6cee55a86fd220ecfa0774f60bb42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:37220", "10.65.0.27:37220", "172.17.0.1:37220"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:51:44.555667138Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8126979752050320": {
+				"ID":          8126979752050320,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3484784650564706,
+				"StableID":   "nZrBVFPGDU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       3484784650564706,
+				"Key":        "nodekey:5c7cbdb918d9bc67daf4ad9df755404b32704f997299032a35be8589b89b1a12",
+				"DiscoKey":   "discokey:6da4453a813976070d4d63dcb4966a675fdf48d7de827609e6ede1039c27be1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:48616", "10.65.0.27:48616", "172.17.0.1:48616"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:51:41.336703888Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5c7cbdb918d9bc67daf4ad9df755404b32704f997299032a35be8589b89b1a12",
+			"MachineKey": "mkey:48b892ffeb53261b042c333d7a059107709621a0c134d4d226c1d0c25d332a0a",
+			"Peers": [{
+				"ID":         2974359144053362,
+				"StableID":   "nbd3MXN6EQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4edbea7a82b2580c811a0f737d0b71c1b4e69c172757160f91f43acf6d175b74",
+				"DiscoKey":   "discokey:4b5894141db06194a387b6ca9d9c9c9e67f35f6bd64e74d7818f9723607ea34b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44294", "10.65.0.27:44294", "172.17.0.1:44294"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:51:40.811678521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1627940801967577,
+				"StableID":   "nx8p3BFJiD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0620d48006948b373b375fd6281e59ea496aee1fe1a763b1338c0581f5d5c23",
+				"DiscoKey":   "discokey:6a5fb7853f84b19db283261ba402c5e33b28802123a863af8dacb386ac8fc052",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35468", "10.65.0.27:35468", "172.17.0.1:35468"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:51:41.859594546Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8126979752050320,
+				"StableID":   "njvv9gyiT621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c16625c4c7ae8da41aa7999037ee193324fbe8bf96cd4b7e096a4c3608f6d13",
+				"DiscoKey":   "discokey:75038a24622349706a194fa84b104619819d2262eadf7bc272ba3ca330910c49",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:51:42.417893595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         176164546492430,
+				"StableID":   "nsZ8jYYnN211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26779fd383cb585b8c227cfc69f96bcf0a03563732d214d53de949c7c8ec1c77",
+				"DiscoKey":   "discokey:86095ff1d0d817c18ce8755f5b6732d7d1b044751f43f181674ea6d2de9f2103",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45849", "10.65.0.27:45849", "172.17.0.1:45849"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:51:42.944559498Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2231664574400161,
+				"StableID":   "nSysTZ3jRJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f3d4c714fb6b8e66d54c14c28ca5e47ec1588ea525357d4b46975cba7915b69",
+				"KeyExpiry":  "2026-10-26T10:51:43Z",
+				"DiscoKey":   "discokey:0da8dbfb9694676f809dbfc35053539bc7ae9c09c78cc28ef8214107fc314659",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55880", "10.65.0.27:55880", "172.17.0.1:55880"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:51:43.467482007Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6863739608862152,
+				"StableID":   "nDmrTSobbv11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae62fc39cead6197a6d3118d971dee8e4b11fc18b234a12c0ea77c8f36630635",
+				"KeyExpiry":  "2026-10-26T10:51:44Z",
+				"DiscoKey":   "discokey:7b8bd44dad1f70c14824bdbd1ca20d66fa7a7a99e3e7986c9e65125c83bdbe32",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50783", "10.65.0.27:50783", "172.17.0.1:50783"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:51:44.002366524Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4102727985992706,
+				"StableID":   "nM6Sz1i83Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8879af2ec86eaff8bf5c2911537a327239306e93e41a01eb64244962f7ca277",
+				"KeyExpiry":  "2026-10-26T10:51:44Z",
+				"DiscoKey":   "discokey:3ad6292daf9298a2cb4848357ab47e2c2dd6cee55a86fd220ecfa0774f60bb42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:37220", "10.65.0.27:37220", "172.17.0.1:37220"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:51:44.555667138Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3484784650564706": {
+				"ID":          3484784650564706,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6863739608862152,
+				"StableID":   "nDmrTSobbv11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae62fc39cead6197a6d3118d971dee8e4b11fc18b234a12c0ea77c8f36630635",
+				"KeyExpiry":  "2026-10-26T10:51:44Z",
+				"DiscoKey":   "discokey:7b8bd44dad1f70c14824bdbd1ca20d66fa7a7a99e3e7986c9e65125c83bdbe32",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50783", "10.65.0.27:50783", "172.17.0.1:50783"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:51:44.002366524Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ae62fc39cead6197a6d3118d971dee8e4b11fc18b234a12c0ea77c8f36630635",
+			"MachineKey": "mkey:1f9f2ded8cbcdc52b8f88fe2a5988146d7dede5df51b0fcab9c5daa2435d7f0e",
+			"Peers": [{
+				"ID":         2974359144053362,
+				"StableID":   "nbd3MXN6EQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4edbea7a82b2580c811a0f737d0b71c1b4e69c172757160f91f43acf6d175b74",
+				"DiscoKey":   "discokey:4b5894141db06194a387b6ca9d9c9c9e67f35f6bd64e74d7818f9723607ea34b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44294", "10.65.0.27:44294", "172.17.0.1:44294"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:51:40.811678521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3484784650564706,
+				"StableID":   "nZrBVFPGDU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c7cbdb918d9bc67daf4ad9df755404b32704f997299032a35be8589b89b1a12",
+				"DiscoKey":   "discokey:6da4453a813976070d4d63dcb4966a675fdf48d7de827609e6ede1039c27be1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:48616", "10.65.0.27:48616", "172.17.0.1:48616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:51:41.336703888Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1627940801967577,
+				"StableID":   "nx8p3BFJiD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0620d48006948b373b375fd6281e59ea496aee1fe1a763b1338c0581f5d5c23",
+				"DiscoKey":   "discokey:6a5fb7853f84b19db283261ba402c5e33b28802123a863af8dacb386ac8fc052",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35468", "10.65.0.27:35468", "172.17.0.1:35468"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:51:41.859594546Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8126979752050320,
+				"StableID":   "njvv9gyiT621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c16625c4c7ae8da41aa7999037ee193324fbe8bf96cd4b7e096a4c3608f6d13",
+				"DiscoKey":   "discokey:75038a24622349706a194fa84b104619819d2262eadf7bc272ba3ca330910c49",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:51:42.417893595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         176164546492430,
+				"StableID":   "nsZ8jYYnN211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26779fd383cb585b8c227cfc69f96bcf0a03563732d214d53de949c7c8ec1c77",
+				"DiscoKey":   "discokey:86095ff1d0d817c18ce8755f5b6732d7d1b044751f43f181674ea6d2de9f2103",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45849", "10.65.0.27:45849", "172.17.0.1:45849"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:51:42.944559498Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2231664574400161,
+				"StableID":   "nSysTZ3jRJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f3d4c714fb6b8e66d54c14c28ca5e47ec1588ea525357d4b46975cba7915b69",
+				"KeyExpiry":  "2026-10-26T10:51:43Z",
+				"DiscoKey":   "discokey:0da8dbfb9694676f809dbfc35053539bc7ae9c09c78cc28ef8214107fc314659",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55880", "10.65.0.27:55880", "172.17.0.1:55880"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:51:43.467482007Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4102727985992706,
+				"StableID":   "nM6Sz1i83Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8879af2ec86eaff8bf5c2911537a327239306e93e41a01eb64244962f7ca277",
+				"KeyExpiry":  "2026-10-26T10:51:44Z",
+				"DiscoKey":   "discokey:3ad6292daf9298a2cb4848357ab47e2c2dd6cee55a86fd220ecfa0774f60bb42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:37220", "10.65.0.27:37220", "172.17.0.1:37220"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:51:44.555667138Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1627940801967577,
+				"StableID":   "nx8p3BFJiD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1627940801967577,
+				"Key":        "nodekey:d0620d48006948b373b375fd6281e59ea496aee1fe1a763b1338c0581f5d5c23",
+				"DiscoKey":   "discokey:6a5fb7853f84b19db283261ba402c5e33b28802123a863af8dacb386ac8fc052",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35468", "10.65.0.27:35468", "172.17.0.1:35468"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:51:41.859594546Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d0620d48006948b373b375fd6281e59ea496aee1fe1a763b1338c0581f5d5c23",
+			"MachineKey": "mkey:897732d561c8b28add84066d3c112e4f4d2efd8479c8ce2b4436197bff1eb166",
+			"Peers": [{
+				"ID":         2974359144053362,
+				"StableID":   "nbd3MXN6EQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4edbea7a82b2580c811a0f737d0b71c1b4e69c172757160f91f43acf6d175b74",
+				"DiscoKey":   "discokey:4b5894141db06194a387b6ca9d9c9c9e67f35f6bd64e74d7818f9723607ea34b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44294", "10.65.0.27:44294", "172.17.0.1:44294"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:51:40.811678521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3484784650564706,
+				"StableID":   "nZrBVFPGDU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c7cbdb918d9bc67daf4ad9df755404b32704f997299032a35be8589b89b1a12",
+				"DiscoKey":   "discokey:6da4453a813976070d4d63dcb4966a675fdf48d7de827609e6ede1039c27be1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:48616", "10.65.0.27:48616", "172.17.0.1:48616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:51:41.336703888Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8126979752050320,
+				"StableID":   "njvv9gyiT621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c16625c4c7ae8da41aa7999037ee193324fbe8bf96cd4b7e096a4c3608f6d13",
+				"DiscoKey":   "discokey:75038a24622349706a194fa84b104619819d2262eadf7bc272ba3ca330910c49",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:50269", "10.65.0.27:50269", "172.17.0.1:50269"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:51:42.417893595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         176164546492430,
+				"StableID":   "nsZ8jYYnN211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26779fd383cb585b8c227cfc69f96bcf0a03563732d214d53de949c7c8ec1c77",
+				"DiscoKey":   "discokey:86095ff1d0d817c18ce8755f5b6732d7d1b044751f43f181674ea6d2de9f2103",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:45849", "10.65.0.27:45849", "172.17.0.1:45849"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:51:42.944559498Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2231664574400161,
+				"StableID":   "nSysTZ3jRJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f3d4c714fb6b8e66d54c14c28ca5e47ec1588ea525357d4b46975cba7915b69",
+				"KeyExpiry":  "2026-10-26T10:51:43Z",
+				"DiscoKey":   "discokey:0da8dbfb9694676f809dbfc35053539bc7ae9c09c78cc28ef8214107fc314659",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55880", "10.65.0.27:55880", "172.17.0.1:55880"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:51:43.467482007Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6863739608862152,
+				"StableID":   "nDmrTSobbv11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae62fc39cead6197a6d3118d971dee8e4b11fc18b234a12c0ea77c8f36630635",
+				"KeyExpiry":  "2026-10-26T10:51:44Z",
+				"DiscoKey":   "discokey:7b8bd44dad1f70c14824bdbd1ca20d66fa7a7a99e3e7986c9e65125c83bdbe32",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50783", "10.65.0.27:50783", "172.17.0.1:50783"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:51:44.002366524Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4102727985992706,
+				"StableID":   "nM6Sz1i83Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8879af2ec86eaff8bf5c2911537a327239306e93e41a01eb64244962f7ca277",
+				"KeyExpiry":  "2026-10-26T10:51:44Z",
+				"DiscoKey":   "discokey:3ad6292daf9298a2cb4848357ab47e2c2dd6cee55a86fd220ecfa0774f60bb42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:37220", "10.65.0.27:37220", "172.17.0.1:37220"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:51:44.555667138Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1627940801967577": {
+				"ID":          1627940801967577,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-malformed-test-bad-port-syntax.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-malformed-test-bad-port-syntax.hujson
@@ -1,0 +1,8845 @@
+// policytest-malformed-test-bad-port-syntax
+//
+// tests block malformed: non-numeric port literal
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:52:06Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-malformed-test-bad-port-syntax",
+	"description":    "tests block malformed: non-numeric port literal",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:52:06.205587844Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                            \n  \n                                                                  \n             \n{\n\t\"id\":          \"policytest-malformed-test-bad-port-syntax\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block malformed: non-numeric port literal\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"thor@example.org\"], \"dst\": [\"webserver:80\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"accept\": [\"webserver:notaport\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-malformed-test-bad-port-syntax.hujson",
+		"full_policy": {
+			"acls": [
+				{"action": "accept", "dst": ["webserver:80"], "src": ["thor@example.org"]}
+			],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["webserver:notaport"], "src": "thor@example.org"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6376009028282424,
+				"StableID":   "nRfJDqwhnr11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6376009028282424,
+				"Key":        "nodekey:7c5f990e3d2557b5d9f78c3e4e600853de159a61934389f7c3c8d50b4f885765",
+				"DiscoKey":   "discokey:4ff1069bd096af0f8b1e2ae1ff24cbc2dce1f20017444dafa957c0045bf9e017",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:46106", "10.65.0.27:46106", "172.17.0.1:46106"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:52:09.731456844Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7c5f990e3d2557b5d9f78c3e4e600853de159a61934389f7c3c8d50b4f885765",
+			"MachineKey": "mkey:580c3885431133f2ed0958e6b775a220decf54d1ffc9c821d2ae66072765f641",
+			"Peers": [{
+				"ID":         6639952032395638,
+				"StableID":   "nFM1fGHFrt11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd94fb9b06a4e77c99260fd5e6fa1665f1b2595ffa33bfcf97fd8d98516f1556",
+				"DiscoKey":   "discokey:caa751c4c5410feef07cc336b5fdb447d9b16a1b333e4e5792df76b145eba742",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44550", "10.65.0.27:44550", "172.17.0.1:44550"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:52:07.666153684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4055940927569083,
+				"StableID":   "nQPRr3hwfY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae4b49ed2e317bfefd41aac4d5075e65c052478e8423e73fff5268c53437b70d",
+				"DiscoKey":   "discokey:37da770d99ecf3471d325f9e55b2500f7a0047b49f54aa246983f6ce2b1ebe11",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57576", "10.65.0.27:57576", "172.17.0.1:57576"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:52:08.144478784Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6777292117753867,
+				"StableID":   "ncdZhMySvu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6517d0957971248ba6841e27248bf17f6d5c6153a25f714fa125b1d1eaa3a163",
+				"DiscoKey":   "discokey:9074da7aec9a4cfd980535fbcac8bfe113bc7a459af339ee1492e400251caf0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53905", "10.65.0.27:53905", "172.17.0.1:53905"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:52:08.658264777Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2040353544153227,
+				"StableID":   "nCmPqQd5wG11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e4bfce43f915b4c3f480728ec02d7aeb1081d141a62e09247e0299a49b4e76e",
+				"DiscoKey":   "discokey:8e88ae855472b9186fd0770cf467b333c68526c1b04aa8ff4468e2b27e8bd035",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:48176", "10.65.0.27:48176", "172.17.0.1:48176"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:52:09.187657217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2138713076775795,
+				"StableID":   "n8o7vDNdhH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0ce969619d77b87dbee3078999c18424aa6fe334c11dda4a6a35f12ac558b062",
+				"KeyExpiry":  "2026-10-26T10:52:10Z",
+				"DiscoKey":   "discokey:1c005398a40f20224ee913b79ec8c4cd72a7c5b94c1aa11e55d03241abe3692b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51368", "10.65.0.27:51368", "172.17.0.1:51368"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:52:10.248191051Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7325999204624678,
+				"StableID":   "nbVQ1SaxCz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c2e4d708f7c3487a498a1926ae72c60dc68ec922ebce6ac71d61a4adc44b0414",
+				"KeyExpiry":  "2026-10-26T10:52:10Z",
+				"DiscoKey":   "discokey:09456ba0b8fba02821414d4e8b22264e54d4d2ab88f311d820b25cf8cf3c3e61",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:34520", "10.65.0.27:34520", "172.17.0.1:34520"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:52:10.795737894Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8731409962749079,
+				"StableID":   "ngMm6NLUBB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfdb157df4e62035fb5df8eed34a0d93af6f2097f0bca3e9b36fd72b4ed38708",
+				"KeyExpiry":  "2026-10-26T10:52:11Z",
+				"DiscoKey":   "discokey:5e1f986a1ffa37359185ebebcd7ba1c014752e3d2c45de9f17d86d899a94f07f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54844", "10.65.0.27:54844", "172.17.0.1:54844"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:52:11.339243048Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6376009028282424": {
+				"ID":          6376009028282424,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8731409962749079,
+				"StableID":   "ngMm6NLUBB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfdb157df4e62035fb5df8eed34a0d93af6f2097f0bca3e9b36fd72b4ed38708",
+				"KeyExpiry":  "2026-10-26T10:52:11Z",
+				"DiscoKey":   "discokey:5e1f986a1ffa37359185ebebcd7ba1c014752e3d2c45de9f17d86d899a94f07f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54844", "10.65.0.27:54844", "172.17.0.1:54844"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:52:11.339243048Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dfdb157df4e62035fb5df8eed34a0d93af6f2097f0bca3e9b36fd72b4ed38708",
+			"MachineKey": "mkey:243418b854fd8362d459848e71950dded798ede6ff8387c238dc3c7f92caf262",
+			"Peers": [{
+				"ID":         6639952032395638,
+				"StableID":   "nFM1fGHFrt11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd94fb9b06a4e77c99260fd5e6fa1665f1b2595ffa33bfcf97fd8d98516f1556",
+				"DiscoKey":   "discokey:caa751c4c5410feef07cc336b5fdb447d9b16a1b333e4e5792df76b145eba742",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44550", "10.65.0.27:44550", "172.17.0.1:44550"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:52:07.666153684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4055940927569083,
+				"StableID":   "nQPRr3hwfY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae4b49ed2e317bfefd41aac4d5075e65c052478e8423e73fff5268c53437b70d",
+				"DiscoKey":   "discokey:37da770d99ecf3471d325f9e55b2500f7a0047b49f54aa246983f6ce2b1ebe11",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57576", "10.65.0.27:57576", "172.17.0.1:57576"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:52:08.144478784Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6777292117753867,
+				"StableID":   "ncdZhMySvu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6517d0957971248ba6841e27248bf17f6d5c6153a25f714fa125b1d1eaa3a163",
+				"DiscoKey":   "discokey:9074da7aec9a4cfd980535fbcac8bfe113bc7a459af339ee1492e400251caf0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53905", "10.65.0.27:53905", "172.17.0.1:53905"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:52:08.658264777Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2040353544153227,
+				"StableID":   "nCmPqQd5wG11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e4bfce43f915b4c3f480728ec02d7aeb1081d141a62e09247e0299a49b4e76e",
+				"DiscoKey":   "discokey:8e88ae855472b9186fd0770cf467b333c68526c1b04aa8ff4468e2b27e8bd035",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:48176", "10.65.0.27:48176", "172.17.0.1:48176"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:52:09.187657217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6376009028282424,
+				"StableID":   "nRfJDqwhnr11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7c5f990e3d2557b5d9f78c3e4e600853de159a61934389f7c3c8d50b4f885765",
+				"DiscoKey":   "discokey:4ff1069bd096af0f8b1e2ae1ff24cbc2dce1f20017444dafa957c0045bf9e017",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:46106", "10.65.0.27:46106", "172.17.0.1:46106"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:52:09.731456844Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2138713076775795,
+				"StableID":   "n8o7vDNdhH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0ce969619d77b87dbee3078999c18424aa6fe334c11dda4a6a35f12ac558b062",
+				"KeyExpiry":  "2026-10-26T10:52:10Z",
+				"DiscoKey":   "discokey:1c005398a40f20224ee913b79ec8c4cd72a7c5b94c1aa11e55d03241abe3692b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51368", "10.65.0.27:51368", "172.17.0.1:51368"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:52:10.248191051Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7325999204624678,
+				"StableID":   "nbVQ1SaxCz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c2e4d708f7c3487a498a1926ae72c60dc68ec922ebce6ac71d61a4adc44b0414",
+				"KeyExpiry":  "2026-10-26T10:52:10Z",
+				"DiscoKey":   "discokey:09456ba0b8fba02821414d4e8b22264e54d4d2ab88f311d820b25cf8cf3c3e61",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:34520", "10.65.0.27:34520", "172.17.0.1:34520"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:52:10.795737894Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6639952032395638,
+				"StableID":   "nFM1fGHFrt11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       6639952032395638,
+				"Key":        "nodekey:fd94fb9b06a4e77c99260fd5e6fa1665f1b2595ffa33bfcf97fd8d98516f1556",
+				"DiscoKey":   "discokey:caa751c4c5410feef07cc336b5fdb447d9b16a1b333e4e5792df76b145eba742",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44550", "10.65.0.27:44550", "172.17.0.1:44550"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:52:07.666153684Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fd94fb9b06a4e77c99260fd5e6fa1665f1b2595ffa33bfcf97fd8d98516f1556",
+			"MachineKey": "mkey:dc49287cc6223e34359db853229b0678e63f8aa28a477a0a3b6e0d424361d329",
+			"Peers": [{
+				"ID":         4055940927569083,
+				"StableID":   "nQPRr3hwfY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae4b49ed2e317bfefd41aac4d5075e65c052478e8423e73fff5268c53437b70d",
+				"DiscoKey":   "discokey:37da770d99ecf3471d325f9e55b2500f7a0047b49f54aa246983f6ce2b1ebe11",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57576", "10.65.0.27:57576", "172.17.0.1:57576"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:52:08.144478784Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6777292117753867,
+				"StableID":   "ncdZhMySvu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6517d0957971248ba6841e27248bf17f6d5c6153a25f714fa125b1d1eaa3a163",
+				"DiscoKey":   "discokey:9074da7aec9a4cfd980535fbcac8bfe113bc7a459af339ee1492e400251caf0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53905", "10.65.0.27:53905", "172.17.0.1:53905"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:52:08.658264777Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2040353544153227,
+				"StableID":   "nCmPqQd5wG11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e4bfce43f915b4c3f480728ec02d7aeb1081d141a62e09247e0299a49b4e76e",
+				"DiscoKey":   "discokey:8e88ae855472b9186fd0770cf467b333c68526c1b04aa8ff4468e2b27e8bd035",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:48176", "10.65.0.27:48176", "172.17.0.1:48176"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:52:09.187657217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6376009028282424,
+				"StableID":   "nRfJDqwhnr11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7c5f990e3d2557b5d9f78c3e4e600853de159a61934389f7c3c8d50b4f885765",
+				"DiscoKey":   "discokey:4ff1069bd096af0f8b1e2ae1ff24cbc2dce1f20017444dafa957c0045bf9e017",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:46106", "10.65.0.27:46106", "172.17.0.1:46106"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:52:09.731456844Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2138713076775795,
+				"StableID":   "n8o7vDNdhH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0ce969619d77b87dbee3078999c18424aa6fe334c11dda4a6a35f12ac558b062",
+				"KeyExpiry":  "2026-10-26T10:52:10Z",
+				"DiscoKey":   "discokey:1c005398a40f20224ee913b79ec8c4cd72a7c5b94c1aa11e55d03241abe3692b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51368", "10.65.0.27:51368", "172.17.0.1:51368"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:52:10.248191051Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7325999204624678,
+				"StableID":   "nbVQ1SaxCz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c2e4d708f7c3487a498a1926ae72c60dc68ec922ebce6ac71d61a4adc44b0414",
+				"KeyExpiry":  "2026-10-26T10:52:10Z",
+				"DiscoKey":   "discokey:09456ba0b8fba02821414d4e8b22264e54d4d2ab88f311d820b25cf8cf3c3e61",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:34520", "10.65.0.27:34520", "172.17.0.1:34520"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:52:10.795737894Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8731409962749079,
+				"StableID":   "ngMm6NLUBB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfdb157df4e62035fb5df8eed34a0d93af6f2097f0bca3e9b36fd72b4ed38708",
+				"KeyExpiry":  "2026-10-26T10:52:11Z",
+				"DiscoKey":   "discokey:5e1f986a1ffa37359185ebebcd7ba1c014752e3d2c45de9f17d86d899a94f07f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54844", "10.65.0.27:54844", "172.17.0.1:54844"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:52:11.339243048Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6639952032395638": {
+				"ID":          6639952032395638,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2138713076775795,
+				"StableID":   "n8o7vDNdhH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0ce969619d77b87dbee3078999c18424aa6fe334c11dda4a6a35f12ac558b062",
+				"KeyExpiry":  "2026-10-26T10:52:10Z",
+				"DiscoKey":   "discokey:1c005398a40f20224ee913b79ec8c4cd72a7c5b94c1aa11e55d03241abe3692b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51368", "10.65.0.27:51368", "172.17.0.1:51368"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:52:10.248191051Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0ce969619d77b87dbee3078999c18424aa6fe334c11dda4a6a35f12ac558b062",
+			"MachineKey": "mkey:12c450f1ea99b6320df51864beae32ec11c5a2055e7c53dcf0fb3c7306338328",
+			"Peers": [{
+				"ID":         6639952032395638,
+				"StableID":   "nFM1fGHFrt11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd94fb9b06a4e77c99260fd5e6fa1665f1b2595ffa33bfcf97fd8d98516f1556",
+				"DiscoKey":   "discokey:caa751c4c5410feef07cc336b5fdb447d9b16a1b333e4e5792df76b145eba742",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44550", "10.65.0.27:44550", "172.17.0.1:44550"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:52:07.666153684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4055940927569083,
+				"StableID":   "nQPRr3hwfY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae4b49ed2e317bfefd41aac4d5075e65c052478e8423e73fff5268c53437b70d",
+				"DiscoKey":   "discokey:37da770d99ecf3471d325f9e55b2500f7a0047b49f54aa246983f6ce2b1ebe11",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57576", "10.65.0.27:57576", "172.17.0.1:57576"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:52:08.144478784Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6777292117753867,
+				"StableID":   "ncdZhMySvu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6517d0957971248ba6841e27248bf17f6d5c6153a25f714fa125b1d1eaa3a163",
+				"DiscoKey":   "discokey:9074da7aec9a4cfd980535fbcac8bfe113bc7a459af339ee1492e400251caf0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53905", "10.65.0.27:53905", "172.17.0.1:53905"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:52:08.658264777Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2040353544153227,
+				"StableID":   "nCmPqQd5wG11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e4bfce43f915b4c3f480728ec02d7aeb1081d141a62e09247e0299a49b4e76e",
+				"DiscoKey":   "discokey:8e88ae855472b9186fd0770cf467b333c68526c1b04aa8ff4468e2b27e8bd035",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:48176", "10.65.0.27:48176", "172.17.0.1:48176"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:52:09.187657217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6376009028282424,
+				"StableID":   "nRfJDqwhnr11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7c5f990e3d2557b5d9f78c3e4e600853de159a61934389f7c3c8d50b4f885765",
+				"DiscoKey":   "discokey:4ff1069bd096af0f8b1e2ae1ff24cbc2dce1f20017444dafa957c0045bf9e017",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:46106", "10.65.0.27:46106", "172.17.0.1:46106"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:52:09.731456844Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7325999204624678,
+				"StableID":   "nbVQ1SaxCz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c2e4d708f7c3487a498a1926ae72c60dc68ec922ebce6ac71d61a4adc44b0414",
+				"KeyExpiry":  "2026-10-26T10:52:10Z",
+				"DiscoKey":   "discokey:09456ba0b8fba02821414d4e8b22264e54d4d2ab88f311d820b25cf8cf3c3e61",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:34520", "10.65.0.27:34520", "172.17.0.1:34520"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:52:10.795737894Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8731409962749079,
+				"StableID":   "ngMm6NLUBB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfdb157df4e62035fb5df8eed34a0d93af6f2097f0bca3e9b36fd72b4ed38708",
+				"KeyExpiry":  "2026-10-26T10:52:11Z",
+				"DiscoKey":   "discokey:5e1f986a1ffa37359185ebebcd7ba1c014752e3d2c45de9f17d86d899a94f07f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54844", "10.65.0.27:54844", "172.17.0.1:54844"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:52:11.339243048Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2040353544153227,
+				"StableID":   "nCmPqQd5wG11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       2040353544153227,
+				"Key":        "nodekey:4e4bfce43f915b4c3f480728ec02d7aeb1081d141a62e09247e0299a49b4e76e",
+				"DiscoKey":   "discokey:8e88ae855472b9186fd0770cf467b333c68526c1b04aa8ff4468e2b27e8bd035",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:48176", "10.65.0.27:48176", "172.17.0.1:48176"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:52:09.187657217Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4e4bfce43f915b4c3f480728ec02d7aeb1081d141a62e09247e0299a49b4e76e",
+			"MachineKey": "mkey:05022b67f8f2b2b0c4ccfb91bd397667daf4d0abe50e6ecafb1ae7b483d79f05",
+			"Peers": [{
+				"ID":         6639952032395638,
+				"StableID":   "nFM1fGHFrt11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd94fb9b06a4e77c99260fd5e6fa1665f1b2595ffa33bfcf97fd8d98516f1556",
+				"DiscoKey":   "discokey:caa751c4c5410feef07cc336b5fdb447d9b16a1b333e4e5792df76b145eba742",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44550", "10.65.0.27:44550", "172.17.0.1:44550"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:52:07.666153684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4055940927569083,
+				"StableID":   "nQPRr3hwfY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae4b49ed2e317bfefd41aac4d5075e65c052478e8423e73fff5268c53437b70d",
+				"DiscoKey":   "discokey:37da770d99ecf3471d325f9e55b2500f7a0047b49f54aa246983f6ce2b1ebe11",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57576", "10.65.0.27:57576", "172.17.0.1:57576"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:52:08.144478784Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6777292117753867,
+				"StableID":   "ncdZhMySvu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6517d0957971248ba6841e27248bf17f6d5c6153a25f714fa125b1d1eaa3a163",
+				"DiscoKey":   "discokey:9074da7aec9a4cfd980535fbcac8bfe113bc7a459af339ee1492e400251caf0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53905", "10.65.0.27:53905", "172.17.0.1:53905"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:52:08.658264777Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6376009028282424,
+				"StableID":   "nRfJDqwhnr11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7c5f990e3d2557b5d9f78c3e4e600853de159a61934389f7c3c8d50b4f885765",
+				"DiscoKey":   "discokey:4ff1069bd096af0f8b1e2ae1ff24cbc2dce1f20017444dafa957c0045bf9e017",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:46106", "10.65.0.27:46106", "172.17.0.1:46106"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:52:09.731456844Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2138713076775795,
+				"StableID":   "n8o7vDNdhH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0ce969619d77b87dbee3078999c18424aa6fe334c11dda4a6a35f12ac558b062",
+				"KeyExpiry":  "2026-10-26T10:52:10Z",
+				"DiscoKey":   "discokey:1c005398a40f20224ee913b79ec8c4cd72a7c5b94c1aa11e55d03241abe3692b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51368", "10.65.0.27:51368", "172.17.0.1:51368"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:52:10.248191051Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7325999204624678,
+				"StableID":   "nbVQ1SaxCz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c2e4d708f7c3487a498a1926ae72c60dc68ec922ebce6ac71d61a4adc44b0414",
+				"KeyExpiry":  "2026-10-26T10:52:10Z",
+				"DiscoKey":   "discokey:09456ba0b8fba02821414d4e8b22264e54d4d2ab88f311d820b25cf8cf3c3e61",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:34520", "10.65.0.27:34520", "172.17.0.1:34520"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:52:10.795737894Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8731409962749079,
+				"StableID":   "ngMm6NLUBB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfdb157df4e62035fb5df8eed34a0d93af6f2097f0bca3e9b36fd72b4ed38708",
+				"KeyExpiry":  "2026-10-26T10:52:11Z",
+				"DiscoKey":   "discokey:5e1f986a1ffa37359185ebebcd7ba1c014752e3d2c45de9f17d86d899a94f07f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54844", "10.65.0.27:54844", "172.17.0.1:54844"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:52:11.339243048Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2040353544153227": {
+				"ID":          2040353544153227,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4055940927569083,
+				"StableID":   "nQPRr3hwfY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       4055940927569083,
+				"Key":        "nodekey:ae4b49ed2e317bfefd41aac4d5075e65c052478e8423e73fff5268c53437b70d",
+				"DiscoKey":   "discokey:37da770d99ecf3471d325f9e55b2500f7a0047b49f54aa246983f6ce2b1ebe11",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57576", "10.65.0.27:57576", "172.17.0.1:57576"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:52:08.144478784Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ae4b49ed2e317bfefd41aac4d5075e65c052478e8423e73fff5268c53437b70d",
+			"MachineKey": "mkey:539789d97fe5091ac6655280ea225508d429bc68d78ff3210e7dcfa7f7e0f170",
+			"Peers": [{
+				"ID":         6639952032395638,
+				"StableID":   "nFM1fGHFrt11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd94fb9b06a4e77c99260fd5e6fa1665f1b2595ffa33bfcf97fd8d98516f1556",
+				"DiscoKey":   "discokey:caa751c4c5410feef07cc336b5fdb447d9b16a1b333e4e5792df76b145eba742",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44550", "10.65.0.27:44550", "172.17.0.1:44550"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:52:07.666153684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6777292117753867,
+				"StableID":   "ncdZhMySvu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6517d0957971248ba6841e27248bf17f6d5c6153a25f714fa125b1d1eaa3a163",
+				"DiscoKey":   "discokey:9074da7aec9a4cfd980535fbcac8bfe113bc7a459af339ee1492e400251caf0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53905", "10.65.0.27:53905", "172.17.0.1:53905"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:52:08.658264777Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2040353544153227,
+				"StableID":   "nCmPqQd5wG11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e4bfce43f915b4c3f480728ec02d7aeb1081d141a62e09247e0299a49b4e76e",
+				"DiscoKey":   "discokey:8e88ae855472b9186fd0770cf467b333c68526c1b04aa8ff4468e2b27e8bd035",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:48176", "10.65.0.27:48176", "172.17.0.1:48176"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:52:09.187657217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6376009028282424,
+				"StableID":   "nRfJDqwhnr11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7c5f990e3d2557b5d9f78c3e4e600853de159a61934389f7c3c8d50b4f885765",
+				"DiscoKey":   "discokey:4ff1069bd096af0f8b1e2ae1ff24cbc2dce1f20017444dafa957c0045bf9e017",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:46106", "10.65.0.27:46106", "172.17.0.1:46106"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:52:09.731456844Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2138713076775795,
+				"StableID":   "n8o7vDNdhH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0ce969619d77b87dbee3078999c18424aa6fe334c11dda4a6a35f12ac558b062",
+				"KeyExpiry":  "2026-10-26T10:52:10Z",
+				"DiscoKey":   "discokey:1c005398a40f20224ee913b79ec8c4cd72a7c5b94c1aa11e55d03241abe3692b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51368", "10.65.0.27:51368", "172.17.0.1:51368"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:52:10.248191051Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7325999204624678,
+				"StableID":   "nbVQ1SaxCz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c2e4d708f7c3487a498a1926ae72c60dc68ec922ebce6ac71d61a4adc44b0414",
+				"KeyExpiry":  "2026-10-26T10:52:10Z",
+				"DiscoKey":   "discokey:09456ba0b8fba02821414d4e8b22264e54d4d2ab88f311d820b25cf8cf3c3e61",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:34520", "10.65.0.27:34520", "172.17.0.1:34520"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:52:10.795737894Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8731409962749079,
+				"StableID":   "ngMm6NLUBB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfdb157df4e62035fb5df8eed34a0d93af6f2097f0bca3e9b36fd72b4ed38708",
+				"KeyExpiry":  "2026-10-26T10:52:11Z",
+				"DiscoKey":   "discokey:5e1f986a1ffa37359185ebebcd7ba1c014752e3d2c45de9f17d86d899a94f07f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54844", "10.65.0.27:54844", "172.17.0.1:54844"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:52:11.339243048Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4055940927569083": {
+				"ID":          4055940927569083,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7325999204624678,
+				"StableID":   "nbVQ1SaxCz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c2e4d708f7c3487a498a1926ae72c60dc68ec922ebce6ac71d61a4adc44b0414",
+				"KeyExpiry":  "2026-10-26T10:52:10Z",
+				"DiscoKey":   "discokey:09456ba0b8fba02821414d4e8b22264e54d4d2ab88f311d820b25cf8cf3c3e61",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:34520", "10.65.0.27:34520", "172.17.0.1:34520"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:52:10.795737894Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c2e4d708f7c3487a498a1926ae72c60dc68ec922ebce6ac71d61a4adc44b0414",
+			"MachineKey": "mkey:1f22b036c2692264bf7f59810d8eab5364c5d0a26f7735a7472d8df42fed0a5b",
+			"Peers": [{
+				"ID":         6639952032395638,
+				"StableID":   "nFM1fGHFrt11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd94fb9b06a4e77c99260fd5e6fa1665f1b2595ffa33bfcf97fd8d98516f1556",
+				"DiscoKey":   "discokey:caa751c4c5410feef07cc336b5fdb447d9b16a1b333e4e5792df76b145eba742",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44550", "10.65.0.27:44550", "172.17.0.1:44550"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:52:07.666153684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4055940927569083,
+				"StableID":   "nQPRr3hwfY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae4b49ed2e317bfefd41aac4d5075e65c052478e8423e73fff5268c53437b70d",
+				"DiscoKey":   "discokey:37da770d99ecf3471d325f9e55b2500f7a0047b49f54aa246983f6ce2b1ebe11",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57576", "10.65.0.27:57576", "172.17.0.1:57576"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:52:08.144478784Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6777292117753867,
+				"StableID":   "ncdZhMySvu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6517d0957971248ba6841e27248bf17f6d5c6153a25f714fa125b1d1eaa3a163",
+				"DiscoKey":   "discokey:9074da7aec9a4cfd980535fbcac8bfe113bc7a459af339ee1492e400251caf0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53905", "10.65.0.27:53905", "172.17.0.1:53905"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:52:08.658264777Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2040353544153227,
+				"StableID":   "nCmPqQd5wG11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e4bfce43f915b4c3f480728ec02d7aeb1081d141a62e09247e0299a49b4e76e",
+				"DiscoKey":   "discokey:8e88ae855472b9186fd0770cf467b333c68526c1b04aa8ff4468e2b27e8bd035",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:48176", "10.65.0.27:48176", "172.17.0.1:48176"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:52:09.187657217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6376009028282424,
+				"StableID":   "nRfJDqwhnr11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7c5f990e3d2557b5d9f78c3e4e600853de159a61934389f7c3c8d50b4f885765",
+				"DiscoKey":   "discokey:4ff1069bd096af0f8b1e2ae1ff24cbc2dce1f20017444dafa957c0045bf9e017",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:46106", "10.65.0.27:46106", "172.17.0.1:46106"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:52:09.731456844Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2138713076775795,
+				"StableID":   "n8o7vDNdhH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0ce969619d77b87dbee3078999c18424aa6fe334c11dda4a6a35f12ac558b062",
+				"KeyExpiry":  "2026-10-26T10:52:10Z",
+				"DiscoKey":   "discokey:1c005398a40f20224ee913b79ec8c4cd72a7c5b94c1aa11e55d03241abe3692b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51368", "10.65.0.27:51368", "172.17.0.1:51368"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:52:10.248191051Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8731409962749079,
+				"StableID":   "ngMm6NLUBB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfdb157df4e62035fb5df8eed34a0d93af6f2097f0bca3e9b36fd72b4ed38708",
+				"KeyExpiry":  "2026-10-26T10:52:11Z",
+				"DiscoKey":   "discokey:5e1f986a1ffa37359185ebebcd7ba1c014752e3d2c45de9f17d86d899a94f07f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54844", "10.65.0.27:54844", "172.17.0.1:54844"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:52:11.339243048Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6777292117753867,
+				"StableID":   "ncdZhMySvu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       6777292117753867,
+				"Key":        "nodekey:6517d0957971248ba6841e27248bf17f6d5c6153a25f714fa125b1d1eaa3a163",
+				"DiscoKey":   "discokey:9074da7aec9a4cfd980535fbcac8bfe113bc7a459af339ee1492e400251caf0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53905", "10.65.0.27:53905", "172.17.0.1:53905"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:52:08.658264777Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6517d0957971248ba6841e27248bf17f6d5c6153a25f714fa125b1d1eaa3a163",
+			"MachineKey": "mkey:a41d365fccb5d5867a1bb4c51034aec0af7083d68dd128fe441e70e914cde429",
+			"Peers": [{
+				"ID":         6639952032395638,
+				"StableID":   "nFM1fGHFrt11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd94fb9b06a4e77c99260fd5e6fa1665f1b2595ffa33bfcf97fd8d98516f1556",
+				"DiscoKey":   "discokey:caa751c4c5410feef07cc336b5fdb447d9b16a1b333e4e5792df76b145eba742",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44550", "10.65.0.27:44550", "172.17.0.1:44550"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:52:07.666153684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4055940927569083,
+				"StableID":   "nQPRr3hwfY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae4b49ed2e317bfefd41aac4d5075e65c052478e8423e73fff5268c53437b70d",
+				"DiscoKey":   "discokey:37da770d99ecf3471d325f9e55b2500f7a0047b49f54aa246983f6ce2b1ebe11",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57576", "10.65.0.27:57576", "172.17.0.1:57576"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:52:08.144478784Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2040353544153227,
+				"StableID":   "nCmPqQd5wG11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e4bfce43f915b4c3f480728ec02d7aeb1081d141a62e09247e0299a49b4e76e",
+				"DiscoKey":   "discokey:8e88ae855472b9186fd0770cf467b333c68526c1b04aa8ff4468e2b27e8bd035",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:48176", "10.65.0.27:48176", "172.17.0.1:48176"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:52:09.187657217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6376009028282424,
+				"StableID":   "nRfJDqwhnr11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7c5f990e3d2557b5d9f78c3e4e600853de159a61934389f7c3c8d50b4f885765",
+				"DiscoKey":   "discokey:4ff1069bd096af0f8b1e2ae1ff24cbc2dce1f20017444dafa957c0045bf9e017",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:46106", "10.65.0.27:46106", "172.17.0.1:46106"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:52:09.731456844Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2138713076775795,
+				"StableID":   "n8o7vDNdhH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0ce969619d77b87dbee3078999c18424aa6fe334c11dda4a6a35f12ac558b062",
+				"KeyExpiry":  "2026-10-26T10:52:10Z",
+				"DiscoKey":   "discokey:1c005398a40f20224ee913b79ec8c4cd72a7c5b94c1aa11e55d03241abe3692b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51368", "10.65.0.27:51368", "172.17.0.1:51368"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:52:10.248191051Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7325999204624678,
+				"StableID":   "nbVQ1SaxCz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c2e4d708f7c3487a498a1926ae72c60dc68ec922ebce6ac71d61a4adc44b0414",
+				"KeyExpiry":  "2026-10-26T10:52:10Z",
+				"DiscoKey":   "discokey:09456ba0b8fba02821414d4e8b22264e54d4d2ab88f311d820b25cf8cf3c3e61",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:34520", "10.65.0.27:34520", "172.17.0.1:34520"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:52:10.795737894Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8731409962749079,
+				"StableID":   "ngMm6NLUBB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfdb157df4e62035fb5df8eed34a0d93af6f2097f0bca3e9b36fd72b4ed38708",
+				"KeyExpiry":  "2026-10-26T10:52:11Z",
+				"DiscoKey":   "discokey:5e1f986a1ffa37359185ebebcd7ba1c014752e3d2c45de9f17d86d899a94f07f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54844", "10.65.0.27:54844", "172.17.0.1:54844"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:52:11.339243048Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6777292117753867": {
+				"ID":          6777292117753867,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-malformed-test-duplicate-entries.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-malformed-test-duplicate-entries.hujson
@@ -1,0 +1,7232 @@
+// policytest-malformed-test-duplicate-entries
+//
+// tests block malformed: two identical entries
+//
+// Nodes with filter rules: 1 of 8
+// Captured at:    2026-04-29T10:52:32Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-malformed-test-duplicate-entries",
+	"description":    "tests block malformed: two identical entries",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:52:32.997942402Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                              \n  \n                                                                     \n                                                      \n{\n\t\"id\":          \"policytest-malformed-test-duplicate-entries\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block malformed: two identical entries\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": false},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"thor@example.org\"], \"dst\": [\"webserver:80\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"accept\": [\"webserver:80\"]},\n\t\t\t{\"src\": \"thor@example.org\", \"accept\": [\"webserver:80\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-malformed-test-duplicate-entries.hujson",
+		"full_policy": {"acls": [
+			{"action": "accept", "dst": ["webserver:80"], "src": ["thor@example.org"]}
+		], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [
+			{"accept": ["webserver:80"], "src": "thor@example.org"},
+			{"accept": ["webserver:80"], "src": "thor@example.org"}
+		]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {"packet_filter_rules": [{
+		"SrcIPs":   ["100.64.0.17", "fd7a:115c:a1e0::11"],
+		"DstPorts": [{"IP": "100.64.0.16", "Ports": {"First": 80, "Last": 80}}]
+	}], "packet_filter_matches": [{
+		"IPProto": [6, 17, 1, 58],
+		"Srcs":    ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+		"SrcCaps": null,
+		"Dsts":    [{"Net": "100.64.0.16/32", "Ports": {"First": 80, "Last": 80}}],
+		"Caps":    []
+	}], "netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8264967119171033,
+			"StableID":   "nkEiGwfDY721CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       8264967119171033,
+			"Key":        "nodekey:37e1d552d1df8e2f8ac1bc16930c0402e42db32b238da97a5abde337bad4757e",
+			"DiscoKey":   "discokey:0e32128320f5767a4032e348efbe9635fd03f55db40c6e594a036bd0d8b7a618",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints":  ["77.164.248.136:42708", "10.65.0.27:42708", "172.17.0.1:42708"],
+			"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:52:36.555202283Z",
+			"Tags":              ["tag:server"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:37e1d552d1df8e2f8ac1bc16930c0402e42db32b238da97a5abde337bad4757e",
+		"MachineKey": "mkey:8bcd4e90623ddf27f935c4d3bfa0dc03bac39f1188cea5e118817cef2d4e0871",
+		"Peers": [{
+			"ID":         3228300763150402,
+			"StableID":   "nm2JeEz6DS11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:0d9b39c37cd79f02d4b6db18f2119b368e92840bd61c176d8097a01e826baa67",
+			"KeyExpiry":  "2026-10-26T10:52:37Z",
+			"DiscoKey":   "discokey:2909b21136f8ccb6c9a7a7b1b56cc1d59df0eb77da3200dea8f0b983c607a779",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints":  ["77.164.248.136:48095", "10.65.0.27:48095", "172.17.0.1:48095"],
+			"HomeDERP":   14,
+			"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496}
+			]},
+			"Created":              "2026-04-29T10:52:37.088182777Z",
+			"Cap":                  131,
+			"Online":               true,
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		}],
+		"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter": [{
+			"IPProto": [6, 17, 1, 58],
+			"Srcs":    ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"SrcCaps": null,
+			"Dsts":    [{"Net": "100.64.0.16/32", "Ports": {"First": 80, "Last": 80}}],
+			"Caps":    []
+		}],
+		"PacketFilterRules": [{
+			"SrcIPs":   ["100.64.0.17", "fd7a:115c:a1e0::11"],
+			"DstPorts": [{"IP": "100.64.0.16", "Ports": {"First": 80, "Last": 80}}]
+		}],
+		"SSHPolicy":       {"rules": []},
+		"CollectServices": false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}, "8264967119171033": {
+			"ID":          8264967119171033,
+			"LoginName":   "beedrill.tail78f774.ts.net",
+			"DisplayName": "beedrill"
+		}}
+	}}, "bulbasaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         6947300395400110,
+			"StableID":   "nuQg2ToSFw11CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:70715a54431d407f52bc63282251f4e87cee43467ed9f4721dc7f15ece74cc25",
+			"KeyExpiry":  "2026-10-26T10:52:38Z",
+			"DiscoKey":   "discokey:517112267c94fa2833834d761742b5db1ecc74cc03f245de7efbf064626c0130",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints":  ["77.164.248.136:46327", "10.65.0.27:46327", "172.17.0.1:46327"],
+			"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:52:38.173071252Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:70715a54431d407f52bc63282251f4e87cee43467ed9f4721dc7f15ece74cc25",
+		"MachineKey":        "mkey:31bd28d8105bd27288deff80ac5cdb063e598002c79d03e32db45e6f3d0bbb75",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}}
+	}}, "charmander": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         403676362954254,
+			"StableID":   "nj1Ssptp9411CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       403676362954254,
+			"Key":        "nodekey:a3fb5d65604562d5ae2c4ce291cbea918e48570f8d8917245a2182143e9f701e",
+			"DiscoKey":   "discokey:e43702c4564aa904608bd71e49f2aeed63a99cecf827ac361c57d8f0010eeb2a",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"Endpoints":  ["77.164.248.136:59125", "10.65.0.27:59125", "172.17.0.1:59125"],
+			"Hostinfo": {
+				"Hostname":    "charmander",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T10:52:34.416938166Z",
+			"Tags":              ["tag:exit"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:a3fb5d65604562d5ae2c4ce291cbea918e48570f8d8917245a2182143e9f701e",
+		"MachineKey":        "mkey:dae776aece4355c074f7f9b9960e5aa1db792578183350f7db438655f9239069",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"403676362954254": {
+			"ID":          403676362954254,
+			"LoginName":   "charmander.tail78f774.ts.net",
+			"DisplayName": "charmander"
+		}}
+	}}, "ivysaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         3228300763150402,
+			"StableID":   "nm2JeEz6DS11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:0d9b39c37cd79f02d4b6db18f2119b368e92840bd61c176d8097a01e826baa67",
+			"KeyExpiry":  "2026-10-26T10:52:37Z",
+			"DiscoKey":   "discokey:2909b21136f8ccb6c9a7a7b1b56cc1d59df0eb77da3200dea8f0b983c607a779",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints":  ["77.164.248.136:48095", "10.65.0.27:48095", "172.17.0.1:48095"],
+			"Hostinfo": {"Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:52:37.088182777Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:0d9b39c37cd79f02d4b6db18f2119b368e92840bd61c176d8097a01e826baa67",
+		"MachineKey": "mkey:33082841202c053706a87907279a2eb1ea8daa47b2cb3793d80d34fab27bf65d",
+		"Peers": [{
+			"ID":         8264967119171033,
+			"StableID":   "nkEiGwfDY721CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:37e1d552d1df8e2f8ac1bc16930c0402e42db32b238da97a5abde337bad4757e",
+			"DiscoKey":   "discokey:0e32128320f5767a4032e348efbe9635fd03f55db40c6e594a036bd0d8b7a618",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints":  ["77.164.248.136:42708", "10.65.0.27:42708", "172.17.0.1:42708"],
+			"HomeDERP":   14,
+			"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358}
+			]},
+			"Created":              "2026-04-29T10:52:36.555202283Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:server"],
+			"Online":               true,
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}}
+	}}, "kakuna": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         3298185082004680,
+			"StableID":   "nTJNbJjkkS11CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       3298185082004680,
+			"Key":        "nodekey:8c11cfcf9d614f46b516109272888eb774b89a550fa6cbd539418ca22692ce47",
+			"DiscoKey":   "discokey:8b9ecea3d57114592206c91fab1d29ea6dbfa5e670bf6f73d76546ce0719ff32",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints":  ["77.164.248.136:43755", "10.65.0.27:43755", "172.17.0.1:43755"],
+			"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:52:36.042531785Z",
+			"Tags":              ["tag:prod"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:8c11cfcf9d614f46b516109272888eb774b89a550fa6cbd539418ca22692ce47",
+		"MachineKey":        "mkey:7d3675ce5637b618540e8db8ea82f74a37f6b2b4ffbab7136ac0215351fd7f71",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3298185082004680": {
+			"ID":          3298185082004680,
+			"LoginName":   "kakuna.tail78f774.ts.net",
+			"DisplayName": "kakuna"
+		}}
+	}}, "squirtle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1070176669207008,
+			"StableID":   "nTzNc8jgM911CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       1070176669207008,
+			"Key":        "nodekey:e7f1db7247f64315458c7c98c49c6674b99dc22b4c3981bddf2d2ea2fa8ae80a",
+			"DiscoKey":   "discokey:a59110f6ee2e0f78d20fe5d49d4cc0769469879d2af00af63a17a7c2a309df39",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"Endpoints":  ["77.164.248.136:33602", "10.65.0.27:33602", "172.17.0.1:33602"],
+			"Hostinfo": {
+				"Hostname":    "squirtle",
+				"RoutableIPs": ["10.33.0.0/16"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T10:52:34.951739078Z",
+			"Tags":              ["tag:router"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:e7f1db7247f64315458c7c98c49c6674b99dc22b4c3981bddf2d2ea2fa8ae80a",
+		"MachineKey":        "mkey:d17c2054595edc713a64e53af7a21fb0b0690c69492edb7d8607e7d80e7a506c",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1070176669207008": {
+			"ID":          1070176669207008,
+			"LoginName":   "squirtle.tail78f774.ts.net",
+			"DisplayName": "squirtle"
+		}}
+	}}, "venusaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5585972007218562,
+			"StableID":   "nVrt1j1uck11CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:3b5ad088b61338351eabc8a53e2959053c5be07138ceb12a9ae7522b5f3e0909",
+			"KeyExpiry":  "2026-10-26T10:52:37Z",
+			"DiscoKey":   "discokey:bc230b993bb8739e4a7a0041005b75e9cdefa7e30fd5183c4943ec839afb272b",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints":  ["77.164.248.136:50594", "10.65.0.27:50594", "172.17.0.1:50594"],
+			"Hostinfo": {"Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:52:37.631046269Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:3b5ad088b61338351eabc8a53e2959053c5be07138ceb12a9ae7522b5f3e0909",
+		"MachineKey":        "mkey:1e04ed341942559314ce89016620c3eb2914eb3f57d4c3a655e13b7d113e501d",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}}
+	}}, "weedle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         3075381640250483,
+			"StableID":   "n28AQX4r1R11CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       3075381640250483,
+			"Key":        "nodekey:f0bacde219e6b813b6d471c97a33fec54c112addb4fe61ccf8ce9a7a604e8c4e",
+			"DiscoKey":   "discokey:c836b454cb795ac008afd207b28856e277c924f8ec8c3a7ba2123ff79e4b7422",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints":  ["77.164.248.136:58184", "10.65.0.27:58184", "172.17.0.1:58184"],
+			"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:52:35.488313Z",
+			"Tags":              ["tag:client"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:f0bacde219e6b813b6d471c97a33fec54c112addb4fe61ccf8ce9a7a604e8c4e",
+		"MachineKey":        "mkey:ec87d2f0c10594287aa189fb23db1312b498dd152013eefb7220947f3ef5f549",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3075381640250483": {
+			"ID":          3075381640250483,
+			"LoginName":   "weedle.tail78f774.ts.net",
+			"DisplayName": "weedle"
+		}}
+	}}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-malformed-test-empty-string-src.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-malformed-test-empty-string-src.hujson
@@ -1,0 +1,8839 @@
+// policytest-malformed-test-empty-string-src
+//
+// tests block malformed: src is empty string
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:53:09Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-malformed-test-empty-string-src",
+	"description":    "tests block malformed: src is empty string",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:53:09.02289567Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                             \n  \n                                                                 \n{\n\t\"id\":          \"policytest-malformed-test-empty-string-src\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block malformed: src is empty string\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"thor@example.org\"], \"dst\": [\"webserver:80\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"\", \"accept\": [\"webserver:80\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-malformed-test-empty-string-src.hujson",
+		"full_policy": {"acls": [
+			{"action": "accept", "dst": ["webserver:80"], "src": ["thor@example.org"]}
+		], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [{"accept": ["webserver:80"], "src": ""}]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1063327505023427,
+				"StableID":   "nWWeR1paJ911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1063327505023427,
+				"Key":        "nodekey:0e762629391fe69d98f60c9efc9996439780dc24117adc1157508bbf49857f73",
+				"DiscoKey":   "discokey:e47e9bd1cdb928482b110191796df94a947c9f65de792a2db287ce59cf4d797d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:33707", "10.65.0.27:33707", "172.17.0.1:33707"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:53:12.977278658Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0e762629391fe69d98f60c9efc9996439780dc24117adc1157508bbf49857f73",
+			"MachineKey": "mkey:6472d812459a98149b59c4a0fd503395bb908d3aeebb08c952d400e5e8f20550",
+			"Peers": [{
+				"ID":         797633731342302,
+				"StableID":   "nKBHUAVFE711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85a67fa28b84a3d6115ce465ad8815c98d7b93dd087022782fd61026305ca142",
+				"DiscoKey":   "discokey:aef579ad0b8ef53092154d321c309ad98d4bbd8aeb62cbc6e4d40becdab5ca3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:39383", "10.65.0.27:39383", "172.17.0.1:39383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:53:10.678024732Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3571809244372067,
+				"StableID":   "nxTfqaNgtU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf8570bdd62b0b505defaa7a1c073535a325f6f6c758ef8b8061f7b30406eb43",
+				"DiscoKey":   "discokey:1b619be44d6098530ccf72ba85eae504933db431ea2d45bfd6a8e9e8a2f3af00",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52589", "10.65.0.27:52589", "172.17.0.1:52589"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:53:11.369023787Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         638779114620292,
+				"StableID":   "nhTqxMeJz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3191d4107d235bdc42c4d58667be07b51eba57c44b37de34061a8e7da43cf74",
+				"DiscoKey":   "discokey:47cea51e57894dd06fc7bc1c9f708c7b727a42c42f188111c6e036f09640e225",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35462", "10.65.0.27:35462", "172.17.0.1:35462"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:53:11.887165271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6207845791414311,
+				"StableID":   "nvxSpmaYUq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83e1468b62e9504d85d229adc35f60abe06a8a5632e09cbd3d04dae8aa5b777b",
+				"DiscoKey":   "discokey:05f9b09b8a45494e903645fb51fc9836c4909f0d7b297c4a8aaaac6e3363116b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:54372", "10.65.0.27:54372", "172.17.0.1:54372"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:53:12.420582327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7229971738623878,
+				"StableID":   "nZ8hff6UTy11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:055bebb1330978e259bb9c87a0afe8a1608e2b0da16848beb7d0f2c950880151",
+				"KeyExpiry":  "2026-10-26T10:53:13Z",
+				"DiscoKey":   "discokey:8cdee3b6318be0301766d852b5e34009cb337dcc81682c15c8ca944f2100c125",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43627", "10.65.0.27:43627", "172.17.0.1:43627"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:53:13.518614011Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5044922746354134,
+				"StableID":   "nB31apZrPg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2683c5c0db6abc265b75c2353e4dc7e8e7a833f18b262aab0f6946665329406a",
+				"KeyExpiry":  "2026-10-26T10:53:14Z",
+				"DiscoKey":   "discokey:102d8a050312ce044011d0d402c9d27f4cb8ba1c3da6a9f0a50d38bcd786a049",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45801", "10.65.0.27:45801", "172.17.0.1:45801"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:53:14.056171292Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8427674992617711,
+				"StableID":   "nWk4tQjuo821CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a90278fe0fafa406a88c353a391a48fd8f736889dd209ade6d0ae86c3b846837",
+				"KeyExpiry":  "2026-10-26T10:53:14Z",
+				"DiscoKey":   "discokey:ad69bdf18325e13c75595eea0c21b7b1f7b15b7c608c2ac800cbf9ff65e29346",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51737", "10.65.0.27:51737", "172.17.0.1:51737"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:53:14.582955477Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1063327505023427": {
+				"ID":          1063327505023427,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8427674992617711,
+				"StableID":   "nWk4tQjuo821CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a90278fe0fafa406a88c353a391a48fd8f736889dd209ade6d0ae86c3b846837",
+				"KeyExpiry":  "2026-10-26T10:53:14Z",
+				"DiscoKey":   "discokey:ad69bdf18325e13c75595eea0c21b7b1f7b15b7c608c2ac800cbf9ff65e29346",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51737", "10.65.0.27:51737", "172.17.0.1:51737"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:53:14.582955477Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a90278fe0fafa406a88c353a391a48fd8f736889dd209ade6d0ae86c3b846837",
+			"MachineKey": "mkey:6f1608a3f1010f4441ee1172fe6ea580fdfeaf053765d3eb93f09c0c1b7c756a",
+			"Peers": [{
+				"ID":         797633731342302,
+				"StableID":   "nKBHUAVFE711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85a67fa28b84a3d6115ce465ad8815c98d7b93dd087022782fd61026305ca142",
+				"DiscoKey":   "discokey:aef579ad0b8ef53092154d321c309ad98d4bbd8aeb62cbc6e4d40becdab5ca3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:39383", "10.65.0.27:39383", "172.17.0.1:39383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:53:10.678024732Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3571809244372067,
+				"StableID":   "nxTfqaNgtU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf8570bdd62b0b505defaa7a1c073535a325f6f6c758ef8b8061f7b30406eb43",
+				"DiscoKey":   "discokey:1b619be44d6098530ccf72ba85eae504933db431ea2d45bfd6a8e9e8a2f3af00",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52589", "10.65.0.27:52589", "172.17.0.1:52589"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:53:11.369023787Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         638779114620292,
+				"StableID":   "nhTqxMeJz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3191d4107d235bdc42c4d58667be07b51eba57c44b37de34061a8e7da43cf74",
+				"DiscoKey":   "discokey:47cea51e57894dd06fc7bc1c9f708c7b727a42c42f188111c6e036f09640e225",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35462", "10.65.0.27:35462", "172.17.0.1:35462"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:53:11.887165271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6207845791414311,
+				"StableID":   "nvxSpmaYUq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83e1468b62e9504d85d229adc35f60abe06a8a5632e09cbd3d04dae8aa5b777b",
+				"DiscoKey":   "discokey:05f9b09b8a45494e903645fb51fc9836c4909f0d7b297c4a8aaaac6e3363116b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:54372", "10.65.0.27:54372", "172.17.0.1:54372"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:53:12.420582327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1063327505023427,
+				"StableID":   "nWWeR1paJ911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e762629391fe69d98f60c9efc9996439780dc24117adc1157508bbf49857f73",
+				"DiscoKey":   "discokey:e47e9bd1cdb928482b110191796df94a947c9f65de792a2db287ce59cf4d797d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:33707", "10.65.0.27:33707", "172.17.0.1:33707"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:53:12.977278658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7229971738623878,
+				"StableID":   "nZ8hff6UTy11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:055bebb1330978e259bb9c87a0afe8a1608e2b0da16848beb7d0f2c950880151",
+				"KeyExpiry":  "2026-10-26T10:53:13Z",
+				"DiscoKey":   "discokey:8cdee3b6318be0301766d852b5e34009cb337dcc81682c15c8ca944f2100c125",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43627", "10.65.0.27:43627", "172.17.0.1:43627"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:53:13.518614011Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5044922746354134,
+				"StableID":   "nB31apZrPg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2683c5c0db6abc265b75c2353e4dc7e8e7a833f18b262aab0f6946665329406a",
+				"KeyExpiry":  "2026-10-26T10:53:14Z",
+				"DiscoKey":   "discokey:102d8a050312ce044011d0d402c9d27f4cb8ba1c3da6a9f0a50d38bcd786a049",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45801", "10.65.0.27:45801", "172.17.0.1:45801"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:53:14.056171292Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         797633731342302,
+				"StableID":   "nKBHUAVFE711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       797633731342302,
+				"Key":        "nodekey:85a67fa28b84a3d6115ce465ad8815c98d7b93dd087022782fd61026305ca142",
+				"DiscoKey":   "discokey:aef579ad0b8ef53092154d321c309ad98d4bbd8aeb62cbc6e4d40becdab5ca3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:39383", "10.65.0.27:39383", "172.17.0.1:39383"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:53:10.678024732Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:85a67fa28b84a3d6115ce465ad8815c98d7b93dd087022782fd61026305ca142",
+			"MachineKey": "mkey:125dd190c65f6a1c4454c6fa377dde7f3d3891adb0aaa94703ef293181cae11e",
+			"Peers": [{
+				"ID":         3571809244372067,
+				"StableID":   "nxTfqaNgtU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf8570bdd62b0b505defaa7a1c073535a325f6f6c758ef8b8061f7b30406eb43",
+				"DiscoKey":   "discokey:1b619be44d6098530ccf72ba85eae504933db431ea2d45bfd6a8e9e8a2f3af00",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52589", "10.65.0.27:52589", "172.17.0.1:52589"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:53:11.369023787Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         638779114620292,
+				"StableID":   "nhTqxMeJz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3191d4107d235bdc42c4d58667be07b51eba57c44b37de34061a8e7da43cf74",
+				"DiscoKey":   "discokey:47cea51e57894dd06fc7bc1c9f708c7b727a42c42f188111c6e036f09640e225",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35462", "10.65.0.27:35462", "172.17.0.1:35462"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:53:11.887165271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6207845791414311,
+				"StableID":   "nvxSpmaYUq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83e1468b62e9504d85d229adc35f60abe06a8a5632e09cbd3d04dae8aa5b777b",
+				"DiscoKey":   "discokey:05f9b09b8a45494e903645fb51fc9836c4909f0d7b297c4a8aaaac6e3363116b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:54372", "10.65.0.27:54372", "172.17.0.1:54372"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:53:12.420582327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1063327505023427,
+				"StableID":   "nWWeR1paJ911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e762629391fe69d98f60c9efc9996439780dc24117adc1157508bbf49857f73",
+				"DiscoKey":   "discokey:e47e9bd1cdb928482b110191796df94a947c9f65de792a2db287ce59cf4d797d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:33707", "10.65.0.27:33707", "172.17.0.1:33707"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:53:12.977278658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7229971738623878,
+				"StableID":   "nZ8hff6UTy11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:055bebb1330978e259bb9c87a0afe8a1608e2b0da16848beb7d0f2c950880151",
+				"KeyExpiry":  "2026-10-26T10:53:13Z",
+				"DiscoKey":   "discokey:8cdee3b6318be0301766d852b5e34009cb337dcc81682c15c8ca944f2100c125",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43627", "10.65.0.27:43627", "172.17.0.1:43627"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:53:13.518614011Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5044922746354134,
+				"StableID":   "nB31apZrPg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2683c5c0db6abc265b75c2353e4dc7e8e7a833f18b262aab0f6946665329406a",
+				"KeyExpiry":  "2026-10-26T10:53:14Z",
+				"DiscoKey":   "discokey:102d8a050312ce044011d0d402c9d27f4cb8ba1c3da6a9f0a50d38bcd786a049",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45801", "10.65.0.27:45801", "172.17.0.1:45801"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:53:14.056171292Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8427674992617711,
+				"StableID":   "nWk4tQjuo821CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a90278fe0fafa406a88c353a391a48fd8f736889dd209ade6d0ae86c3b846837",
+				"KeyExpiry":  "2026-10-26T10:53:14Z",
+				"DiscoKey":   "discokey:ad69bdf18325e13c75595eea0c21b7b1f7b15b7c608c2ac800cbf9ff65e29346",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51737", "10.65.0.27:51737", "172.17.0.1:51737"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:53:14.582955477Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "797633731342302": {
+				"ID":          797633731342302,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7229971738623878,
+				"StableID":   "nZ8hff6UTy11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:055bebb1330978e259bb9c87a0afe8a1608e2b0da16848beb7d0f2c950880151",
+				"KeyExpiry":  "2026-10-26T10:53:13Z",
+				"DiscoKey":   "discokey:8cdee3b6318be0301766d852b5e34009cb337dcc81682c15c8ca944f2100c125",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43627", "10.65.0.27:43627", "172.17.0.1:43627"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:53:13.518614011Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:055bebb1330978e259bb9c87a0afe8a1608e2b0da16848beb7d0f2c950880151",
+			"MachineKey": "mkey:3b1f6bc1d00f185c172bc1ebef3f1acad536b4c1198aaadbfeb31c8911940b69",
+			"Peers": [{
+				"ID":         797633731342302,
+				"StableID":   "nKBHUAVFE711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85a67fa28b84a3d6115ce465ad8815c98d7b93dd087022782fd61026305ca142",
+				"DiscoKey":   "discokey:aef579ad0b8ef53092154d321c309ad98d4bbd8aeb62cbc6e4d40becdab5ca3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:39383", "10.65.0.27:39383", "172.17.0.1:39383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:53:10.678024732Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3571809244372067,
+				"StableID":   "nxTfqaNgtU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf8570bdd62b0b505defaa7a1c073535a325f6f6c758ef8b8061f7b30406eb43",
+				"DiscoKey":   "discokey:1b619be44d6098530ccf72ba85eae504933db431ea2d45bfd6a8e9e8a2f3af00",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52589", "10.65.0.27:52589", "172.17.0.1:52589"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:53:11.369023787Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         638779114620292,
+				"StableID":   "nhTqxMeJz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3191d4107d235bdc42c4d58667be07b51eba57c44b37de34061a8e7da43cf74",
+				"DiscoKey":   "discokey:47cea51e57894dd06fc7bc1c9f708c7b727a42c42f188111c6e036f09640e225",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35462", "10.65.0.27:35462", "172.17.0.1:35462"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:53:11.887165271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6207845791414311,
+				"StableID":   "nvxSpmaYUq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83e1468b62e9504d85d229adc35f60abe06a8a5632e09cbd3d04dae8aa5b777b",
+				"DiscoKey":   "discokey:05f9b09b8a45494e903645fb51fc9836c4909f0d7b297c4a8aaaac6e3363116b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:54372", "10.65.0.27:54372", "172.17.0.1:54372"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:53:12.420582327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1063327505023427,
+				"StableID":   "nWWeR1paJ911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e762629391fe69d98f60c9efc9996439780dc24117adc1157508bbf49857f73",
+				"DiscoKey":   "discokey:e47e9bd1cdb928482b110191796df94a947c9f65de792a2db287ce59cf4d797d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:33707", "10.65.0.27:33707", "172.17.0.1:33707"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:53:12.977278658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5044922746354134,
+				"StableID":   "nB31apZrPg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2683c5c0db6abc265b75c2353e4dc7e8e7a833f18b262aab0f6946665329406a",
+				"KeyExpiry":  "2026-10-26T10:53:14Z",
+				"DiscoKey":   "discokey:102d8a050312ce044011d0d402c9d27f4cb8ba1c3da6a9f0a50d38bcd786a049",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45801", "10.65.0.27:45801", "172.17.0.1:45801"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:53:14.056171292Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8427674992617711,
+				"StableID":   "nWk4tQjuo821CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a90278fe0fafa406a88c353a391a48fd8f736889dd209ade6d0ae86c3b846837",
+				"KeyExpiry":  "2026-10-26T10:53:14Z",
+				"DiscoKey":   "discokey:ad69bdf18325e13c75595eea0c21b7b1f7b15b7c608c2ac800cbf9ff65e29346",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51737", "10.65.0.27:51737", "172.17.0.1:51737"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:53:14.582955477Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6207845791414311,
+				"StableID":   "nvxSpmaYUq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       6207845791414311,
+				"Key":        "nodekey:83e1468b62e9504d85d229adc35f60abe06a8a5632e09cbd3d04dae8aa5b777b",
+				"DiscoKey":   "discokey:05f9b09b8a45494e903645fb51fc9836c4909f0d7b297c4a8aaaac6e3363116b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:54372", "10.65.0.27:54372", "172.17.0.1:54372"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:53:12.420582327Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:83e1468b62e9504d85d229adc35f60abe06a8a5632e09cbd3d04dae8aa5b777b",
+			"MachineKey": "mkey:98047333d48c79e307cbe31e219b4fc5e62f4c8f51512411b362acc0f5f27e1c",
+			"Peers": [{
+				"ID":         797633731342302,
+				"StableID":   "nKBHUAVFE711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85a67fa28b84a3d6115ce465ad8815c98d7b93dd087022782fd61026305ca142",
+				"DiscoKey":   "discokey:aef579ad0b8ef53092154d321c309ad98d4bbd8aeb62cbc6e4d40becdab5ca3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:39383", "10.65.0.27:39383", "172.17.0.1:39383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:53:10.678024732Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3571809244372067,
+				"StableID":   "nxTfqaNgtU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf8570bdd62b0b505defaa7a1c073535a325f6f6c758ef8b8061f7b30406eb43",
+				"DiscoKey":   "discokey:1b619be44d6098530ccf72ba85eae504933db431ea2d45bfd6a8e9e8a2f3af00",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52589", "10.65.0.27:52589", "172.17.0.1:52589"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:53:11.369023787Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         638779114620292,
+				"StableID":   "nhTqxMeJz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3191d4107d235bdc42c4d58667be07b51eba57c44b37de34061a8e7da43cf74",
+				"DiscoKey":   "discokey:47cea51e57894dd06fc7bc1c9f708c7b727a42c42f188111c6e036f09640e225",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35462", "10.65.0.27:35462", "172.17.0.1:35462"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:53:11.887165271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1063327505023427,
+				"StableID":   "nWWeR1paJ911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e762629391fe69d98f60c9efc9996439780dc24117adc1157508bbf49857f73",
+				"DiscoKey":   "discokey:e47e9bd1cdb928482b110191796df94a947c9f65de792a2db287ce59cf4d797d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:33707", "10.65.0.27:33707", "172.17.0.1:33707"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:53:12.977278658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7229971738623878,
+				"StableID":   "nZ8hff6UTy11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:055bebb1330978e259bb9c87a0afe8a1608e2b0da16848beb7d0f2c950880151",
+				"KeyExpiry":  "2026-10-26T10:53:13Z",
+				"DiscoKey":   "discokey:8cdee3b6318be0301766d852b5e34009cb337dcc81682c15c8ca944f2100c125",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43627", "10.65.0.27:43627", "172.17.0.1:43627"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:53:13.518614011Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5044922746354134,
+				"StableID":   "nB31apZrPg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2683c5c0db6abc265b75c2353e4dc7e8e7a833f18b262aab0f6946665329406a",
+				"KeyExpiry":  "2026-10-26T10:53:14Z",
+				"DiscoKey":   "discokey:102d8a050312ce044011d0d402c9d27f4cb8ba1c3da6a9f0a50d38bcd786a049",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45801", "10.65.0.27:45801", "172.17.0.1:45801"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:53:14.056171292Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8427674992617711,
+				"StableID":   "nWk4tQjuo821CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a90278fe0fafa406a88c353a391a48fd8f736889dd209ade6d0ae86c3b846837",
+				"KeyExpiry":  "2026-10-26T10:53:14Z",
+				"DiscoKey":   "discokey:ad69bdf18325e13c75595eea0c21b7b1f7b15b7c608c2ac800cbf9ff65e29346",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51737", "10.65.0.27:51737", "172.17.0.1:51737"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:53:14.582955477Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6207845791414311": {
+				"ID":          6207845791414311,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3571809244372067,
+				"StableID":   "nxTfqaNgtU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       3571809244372067,
+				"Key":        "nodekey:bf8570bdd62b0b505defaa7a1c073535a325f6f6c758ef8b8061f7b30406eb43",
+				"DiscoKey":   "discokey:1b619be44d6098530ccf72ba85eae504933db431ea2d45bfd6a8e9e8a2f3af00",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52589", "10.65.0.27:52589", "172.17.0.1:52589"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:53:11.369023787Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bf8570bdd62b0b505defaa7a1c073535a325f6f6c758ef8b8061f7b30406eb43",
+			"MachineKey": "mkey:cf67a9663b1c2214086bf6812955a914264ce7c24b7e8df5bbf7c070b81bb50b",
+			"Peers": [{
+				"ID":         797633731342302,
+				"StableID":   "nKBHUAVFE711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85a67fa28b84a3d6115ce465ad8815c98d7b93dd087022782fd61026305ca142",
+				"DiscoKey":   "discokey:aef579ad0b8ef53092154d321c309ad98d4bbd8aeb62cbc6e4d40becdab5ca3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:39383", "10.65.0.27:39383", "172.17.0.1:39383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:53:10.678024732Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         638779114620292,
+				"StableID":   "nhTqxMeJz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3191d4107d235bdc42c4d58667be07b51eba57c44b37de34061a8e7da43cf74",
+				"DiscoKey":   "discokey:47cea51e57894dd06fc7bc1c9f708c7b727a42c42f188111c6e036f09640e225",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35462", "10.65.0.27:35462", "172.17.0.1:35462"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:53:11.887165271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6207845791414311,
+				"StableID":   "nvxSpmaYUq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83e1468b62e9504d85d229adc35f60abe06a8a5632e09cbd3d04dae8aa5b777b",
+				"DiscoKey":   "discokey:05f9b09b8a45494e903645fb51fc9836c4909f0d7b297c4a8aaaac6e3363116b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:54372", "10.65.0.27:54372", "172.17.0.1:54372"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:53:12.420582327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1063327505023427,
+				"StableID":   "nWWeR1paJ911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e762629391fe69d98f60c9efc9996439780dc24117adc1157508bbf49857f73",
+				"DiscoKey":   "discokey:e47e9bd1cdb928482b110191796df94a947c9f65de792a2db287ce59cf4d797d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:33707", "10.65.0.27:33707", "172.17.0.1:33707"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:53:12.977278658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7229971738623878,
+				"StableID":   "nZ8hff6UTy11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:055bebb1330978e259bb9c87a0afe8a1608e2b0da16848beb7d0f2c950880151",
+				"KeyExpiry":  "2026-10-26T10:53:13Z",
+				"DiscoKey":   "discokey:8cdee3b6318be0301766d852b5e34009cb337dcc81682c15c8ca944f2100c125",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43627", "10.65.0.27:43627", "172.17.0.1:43627"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:53:13.518614011Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5044922746354134,
+				"StableID":   "nB31apZrPg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2683c5c0db6abc265b75c2353e4dc7e8e7a833f18b262aab0f6946665329406a",
+				"KeyExpiry":  "2026-10-26T10:53:14Z",
+				"DiscoKey":   "discokey:102d8a050312ce044011d0d402c9d27f4cb8ba1c3da6a9f0a50d38bcd786a049",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45801", "10.65.0.27:45801", "172.17.0.1:45801"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:53:14.056171292Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8427674992617711,
+				"StableID":   "nWk4tQjuo821CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a90278fe0fafa406a88c353a391a48fd8f736889dd209ade6d0ae86c3b846837",
+				"KeyExpiry":  "2026-10-26T10:53:14Z",
+				"DiscoKey":   "discokey:ad69bdf18325e13c75595eea0c21b7b1f7b15b7c608c2ac800cbf9ff65e29346",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51737", "10.65.0.27:51737", "172.17.0.1:51737"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:53:14.582955477Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3571809244372067": {
+				"ID":          3571809244372067,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5044922746354134,
+				"StableID":   "nB31apZrPg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2683c5c0db6abc265b75c2353e4dc7e8e7a833f18b262aab0f6946665329406a",
+				"KeyExpiry":  "2026-10-26T10:53:14Z",
+				"DiscoKey":   "discokey:102d8a050312ce044011d0d402c9d27f4cb8ba1c3da6a9f0a50d38bcd786a049",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45801", "10.65.0.27:45801", "172.17.0.1:45801"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:53:14.056171292Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2683c5c0db6abc265b75c2353e4dc7e8e7a833f18b262aab0f6946665329406a",
+			"MachineKey": "mkey:dc7e907de97a5399f65e0ed05ac1e6256d63145afc6a2dd531f1cc8ef489fc03",
+			"Peers": [{
+				"ID":         797633731342302,
+				"StableID":   "nKBHUAVFE711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85a67fa28b84a3d6115ce465ad8815c98d7b93dd087022782fd61026305ca142",
+				"DiscoKey":   "discokey:aef579ad0b8ef53092154d321c309ad98d4bbd8aeb62cbc6e4d40becdab5ca3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:39383", "10.65.0.27:39383", "172.17.0.1:39383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:53:10.678024732Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3571809244372067,
+				"StableID":   "nxTfqaNgtU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf8570bdd62b0b505defaa7a1c073535a325f6f6c758ef8b8061f7b30406eb43",
+				"DiscoKey":   "discokey:1b619be44d6098530ccf72ba85eae504933db431ea2d45bfd6a8e9e8a2f3af00",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52589", "10.65.0.27:52589", "172.17.0.1:52589"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:53:11.369023787Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         638779114620292,
+				"StableID":   "nhTqxMeJz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3191d4107d235bdc42c4d58667be07b51eba57c44b37de34061a8e7da43cf74",
+				"DiscoKey":   "discokey:47cea51e57894dd06fc7bc1c9f708c7b727a42c42f188111c6e036f09640e225",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35462", "10.65.0.27:35462", "172.17.0.1:35462"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:53:11.887165271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6207845791414311,
+				"StableID":   "nvxSpmaYUq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83e1468b62e9504d85d229adc35f60abe06a8a5632e09cbd3d04dae8aa5b777b",
+				"DiscoKey":   "discokey:05f9b09b8a45494e903645fb51fc9836c4909f0d7b297c4a8aaaac6e3363116b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:54372", "10.65.0.27:54372", "172.17.0.1:54372"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:53:12.420582327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1063327505023427,
+				"StableID":   "nWWeR1paJ911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e762629391fe69d98f60c9efc9996439780dc24117adc1157508bbf49857f73",
+				"DiscoKey":   "discokey:e47e9bd1cdb928482b110191796df94a947c9f65de792a2db287ce59cf4d797d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:33707", "10.65.0.27:33707", "172.17.0.1:33707"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:53:12.977278658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7229971738623878,
+				"StableID":   "nZ8hff6UTy11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:055bebb1330978e259bb9c87a0afe8a1608e2b0da16848beb7d0f2c950880151",
+				"KeyExpiry":  "2026-10-26T10:53:13Z",
+				"DiscoKey":   "discokey:8cdee3b6318be0301766d852b5e34009cb337dcc81682c15c8ca944f2100c125",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43627", "10.65.0.27:43627", "172.17.0.1:43627"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:53:13.518614011Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8427674992617711,
+				"StableID":   "nWk4tQjuo821CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a90278fe0fafa406a88c353a391a48fd8f736889dd209ade6d0ae86c3b846837",
+				"KeyExpiry":  "2026-10-26T10:53:14Z",
+				"DiscoKey":   "discokey:ad69bdf18325e13c75595eea0c21b7b1f7b15b7c608c2ac800cbf9ff65e29346",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51737", "10.65.0.27:51737", "172.17.0.1:51737"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:53:14.582955477Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         638779114620292,
+				"StableID":   "nhTqxMeJz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       638779114620292,
+				"Key":        "nodekey:e3191d4107d235bdc42c4d58667be07b51eba57c44b37de34061a8e7da43cf74",
+				"DiscoKey":   "discokey:47cea51e57894dd06fc7bc1c9f708c7b727a42c42f188111c6e036f09640e225",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35462", "10.65.0.27:35462", "172.17.0.1:35462"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:53:11.887165271Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e3191d4107d235bdc42c4d58667be07b51eba57c44b37de34061a8e7da43cf74",
+			"MachineKey": "mkey:83f607cecce087ca193f486d30739e4c86fb518a6ebf590d599d0bb3d9b9c351",
+			"Peers": [{
+				"ID":         797633731342302,
+				"StableID":   "nKBHUAVFE711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85a67fa28b84a3d6115ce465ad8815c98d7b93dd087022782fd61026305ca142",
+				"DiscoKey":   "discokey:aef579ad0b8ef53092154d321c309ad98d4bbd8aeb62cbc6e4d40becdab5ca3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:39383", "10.65.0.27:39383", "172.17.0.1:39383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:53:10.678024732Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3571809244372067,
+				"StableID":   "nxTfqaNgtU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf8570bdd62b0b505defaa7a1c073535a325f6f6c758ef8b8061f7b30406eb43",
+				"DiscoKey":   "discokey:1b619be44d6098530ccf72ba85eae504933db431ea2d45bfd6a8e9e8a2f3af00",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52589", "10.65.0.27:52589", "172.17.0.1:52589"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:53:11.369023787Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6207845791414311,
+				"StableID":   "nvxSpmaYUq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83e1468b62e9504d85d229adc35f60abe06a8a5632e09cbd3d04dae8aa5b777b",
+				"DiscoKey":   "discokey:05f9b09b8a45494e903645fb51fc9836c4909f0d7b297c4a8aaaac6e3363116b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:54372", "10.65.0.27:54372", "172.17.0.1:54372"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:53:12.420582327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1063327505023427,
+				"StableID":   "nWWeR1paJ911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e762629391fe69d98f60c9efc9996439780dc24117adc1157508bbf49857f73",
+				"DiscoKey":   "discokey:e47e9bd1cdb928482b110191796df94a947c9f65de792a2db287ce59cf4d797d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:33707", "10.65.0.27:33707", "172.17.0.1:33707"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:53:12.977278658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7229971738623878,
+				"StableID":   "nZ8hff6UTy11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:055bebb1330978e259bb9c87a0afe8a1608e2b0da16848beb7d0f2c950880151",
+				"KeyExpiry":  "2026-10-26T10:53:13Z",
+				"DiscoKey":   "discokey:8cdee3b6318be0301766d852b5e34009cb337dcc81682c15c8ca944f2100c125",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43627", "10.65.0.27:43627", "172.17.0.1:43627"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:53:13.518614011Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5044922746354134,
+				"StableID":   "nB31apZrPg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2683c5c0db6abc265b75c2353e4dc7e8e7a833f18b262aab0f6946665329406a",
+				"KeyExpiry":  "2026-10-26T10:53:14Z",
+				"DiscoKey":   "discokey:102d8a050312ce044011d0d402c9d27f4cb8ba1c3da6a9f0a50d38bcd786a049",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45801", "10.65.0.27:45801", "172.17.0.1:45801"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:53:14.056171292Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8427674992617711,
+				"StableID":   "nWk4tQjuo821CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a90278fe0fafa406a88c353a391a48fd8f736889dd209ade6d0ae86c3b846837",
+				"KeyExpiry":  "2026-10-26T10:53:14Z",
+				"DiscoKey":   "discokey:ad69bdf18325e13c75595eea0c21b7b1f7b15b7c608c2ac800cbf9ff65e29346",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51737", "10.65.0.27:51737", "172.17.0.1:51737"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:53:14.582955477Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "638779114620292": {
+				"ID":          638779114620292,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-malformed-test-missing-accept-and-deny.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-malformed-test-missing-accept-and-deny.hujson
@@ -1,0 +1,8841 @@
+// policytest-malformed-test-missing-accept-and-deny
+//
+// tests block malformed: entry missing both accept and deny
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:53:36Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-malformed-test-missing-accept-and-deny",
+	"description":    "tests block malformed: entry missing both accept and deny",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:53:36.29282311Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                                    \n  \n                                                                      \n                                                             \n{\n\t\"id\":          \"policytest-malformed-test-missing-accept-and-deny\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block malformed: entry missing both accept and deny\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"thor@example.org\"], \"dst\": [\"tag:server:22\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\"}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-malformed-test-missing-accept-and-deny.hujson",
+		"full_policy": {"acls": [{
+			"action": "accept",
+			"dst":    ["tag:server:22"],
+			"src":    ["thor@example.org"]
+		}], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [{"src": "thor@example.org"}]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3267684606633163,
+				"StableID":   "nJxc2xXwWS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       3267684606633163,
+				"Key":        "nodekey:f47280337a5284f99ef2e851c7b9d3151897922d4d5499b67be1ab711be4cd65",
+				"DiscoKey":   "discokey:54b6326f7a4305771e53e6539b3728c210b56bd7d55deab1ae18ad8401fd9c67",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:48941", "10.65.0.27:48941", "172.17.0.1:48941"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:53:39.91627883Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f47280337a5284f99ef2e851c7b9d3151897922d4d5499b67be1ab711be4cd65",
+			"MachineKey": "mkey:048942815acc427e1398954e5eca16b49dac2f1ca001415a43b1720c365f8226",
+			"Peers": [{
+				"ID":         1332891564342740,
+				"StableID":   "n5MZGUofQB11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38ca5e019d152b668232da0db09135d19b327666fcb95ce2e1cdbd53afb49b44",
+				"DiscoKey":   "discokey:cb02825c55d02bd74b45e1c0ce94300275c573549de571c2b62688e45e00863d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60598", "10.65.0.27:60598", "172.17.0.1:60598"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:53:37.744470111Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5502462458311255,
+				"StableID":   "nphK9nM5yj11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea65343a0a009c4c1ef9315b5fb9439aaa6354a7954f85bff5039db0b80c93b",
+				"DiscoKey":   "discokey:36a3ad0fc57b9f555e1a57e36fe2dd659f714fbf537ca0e2450af1f2a50e3d54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60909", "10.65.0.27:60909", "172.17.0.1:60909"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:53:38.307795398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6368441665045699,
+				"StableID":   "ntMhEVAHjr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8eaf7cd8a67aa93f0ceaa68f163e79726d0bebd3593ba60d424a78aeaa50ce31",
+				"DiscoKey":   "discokey:4f580b1f4fff4906e4bd68703b4eb252f50ae3b6bf06f02c9a0862f7d5784d0e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:41983", "10.65.0.27:41983", "172.17.0.1:41983"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:53:38.85914463Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4917962976200815,
+				"StableID":   "ncRASnYMQf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e40e2e376a0263a97939dc575ce4ae4e97999f06d68d672bd038a35eedad37a",
+				"DiscoKey":   "discokey:fe88e44fc7d342c6730a86b5ae100ca03a702b3cc3a3062af356f37c9667bf46",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58675", "10.65.0.27:58675", "172.17.0.1:58675"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:53:39.398338023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1500449647044741,
+				"StableID":   "nQi8GYGZiC11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ac2fd0f325119a9ad913873cad20148f2b73b9b2f3473e129545409ec7897d35",
+				"KeyExpiry":  "2026-10-26T10:53:40Z",
+				"DiscoKey":   "discokey:85f75cddfb2e8fafc05d39b5c27136639bae8b79527a84b145bfb5175898dc2f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55802", "10.65.0.27:55802", "172.17.0.1:55802"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:53:40.463503706Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5573586227500890,
+				"StableID":   "njsL5EfHXk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:99d641ff88a64691c63135dd0a1711ec1410535b8c6839595b5ed8daf6dedf21",
+				"KeyExpiry":  "2026-10-26T10:53:41Z",
+				"DiscoKey":   "discokey:265178ee5d1b0f78e57695826eff4f3ecb29a2a21fdd278f980fdf41aca7cc1d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60383", "10.65.0.27:60383", "172.17.0.1:60383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:53:41.029591414Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3088679026792188,
+				"StableID":   "nqyxuuMs7R11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:75a7e9837a3cb73cce4e81333158d8a7112ff4b13e0fd1ca855362f5b48c4b1d",
+				"KeyExpiry":  "2026-10-26T10:53:41Z",
+				"DiscoKey":   "discokey:4df6ad15c00d37b0e7d6ca8dce56b80a107806b19291d8516643dd052c8c6538",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39486", "10.65.0.27:39486", "172.17.0.1:39486"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:53:41.556487108Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3267684606633163": {
+				"ID":          3267684606633163,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3088679026792188,
+				"StableID":   "nqyxuuMs7R11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:75a7e9837a3cb73cce4e81333158d8a7112ff4b13e0fd1ca855362f5b48c4b1d",
+				"KeyExpiry":  "2026-10-26T10:53:41Z",
+				"DiscoKey":   "discokey:4df6ad15c00d37b0e7d6ca8dce56b80a107806b19291d8516643dd052c8c6538",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39486", "10.65.0.27:39486", "172.17.0.1:39486"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:53:41.556487108Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:75a7e9837a3cb73cce4e81333158d8a7112ff4b13e0fd1ca855362f5b48c4b1d",
+			"MachineKey": "mkey:c7e1e54eb7ab97926ad5317ae4d5f4775dd3406e9cceb69f153eecb911cf9a4e",
+			"Peers": [{
+				"ID":         1332891564342740,
+				"StableID":   "n5MZGUofQB11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38ca5e019d152b668232da0db09135d19b327666fcb95ce2e1cdbd53afb49b44",
+				"DiscoKey":   "discokey:cb02825c55d02bd74b45e1c0ce94300275c573549de571c2b62688e45e00863d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60598", "10.65.0.27:60598", "172.17.0.1:60598"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:53:37.744470111Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5502462458311255,
+				"StableID":   "nphK9nM5yj11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea65343a0a009c4c1ef9315b5fb9439aaa6354a7954f85bff5039db0b80c93b",
+				"DiscoKey":   "discokey:36a3ad0fc57b9f555e1a57e36fe2dd659f714fbf537ca0e2450af1f2a50e3d54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60909", "10.65.0.27:60909", "172.17.0.1:60909"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:53:38.307795398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6368441665045699,
+				"StableID":   "ntMhEVAHjr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8eaf7cd8a67aa93f0ceaa68f163e79726d0bebd3593ba60d424a78aeaa50ce31",
+				"DiscoKey":   "discokey:4f580b1f4fff4906e4bd68703b4eb252f50ae3b6bf06f02c9a0862f7d5784d0e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:41983", "10.65.0.27:41983", "172.17.0.1:41983"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:53:38.85914463Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4917962976200815,
+				"StableID":   "ncRASnYMQf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e40e2e376a0263a97939dc575ce4ae4e97999f06d68d672bd038a35eedad37a",
+				"DiscoKey":   "discokey:fe88e44fc7d342c6730a86b5ae100ca03a702b3cc3a3062af356f37c9667bf46",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58675", "10.65.0.27:58675", "172.17.0.1:58675"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:53:39.398338023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3267684606633163,
+				"StableID":   "nJxc2xXwWS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f47280337a5284f99ef2e851c7b9d3151897922d4d5499b67be1ab711be4cd65",
+				"DiscoKey":   "discokey:54b6326f7a4305771e53e6539b3728c210b56bd7d55deab1ae18ad8401fd9c67",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:48941", "10.65.0.27:48941", "172.17.0.1:48941"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:53:39.91627883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1500449647044741,
+				"StableID":   "nQi8GYGZiC11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ac2fd0f325119a9ad913873cad20148f2b73b9b2f3473e129545409ec7897d35",
+				"KeyExpiry":  "2026-10-26T10:53:40Z",
+				"DiscoKey":   "discokey:85f75cddfb2e8fafc05d39b5c27136639bae8b79527a84b145bfb5175898dc2f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55802", "10.65.0.27:55802", "172.17.0.1:55802"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:53:40.463503706Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5573586227500890,
+				"StableID":   "njsL5EfHXk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:99d641ff88a64691c63135dd0a1711ec1410535b8c6839595b5ed8daf6dedf21",
+				"KeyExpiry":  "2026-10-26T10:53:41Z",
+				"DiscoKey":   "discokey:265178ee5d1b0f78e57695826eff4f3ecb29a2a21fdd278f980fdf41aca7cc1d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60383", "10.65.0.27:60383", "172.17.0.1:60383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:53:41.029591414Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1332891564342740,
+				"StableID":   "n5MZGUofQB11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1332891564342740,
+				"Key":        "nodekey:38ca5e019d152b668232da0db09135d19b327666fcb95ce2e1cdbd53afb49b44",
+				"DiscoKey":   "discokey:cb02825c55d02bd74b45e1c0ce94300275c573549de571c2b62688e45e00863d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60598", "10.65.0.27:60598", "172.17.0.1:60598"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:53:37.744470111Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:38ca5e019d152b668232da0db09135d19b327666fcb95ce2e1cdbd53afb49b44",
+			"MachineKey": "mkey:22092b87041e9155244ce07b8ed9be79a71cb58167762651c9a1c2f394c12c5d",
+			"Peers": [{
+				"ID":         5502462458311255,
+				"StableID":   "nphK9nM5yj11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea65343a0a009c4c1ef9315b5fb9439aaa6354a7954f85bff5039db0b80c93b",
+				"DiscoKey":   "discokey:36a3ad0fc57b9f555e1a57e36fe2dd659f714fbf537ca0e2450af1f2a50e3d54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60909", "10.65.0.27:60909", "172.17.0.1:60909"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:53:38.307795398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6368441665045699,
+				"StableID":   "ntMhEVAHjr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8eaf7cd8a67aa93f0ceaa68f163e79726d0bebd3593ba60d424a78aeaa50ce31",
+				"DiscoKey":   "discokey:4f580b1f4fff4906e4bd68703b4eb252f50ae3b6bf06f02c9a0862f7d5784d0e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:41983", "10.65.0.27:41983", "172.17.0.1:41983"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:53:38.85914463Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4917962976200815,
+				"StableID":   "ncRASnYMQf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e40e2e376a0263a97939dc575ce4ae4e97999f06d68d672bd038a35eedad37a",
+				"DiscoKey":   "discokey:fe88e44fc7d342c6730a86b5ae100ca03a702b3cc3a3062af356f37c9667bf46",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58675", "10.65.0.27:58675", "172.17.0.1:58675"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:53:39.398338023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3267684606633163,
+				"StableID":   "nJxc2xXwWS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f47280337a5284f99ef2e851c7b9d3151897922d4d5499b67be1ab711be4cd65",
+				"DiscoKey":   "discokey:54b6326f7a4305771e53e6539b3728c210b56bd7d55deab1ae18ad8401fd9c67",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:48941", "10.65.0.27:48941", "172.17.0.1:48941"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:53:39.91627883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1500449647044741,
+				"StableID":   "nQi8GYGZiC11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ac2fd0f325119a9ad913873cad20148f2b73b9b2f3473e129545409ec7897d35",
+				"KeyExpiry":  "2026-10-26T10:53:40Z",
+				"DiscoKey":   "discokey:85f75cddfb2e8fafc05d39b5c27136639bae8b79527a84b145bfb5175898dc2f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55802", "10.65.0.27:55802", "172.17.0.1:55802"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:53:40.463503706Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5573586227500890,
+				"StableID":   "njsL5EfHXk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:99d641ff88a64691c63135dd0a1711ec1410535b8c6839595b5ed8daf6dedf21",
+				"KeyExpiry":  "2026-10-26T10:53:41Z",
+				"DiscoKey":   "discokey:265178ee5d1b0f78e57695826eff4f3ecb29a2a21fdd278f980fdf41aca7cc1d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60383", "10.65.0.27:60383", "172.17.0.1:60383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:53:41.029591414Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3088679026792188,
+				"StableID":   "nqyxuuMs7R11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:75a7e9837a3cb73cce4e81333158d8a7112ff4b13e0fd1ca855362f5b48c4b1d",
+				"KeyExpiry":  "2026-10-26T10:53:41Z",
+				"DiscoKey":   "discokey:4df6ad15c00d37b0e7d6ca8dce56b80a107806b19291d8516643dd052c8c6538",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39486", "10.65.0.27:39486", "172.17.0.1:39486"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:53:41.556487108Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1332891564342740": {
+				"ID":          1332891564342740,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1500449647044741,
+				"StableID":   "nQi8GYGZiC11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ac2fd0f325119a9ad913873cad20148f2b73b9b2f3473e129545409ec7897d35",
+				"KeyExpiry":  "2026-10-26T10:53:40Z",
+				"DiscoKey":   "discokey:85f75cddfb2e8fafc05d39b5c27136639bae8b79527a84b145bfb5175898dc2f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55802", "10.65.0.27:55802", "172.17.0.1:55802"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:53:40.463503706Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ac2fd0f325119a9ad913873cad20148f2b73b9b2f3473e129545409ec7897d35",
+			"MachineKey": "mkey:9a977cff241fe0078ca61a02b0e5469366e80d24098a942d4de9f51de35bff51",
+			"Peers": [{
+				"ID":         1332891564342740,
+				"StableID":   "n5MZGUofQB11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38ca5e019d152b668232da0db09135d19b327666fcb95ce2e1cdbd53afb49b44",
+				"DiscoKey":   "discokey:cb02825c55d02bd74b45e1c0ce94300275c573549de571c2b62688e45e00863d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60598", "10.65.0.27:60598", "172.17.0.1:60598"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:53:37.744470111Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5502462458311255,
+				"StableID":   "nphK9nM5yj11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea65343a0a009c4c1ef9315b5fb9439aaa6354a7954f85bff5039db0b80c93b",
+				"DiscoKey":   "discokey:36a3ad0fc57b9f555e1a57e36fe2dd659f714fbf537ca0e2450af1f2a50e3d54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60909", "10.65.0.27:60909", "172.17.0.1:60909"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:53:38.307795398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6368441665045699,
+				"StableID":   "ntMhEVAHjr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8eaf7cd8a67aa93f0ceaa68f163e79726d0bebd3593ba60d424a78aeaa50ce31",
+				"DiscoKey":   "discokey:4f580b1f4fff4906e4bd68703b4eb252f50ae3b6bf06f02c9a0862f7d5784d0e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:41983", "10.65.0.27:41983", "172.17.0.1:41983"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:53:38.85914463Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4917962976200815,
+				"StableID":   "ncRASnYMQf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e40e2e376a0263a97939dc575ce4ae4e97999f06d68d672bd038a35eedad37a",
+				"DiscoKey":   "discokey:fe88e44fc7d342c6730a86b5ae100ca03a702b3cc3a3062af356f37c9667bf46",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58675", "10.65.0.27:58675", "172.17.0.1:58675"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:53:39.398338023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3267684606633163,
+				"StableID":   "nJxc2xXwWS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f47280337a5284f99ef2e851c7b9d3151897922d4d5499b67be1ab711be4cd65",
+				"DiscoKey":   "discokey:54b6326f7a4305771e53e6539b3728c210b56bd7d55deab1ae18ad8401fd9c67",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:48941", "10.65.0.27:48941", "172.17.0.1:48941"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:53:39.91627883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5573586227500890,
+				"StableID":   "njsL5EfHXk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:99d641ff88a64691c63135dd0a1711ec1410535b8c6839595b5ed8daf6dedf21",
+				"KeyExpiry":  "2026-10-26T10:53:41Z",
+				"DiscoKey":   "discokey:265178ee5d1b0f78e57695826eff4f3ecb29a2a21fdd278f980fdf41aca7cc1d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60383", "10.65.0.27:60383", "172.17.0.1:60383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:53:41.029591414Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3088679026792188,
+				"StableID":   "nqyxuuMs7R11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:75a7e9837a3cb73cce4e81333158d8a7112ff4b13e0fd1ca855362f5b48c4b1d",
+				"KeyExpiry":  "2026-10-26T10:53:41Z",
+				"DiscoKey":   "discokey:4df6ad15c00d37b0e7d6ca8dce56b80a107806b19291d8516643dd052c8c6538",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39486", "10.65.0.27:39486", "172.17.0.1:39486"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:53:41.556487108Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4917962976200815,
+				"StableID":   "ncRASnYMQf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       4917962976200815,
+				"Key":        "nodekey:6e40e2e376a0263a97939dc575ce4ae4e97999f06d68d672bd038a35eedad37a",
+				"DiscoKey":   "discokey:fe88e44fc7d342c6730a86b5ae100ca03a702b3cc3a3062af356f37c9667bf46",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58675", "10.65.0.27:58675", "172.17.0.1:58675"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:53:39.398338023Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6e40e2e376a0263a97939dc575ce4ae4e97999f06d68d672bd038a35eedad37a",
+			"MachineKey": "mkey:55f89086715d398b4dc8a4575068fbd6af6dfee3b4f531d179e5e81970740d17",
+			"Peers": [{
+				"ID":         1332891564342740,
+				"StableID":   "n5MZGUofQB11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38ca5e019d152b668232da0db09135d19b327666fcb95ce2e1cdbd53afb49b44",
+				"DiscoKey":   "discokey:cb02825c55d02bd74b45e1c0ce94300275c573549de571c2b62688e45e00863d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60598", "10.65.0.27:60598", "172.17.0.1:60598"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:53:37.744470111Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5502462458311255,
+				"StableID":   "nphK9nM5yj11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea65343a0a009c4c1ef9315b5fb9439aaa6354a7954f85bff5039db0b80c93b",
+				"DiscoKey":   "discokey:36a3ad0fc57b9f555e1a57e36fe2dd659f714fbf537ca0e2450af1f2a50e3d54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60909", "10.65.0.27:60909", "172.17.0.1:60909"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:53:38.307795398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6368441665045699,
+				"StableID":   "ntMhEVAHjr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8eaf7cd8a67aa93f0ceaa68f163e79726d0bebd3593ba60d424a78aeaa50ce31",
+				"DiscoKey":   "discokey:4f580b1f4fff4906e4bd68703b4eb252f50ae3b6bf06f02c9a0862f7d5784d0e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:41983", "10.65.0.27:41983", "172.17.0.1:41983"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:53:38.85914463Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3267684606633163,
+				"StableID":   "nJxc2xXwWS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f47280337a5284f99ef2e851c7b9d3151897922d4d5499b67be1ab711be4cd65",
+				"DiscoKey":   "discokey:54b6326f7a4305771e53e6539b3728c210b56bd7d55deab1ae18ad8401fd9c67",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:48941", "10.65.0.27:48941", "172.17.0.1:48941"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:53:39.91627883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1500449647044741,
+				"StableID":   "nQi8GYGZiC11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ac2fd0f325119a9ad913873cad20148f2b73b9b2f3473e129545409ec7897d35",
+				"KeyExpiry":  "2026-10-26T10:53:40Z",
+				"DiscoKey":   "discokey:85f75cddfb2e8fafc05d39b5c27136639bae8b79527a84b145bfb5175898dc2f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55802", "10.65.0.27:55802", "172.17.0.1:55802"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:53:40.463503706Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5573586227500890,
+				"StableID":   "njsL5EfHXk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:99d641ff88a64691c63135dd0a1711ec1410535b8c6839595b5ed8daf6dedf21",
+				"KeyExpiry":  "2026-10-26T10:53:41Z",
+				"DiscoKey":   "discokey:265178ee5d1b0f78e57695826eff4f3ecb29a2a21fdd278f980fdf41aca7cc1d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60383", "10.65.0.27:60383", "172.17.0.1:60383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:53:41.029591414Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3088679026792188,
+				"StableID":   "nqyxuuMs7R11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:75a7e9837a3cb73cce4e81333158d8a7112ff4b13e0fd1ca855362f5b48c4b1d",
+				"KeyExpiry":  "2026-10-26T10:53:41Z",
+				"DiscoKey":   "discokey:4df6ad15c00d37b0e7d6ca8dce56b80a107806b19291d8516643dd052c8c6538",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39486", "10.65.0.27:39486", "172.17.0.1:39486"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:53:41.556487108Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4917962976200815": {
+				"ID":          4917962976200815,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5502462458311255,
+				"StableID":   "nphK9nM5yj11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       5502462458311255,
+				"Key":        "nodekey:eea65343a0a009c4c1ef9315b5fb9439aaa6354a7954f85bff5039db0b80c93b",
+				"DiscoKey":   "discokey:36a3ad0fc57b9f555e1a57e36fe2dd659f714fbf537ca0e2450af1f2a50e3d54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60909", "10.65.0.27:60909", "172.17.0.1:60909"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:53:38.307795398Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:eea65343a0a009c4c1ef9315b5fb9439aaa6354a7954f85bff5039db0b80c93b",
+			"MachineKey": "mkey:8dfeafbbf45d5cb2ff8448ed610f8d63812131df74ad414b67264ea23773b500",
+			"Peers": [{
+				"ID":         1332891564342740,
+				"StableID":   "n5MZGUofQB11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38ca5e019d152b668232da0db09135d19b327666fcb95ce2e1cdbd53afb49b44",
+				"DiscoKey":   "discokey:cb02825c55d02bd74b45e1c0ce94300275c573549de571c2b62688e45e00863d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60598", "10.65.0.27:60598", "172.17.0.1:60598"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:53:37.744470111Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6368441665045699,
+				"StableID":   "ntMhEVAHjr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8eaf7cd8a67aa93f0ceaa68f163e79726d0bebd3593ba60d424a78aeaa50ce31",
+				"DiscoKey":   "discokey:4f580b1f4fff4906e4bd68703b4eb252f50ae3b6bf06f02c9a0862f7d5784d0e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:41983", "10.65.0.27:41983", "172.17.0.1:41983"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:53:38.85914463Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4917962976200815,
+				"StableID":   "ncRASnYMQf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e40e2e376a0263a97939dc575ce4ae4e97999f06d68d672bd038a35eedad37a",
+				"DiscoKey":   "discokey:fe88e44fc7d342c6730a86b5ae100ca03a702b3cc3a3062af356f37c9667bf46",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58675", "10.65.0.27:58675", "172.17.0.1:58675"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:53:39.398338023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3267684606633163,
+				"StableID":   "nJxc2xXwWS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f47280337a5284f99ef2e851c7b9d3151897922d4d5499b67be1ab711be4cd65",
+				"DiscoKey":   "discokey:54b6326f7a4305771e53e6539b3728c210b56bd7d55deab1ae18ad8401fd9c67",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:48941", "10.65.0.27:48941", "172.17.0.1:48941"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:53:39.91627883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1500449647044741,
+				"StableID":   "nQi8GYGZiC11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ac2fd0f325119a9ad913873cad20148f2b73b9b2f3473e129545409ec7897d35",
+				"KeyExpiry":  "2026-10-26T10:53:40Z",
+				"DiscoKey":   "discokey:85f75cddfb2e8fafc05d39b5c27136639bae8b79527a84b145bfb5175898dc2f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55802", "10.65.0.27:55802", "172.17.0.1:55802"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:53:40.463503706Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5573586227500890,
+				"StableID":   "njsL5EfHXk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:99d641ff88a64691c63135dd0a1711ec1410535b8c6839595b5ed8daf6dedf21",
+				"KeyExpiry":  "2026-10-26T10:53:41Z",
+				"DiscoKey":   "discokey:265178ee5d1b0f78e57695826eff4f3ecb29a2a21fdd278f980fdf41aca7cc1d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60383", "10.65.0.27:60383", "172.17.0.1:60383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:53:41.029591414Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3088679026792188,
+				"StableID":   "nqyxuuMs7R11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:75a7e9837a3cb73cce4e81333158d8a7112ff4b13e0fd1ca855362f5b48c4b1d",
+				"KeyExpiry":  "2026-10-26T10:53:41Z",
+				"DiscoKey":   "discokey:4df6ad15c00d37b0e7d6ca8dce56b80a107806b19291d8516643dd052c8c6538",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39486", "10.65.0.27:39486", "172.17.0.1:39486"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:53:41.556487108Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5502462458311255": {
+				"ID":          5502462458311255,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5573586227500890,
+				"StableID":   "njsL5EfHXk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:99d641ff88a64691c63135dd0a1711ec1410535b8c6839595b5ed8daf6dedf21",
+				"KeyExpiry":  "2026-10-26T10:53:41Z",
+				"DiscoKey":   "discokey:265178ee5d1b0f78e57695826eff4f3ecb29a2a21fdd278f980fdf41aca7cc1d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60383", "10.65.0.27:60383", "172.17.0.1:60383"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:53:41.029591414Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:99d641ff88a64691c63135dd0a1711ec1410535b8c6839595b5ed8daf6dedf21",
+			"MachineKey": "mkey:09e9bf609280fe8987218066fe2cba6be45e59b90db3341acc90458c69731b5b",
+			"Peers": [{
+				"ID":         1332891564342740,
+				"StableID":   "n5MZGUofQB11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38ca5e019d152b668232da0db09135d19b327666fcb95ce2e1cdbd53afb49b44",
+				"DiscoKey":   "discokey:cb02825c55d02bd74b45e1c0ce94300275c573549de571c2b62688e45e00863d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60598", "10.65.0.27:60598", "172.17.0.1:60598"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:53:37.744470111Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5502462458311255,
+				"StableID":   "nphK9nM5yj11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea65343a0a009c4c1ef9315b5fb9439aaa6354a7954f85bff5039db0b80c93b",
+				"DiscoKey":   "discokey:36a3ad0fc57b9f555e1a57e36fe2dd659f714fbf537ca0e2450af1f2a50e3d54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60909", "10.65.0.27:60909", "172.17.0.1:60909"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:53:38.307795398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6368441665045699,
+				"StableID":   "ntMhEVAHjr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8eaf7cd8a67aa93f0ceaa68f163e79726d0bebd3593ba60d424a78aeaa50ce31",
+				"DiscoKey":   "discokey:4f580b1f4fff4906e4bd68703b4eb252f50ae3b6bf06f02c9a0862f7d5784d0e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:41983", "10.65.0.27:41983", "172.17.0.1:41983"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:53:38.85914463Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4917962976200815,
+				"StableID":   "ncRASnYMQf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e40e2e376a0263a97939dc575ce4ae4e97999f06d68d672bd038a35eedad37a",
+				"DiscoKey":   "discokey:fe88e44fc7d342c6730a86b5ae100ca03a702b3cc3a3062af356f37c9667bf46",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58675", "10.65.0.27:58675", "172.17.0.1:58675"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:53:39.398338023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3267684606633163,
+				"StableID":   "nJxc2xXwWS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f47280337a5284f99ef2e851c7b9d3151897922d4d5499b67be1ab711be4cd65",
+				"DiscoKey":   "discokey:54b6326f7a4305771e53e6539b3728c210b56bd7d55deab1ae18ad8401fd9c67",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:48941", "10.65.0.27:48941", "172.17.0.1:48941"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:53:39.91627883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1500449647044741,
+				"StableID":   "nQi8GYGZiC11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ac2fd0f325119a9ad913873cad20148f2b73b9b2f3473e129545409ec7897d35",
+				"KeyExpiry":  "2026-10-26T10:53:40Z",
+				"DiscoKey":   "discokey:85f75cddfb2e8fafc05d39b5c27136639bae8b79527a84b145bfb5175898dc2f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55802", "10.65.0.27:55802", "172.17.0.1:55802"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:53:40.463503706Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3088679026792188,
+				"StableID":   "nqyxuuMs7R11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:75a7e9837a3cb73cce4e81333158d8a7112ff4b13e0fd1ca855362f5b48c4b1d",
+				"KeyExpiry":  "2026-10-26T10:53:41Z",
+				"DiscoKey":   "discokey:4df6ad15c00d37b0e7d6ca8dce56b80a107806b19291d8516643dd052c8c6538",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39486", "10.65.0.27:39486", "172.17.0.1:39486"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:53:41.556487108Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6368441665045699,
+				"StableID":   "ntMhEVAHjr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       6368441665045699,
+				"Key":        "nodekey:8eaf7cd8a67aa93f0ceaa68f163e79726d0bebd3593ba60d424a78aeaa50ce31",
+				"DiscoKey":   "discokey:4f580b1f4fff4906e4bd68703b4eb252f50ae3b6bf06f02c9a0862f7d5784d0e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:41983", "10.65.0.27:41983", "172.17.0.1:41983"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:53:38.85914463Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8eaf7cd8a67aa93f0ceaa68f163e79726d0bebd3593ba60d424a78aeaa50ce31",
+			"MachineKey": "mkey:682cefc23ce1e442ce0a9285ee678149699713ee93af95758ebc6a0551dddd6c",
+			"Peers": [{
+				"ID":         1332891564342740,
+				"StableID":   "n5MZGUofQB11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38ca5e019d152b668232da0db09135d19b327666fcb95ce2e1cdbd53afb49b44",
+				"DiscoKey":   "discokey:cb02825c55d02bd74b45e1c0ce94300275c573549de571c2b62688e45e00863d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60598", "10.65.0.27:60598", "172.17.0.1:60598"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:53:37.744470111Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5502462458311255,
+				"StableID":   "nphK9nM5yj11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea65343a0a009c4c1ef9315b5fb9439aaa6354a7954f85bff5039db0b80c93b",
+				"DiscoKey":   "discokey:36a3ad0fc57b9f555e1a57e36fe2dd659f714fbf537ca0e2450af1f2a50e3d54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60909", "10.65.0.27:60909", "172.17.0.1:60909"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:53:38.307795398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4917962976200815,
+				"StableID":   "ncRASnYMQf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e40e2e376a0263a97939dc575ce4ae4e97999f06d68d672bd038a35eedad37a",
+				"DiscoKey":   "discokey:fe88e44fc7d342c6730a86b5ae100ca03a702b3cc3a3062af356f37c9667bf46",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:58675", "10.65.0.27:58675", "172.17.0.1:58675"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:53:39.398338023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3267684606633163,
+				"StableID":   "nJxc2xXwWS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f47280337a5284f99ef2e851c7b9d3151897922d4d5499b67be1ab711be4cd65",
+				"DiscoKey":   "discokey:54b6326f7a4305771e53e6539b3728c210b56bd7d55deab1ae18ad8401fd9c67",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:48941", "10.65.0.27:48941", "172.17.0.1:48941"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:53:39.91627883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1500449647044741,
+				"StableID":   "nQi8GYGZiC11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ac2fd0f325119a9ad913873cad20148f2b73b9b2f3473e129545409ec7897d35",
+				"KeyExpiry":  "2026-10-26T10:53:40Z",
+				"DiscoKey":   "discokey:85f75cddfb2e8fafc05d39b5c27136639bae8b79527a84b145bfb5175898dc2f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55802", "10.65.0.27:55802", "172.17.0.1:55802"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:53:40.463503706Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5573586227500890,
+				"StableID":   "njsL5EfHXk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:99d641ff88a64691c63135dd0a1711ec1410535b8c6839595b5ed8daf6dedf21",
+				"KeyExpiry":  "2026-10-26T10:53:41Z",
+				"DiscoKey":   "discokey:265178ee5d1b0f78e57695826eff4f3ecb29a2a21fdd278f980fdf41aca7cc1d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60383", "10.65.0.27:60383", "172.17.0.1:60383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:53:41.029591414Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3088679026792188,
+				"StableID":   "nqyxuuMs7R11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:75a7e9837a3cb73cce4e81333158d8a7112ff4b13e0fd1ca855362f5b48c4b1d",
+				"KeyExpiry":  "2026-10-26T10:53:41Z",
+				"DiscoKey":   "discokey:4df6ad15c00d37b0e7d6ca8dce56b80a107806b19291d8516643dd052c8c6538",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39486", "10.65.0.27:39486", "172.17.0.1:39486"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:53:41.556487108Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6368441665045699": {
+				"ID":          6368441665045699,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-malformed-test-missing-src.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-malformed-test-missing-src.hujson
@@ -1,0 +1,8833 @@
+// policytest-malformed-test-missing-src
+//
+// tests block malformed: entry missing src field
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:54:03Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-malformed-test-missing-src",
+	"description":    "tests block malformed: entry missing src field",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:54:03.262605445Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                        \n  \n                                                                      \n{\n\t\"id\":          \"policytest-malformed-test-missing-src\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block malformed: entry missing src field\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"thor@example.org\"], \"dst\": [\"tag:server:22\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"accept\": [\"tag:server:22\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-malformed-test-missing-src.hujson",
+		"full_policy": {"acls": [{
+			"action": "accept",
+			"dst":    ["tag:server:22"],
+			"src":    ["thor@example.org"]
+		}], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [{"accept": ["tag:server:22"]}]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5212428115072722,
+				"StableID":   "nXfdQaeihh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       5212428115072722,
+				"Key":        "nodekey:1b76b6aa0c9b3036124de49d83e06e6d421c218b59a5c5277acb444b7ee51033",
+				"DiscoKey":   "discokey:6afc8e170cf8b697f74bed884ff9122bab8371d24ab452ae9eb2e515e00aa114",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:58787", "10.65.0.27:58787", "172.17.0.1:58787"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:54:06.908388851Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1b76b6aa0c9b3036124de49d83e06e6d421c218b59a5c5277acb444b7ee51033",
+			"MachineKey": "mkey:003fbf444cbdf73655b38e5c649c6beeac6dfd12688012ac2273cb8fbe4d3371",
+			"Peers": [{
+				"ID":         1658444280491370,
+				"StableID":   "nd2Wz6X7xD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:130363cdc39f67cc8b0d57325bb16f0eb3e290ba2359a4384306497fa286ab7c",
+				"DiscoKey":   "discokey:3c6ab67bc26c3af7bbaf0cc62ba26046301a06afc6b9575b18714f958ec4d63d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43960", "10.65.0.27:43960", "172.17.0.1:43960"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:54:04.755869816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4933316091817792,
+				"StableID":   "nVqpgCrJXf11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1b1826da75e0ee6b7c3ad8d3f78fbffeebd76b522be626413e351da37d76cb2c",
+				"DiscoKey":   "discokey:2b2652e3ad0cb594c652dbcc1f519f74918e5c33371c3df3908a3c7a2ce7753b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46754", "10.65.0.27:46754", "172.17.0.1:46754"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:54:05.303136385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2081235777602505,
+				"StableID":   "nGcxo1YbFH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dfec1e697305440ecad6c402549ea20aff00232d4a78bf6f2e0b88475089e32f",
+				"DiscoKey":   "discokey:670d0512e171b368e2051223595caeadf2be201bdbeb4f3076073e14b42ef62a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57876", "10.65.0.27:57876", "172.17.0.1:57876"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:54:05.834271944Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         646735944207144,
+				"StableID":   "nPrHk5fu3611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00cf617fb0547a8c8d196822cfc39d3bc9e84957d9ca0a03ccac83c2db75df38",
+				"DiscoKey":   "discokey:d0e2bd6bdb887cee3b7e7470c1b1c573a00e20cc7aec76e0ee165d19e2ef7308",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:54:06.393814867Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4978826387343245,
+				"StableID":   "nifFfwKvsf11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5251252bbb1c935682c8cec620295d1c6f30090c7ec0f49e42d61a152b9e72e",
+				"KeyExpiry":  "2026-10-26T10:54:07Z",
+				"DiscoKey":   "discokey:682023d9fb58948c79d45bc2015c36d7a6f899057cf129c242e93a94a224d244",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49840", "10.65.0.27:49840", "172.17.0.1:49840"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:54:07.466686051Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         365001491087147,
+				"StableID":   "nxDxsGyJr311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f32b0a4f92ee27d5a21c0b41ae2210feb100c14725c5306b3575d7c43b22c65a",
+				"KeyExpiry":  "2026-10-26T10:54:07Z",
+				"DiscoKey":   "discokey:7fe1ca8b066b917a24db8b740c8764d4579cb39581250eed13d46da18515d12b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50387", "10.65.0.27:50387", "172.17.0.1:50387"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:54:07.993502885Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4355757344027596,
+				"StableID":   "nwQHuqMj1b11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f115257ae45de14fb0d5872d3bf96ec9641f658c9b16e2be887b16fb94a1372",
+				"KeyExpiry":  "2026-10-26T10:54:08Z",
+				"DiscoKey":   "discokey:ab65dbf3cf8ff354880cd5859d2be610f8eb5dcb92df0d3bb978b40db9e13d48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41037", "10.65.0.27:41037", "172.17.0.1:41037"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:54:08.564480112Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5212428115072722": {
+				"ID":          5212428115072722,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4355757344027596,
+				"StableID":   "nwQHuqMj1b11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f115257ae45de14fb0d5872d3bf96ec9641f658c9b16e2be887b16fb94a1372",
+				"KeyExpiry":  "2026-10-26T10:54:08Z",
+				"DiscoKey":   "discokey:ab65dbf3cf8ff354880cd5859d2be610f8eb5dcb92df0d3bb978b40db9e13d48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41037", "10.65.0.27:41037", "172.17.0.1:41037"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:54:08.564480112Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1f115257ae45de14fb0d5872d3bf96ec9641f658c9b16e2be887b16fb94a1372",
+			"MachineKey": "mkey:c703c5a614a3885c3cb2129094eb8277d1b8f9e1caba2b02692975f3cf23e215",
+			"Peers": [{
+				"ID":         1658444280491370,
+				"StableID":   "nd2Wz6X7xD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:130363cdc39f67cc8b0d57325bb16f0eb3e290ba2359a4384306497fa286ab7c",
+				"DiscoKey":   "discokey:3c6ab67bc26c3af7bbaf0cc62ba26046301a06afc6b9575b18714f958ec4d63d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43960", "10.65.0.27:43960", "172.17.0.1:43960"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:54:04.755869816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4933316091817792,
+				"StableID":   "nVqpgCrJXf11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1b1826da75e0ee6b7c3ad8d3f78fbffeebd76b522be626413e351da37d76cb2c",
+				"DiscoKey":   "discokey:2b2652e3ad0cb594c652dbcc1f519f74918e5c33371c3df3908a3c7a2ce7753b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46754", "10.65.0.27:46754", "172.17.0.1:46754"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:54:05.303136385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2081235777602505,
+				"StableID":   "nGcxo1YbFH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dfec1e697305440ecad6c402549ea20aff00232d4a78bf6f2e0b88475089e32f",
+				"DiscoKey":   "discokey:670d0512e171b368e2051223595caeadf2be201bdbeb4f3076073e14b42ef62a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57876", "10.65.0.27:57876", "172.17.0.1:57876"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:54:05.834271944Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         646735944207144,
+				"StableID":   "nPrHk5fu3611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00cf617fb0547a8c8d196822cfc39d3bc9e84957d9ca0a03ccac83c2db75df38",
+				"DiscoKey":   "discokey:d0e2bd6bdb887cee3b7e7470c1b1c573a00e20cc7aec76e0ee165d19e2ef7308",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:54:06.393814867Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5212428115072722,
+				"StableID":   "nXfdQaeihh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1b76b6aa0c9b3036124de49d83e06e6d421c218b59a5c5277acb444b7ee51033",
+				"DiscoKey":   "discokey:6afc8e170cf8b697f74bed884ff9122bab8371d24ab452ae9eb2e515e00aa114",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:58787", "10.65.0.27:58787", "172.17.0.1:58787"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:54:06.908388851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4978826387343245,
+				"StableID":   "nifFfwKvsf11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5251252bbb1c935682c8cec620295d1c6f30090c7ec0f49e42d61a152b9e72e",
+				"KeyExpiry":  "2026-10-26T10:54:07Z",
+				"DiscoKey":   "discokey:682023d9fb58948c79d45bc2015c36d7a6f899057cf129c242e93a94a224d244",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49840", "10.65.0.27:49840", "172.17.0.1:49840"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:54:07.466686051Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         365001491087147,
+				"StableID":   "nxDxsGyJr311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f32b0a4f92ee27d5a21c0b41ae2210feb100c14725c5306b3575d7c43b22c65a",
+				"KeyExpiry":  "2026-10-26T10:54:07Z",
+				"DiscoKey":   "discokey:7fe1ca8b066b917a24db8b740c8764d4579cb39581250eed13d46da18515d12b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50387", "10.65.0.27:50387", "172.17.0.1:50387"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:54:07.993502885Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1658444280491370,
+				"StableID":   "nd2Wz6X7xD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1658444280491370,
+				"Key":        "nodekey:130363cdc39f67cc8b0d57325bb16f0eb3e290ba2359a4384306497fa286ab7c",
+				"DiscoKey":   "discokey:3c6ab67bc26c3af7bbaf0cc62ba26046301a06afc6b9575b18714f958ec4d63d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43960", "10.65.0.27:43960", "172.17.0.1:43960"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:54:04.755869816Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:130363cdc39f67cc8b0d57325bb16f0eb3e290ba2359a4384306497fa286ab7c",
+			"MachineKey": "mkey:2b078a3611cfa416eaa545676a0f8b993004dfcf17411be9944ef31eb16af40d",
+			"Peers": [{
+				"ID":         4933316091817792,
+				"StableID":   "nVqpgCrJXf11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1b1826da75e0ee6b7c3ad8d3f78fbffeebd76b522be626413e351da37d76cb2c",
+				"DiscoKey":   "discokey:2b2652e3ad0cb594c652dbcc1f519f74918e5c33371c3df3908a3c7a2ce7753b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46754", "10.65.0.27:46754", "172.17.0.1:46754"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:54:05.303136385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2081235777602505,
+				"StableID":   "nGcxo1YbFH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dfec1e697305440ecad6c402549ea20aff00232d4a78bf6f2e0b88475089e32f",
+				"DiscoKey":   "discokey:670d0512e171b368e2051223595caeadf2be201bdbeb4f3076073e14b42ef62a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57876", "10.65.0.27:57876", "172.17.0.1:57876"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:54:05.834271944Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         646735944207144,
+				"StableID":   "nPrHk5fu3611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00cf617fb0547a8c8d196822cfc39d3bc9e84957d9ca0a03ccac83c2db75df38",
+				"DiscoKey":   "discokey:d0e2bd6bdb887cee3b7e7470c1b1c573a00e20cc7aec76e0ee165d19e2ef7308",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:54:06.393814867Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5212428115072722,
+				"StableID":   "nXfdQaeihh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1b76b6aa0c9b3036124de49d83e06e6d421c218b59a5c5277acb444b7ee51033",
+				"DiscoKey":   "discokey:6afc8e170cf8b697f74bed884ff9122bab8371d24ab452ae9eb2e515e00aa114",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:58787", "10.65.0.27:58787", "172.17.0.1:58787"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:54:06.908388851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4978826387343245,
+				"StableID":   "nifFfwKvsf11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5251252bbb1c935682c8cec620295d1c6f30090c7ec0f49e42d61a152b9e72e",
+				"KeyExpiry":  "2026-10-26T10:54:07Z",
+				"DiscoKey":   "discokey:682023d9fb58948c79d45bc2015c36d7a6f899057cf129c242e93a94a224d244",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49840", "10.65.0.27:49840", "172.17.0.1:49840"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:54:07.466686051Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         365001491087147,
+				"StableID":   "nxDxsGyJr311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f32b0a4f92ee27d5a21c0b41ae2210feb100c14725c5306b3575d7c43b22c65a",
+				"KeyExpiry":  "2026-10-26T10:54:07Z",
+				"DiscoKey":   "discokey:7fe1ca8b066b917a24db8b740c8764d4579cb39581250eed13d46da18515d12b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50387", "10.65.0.27:50387", "172.17.0.1:50387"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:54:07.993502885Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4355757344027596,
+				"StableID":   "nwQHuqMj1b11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f115257ae45de14fb0d5872d3bf96ec9641f658c9b16e2be887b16fb94a1372",
+				"KeyExpiry":  "2026-10-26T10:54:08Z",
+				"DiscoKey":   "discokey:ab65dbf3cf8ff354880cd5859d2be610f8eb5dcb92df0d3bb978b40db9e13d48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41037", "10.65.0.27:41037", "172.17.0.1:41037"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:54:08.564480112Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1658444280491370": {
+				"ID":          1658444280491370,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4978826387343245,
+				"StableID":   "nifFfwKvsf11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5251252bbb1c935682c8cec620295d1c6f30090c7ec0f49e42d61a152b9e72e",
+				"KeyExpiry":  "2026-10-26T10:54:07Z",
+				"DiscoKey":   "discokey:682023d9fb58948c79d45bc2015c36d7a6f899057cf129c242e93a94a224d244",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49840", "10.65.0.27:49840", "172.17.0.1:49840"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:54:07.466686051Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e5251252bbb1c935682c8cec620295d1c6f30090c7ec0f49e42d61a152b9e72e",
+			"MachineKey": "mkey:11f96d21a99ee052f36d0df5834f82adbbef2ad3db1b2cf2b53d936bf45d4752",
+			"Peers": [{
+				"ID":         1658444280491370,
+				"StableID":   "nd2Wz6X7xD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:130363cdc39f67cc8b0d57325bb16f0eb3e290ba2359a4384306497fa286ab7c",
+				"DiscoKey":   "discokey:3c6ab67bc26c3af7bbaf0cc62ba26046301a06afc6b9575b18714f958ec4d63d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43960", "10.65.0.27:43960", "172.17.0.1:43960"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:54:04.755869816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4933316091817792,
+				"StableID":   "nVqpgCrJXf11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1b1826da75e0ee6b7c3ad8d3f78fbffeebd76b522be626413e351da37d76cb2c",
+				"DiscoKey":   "discokey:2b2652e3ad0cb594c652dbcc1f519f74918e5c33371c3df3908a3c7a2ce7753b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46754", "10.65.0.27:46754", "172.17.0.1:46754"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:54:05.303136385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2081235777602505,
+				"StableID":   "nGcxo1YbFH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dfec1e697305440ecad6c402549ea20aff00232d4a78bf6f2e0b88475089e32f",
+				"DiscoKey":   "discokey:670d0512e171b368e2051223595caeadf2be201bdbeb4f3076073e14b42ef62a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57876", "10.65.0.27:57876", "172.17.0.1:57876"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:54:05.834271944Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         646735944207144,
+				"StableID":   "nPrHk5fu3611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00cf617fb0547a8c8d196822cfc39d3bc9e84957d9ca0a03ccac83c2db75df38",
+				"DiscoKey":   "discokey:d0e2bd6bdb887cee3b7e7470c1b1c573a00e20cc7aec76e0ee165d19e2ef7308",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:54:06.393814867Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5212428115072722,
+				"StableID":   "nXfdQaeihh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1b76b6aa0c9b3036124de49d83e06e6d421c218b59a5c5277acb444b7ee51033",
+				"DiscoKey":   "discokey:6afc8e170cf8b697f74bed884ff9122bab8371d24ab452ae9eb2e515e00aa114",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:58787", "10.65.0.27:58787", "172.17.0.1:58787"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:54:06.908388851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         365001491087147,
+				"StableID":   "nxDxsGyJr311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f32b0a4f92ee27d5a21c0b41ae2210feb100c14725c5306b3575d7c43b22c65a",
+				"KeyExpiry":  "2026-10-26T10:54:07Z",
+				"DiscoKey":   "discokey:7fe1ca8b066b917a24db8b740c8764d4579cb39581250eed13d46da18515d12b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50387", "10.65.0.27:50387", "172.17.0.1:50387"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:54:07.993502885Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4355757344027596,
+				"StableID":   "nwQHuqMj1b11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f115257ae45de14fb0d5872d3bf96ec9641f658c9b16e2be887b16fb94a1372",
+				"KeyExpiry":  "2026-10-26T10:54:08Z",
+				"DiscoKey":   "discokey:ab65dbf3cf8ff354880cd5859d2be610f8eb5dcb92df0d3bb978b40db9e13d48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41037", "10.65.0.27:41037", "172.17.0.1:41037"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:54:08.564480112Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         646735944207144,
+				"StableID":   "nPrHk5fu3611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       646735944207144,
+				"Key":        "nodekey:00cf617fb0547a8c8d196822cfc39d3bc9e84957d9ca0a03ccac83c2db75df38",
+				"DiscoKey":   "discokey:d0e2bd6bdb887cee3b7e7470c1b1c573a00e20cc7aec76e0ee165d19e2ef7308",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:54:06.393814867Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:00cf617fb0547a8c8d196822cfc39d3bc9e84957d9ca0a03ccac83c2db75df38",
+			"MachineKey": "mkey:875397bae7ed5efb0fab15f17a24f8583a90d087cfed2e3c7c6030fbcbdc1632",
+			"Peers": [{
+				"ID":         1658444280491370,
+				"StableID":   "nd2Wz6X7xD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:130363cdc39f67cc8b0d57325bb16f0eb3e290ba2359a4384306497fa286ab7c",
+				"DiscoKey":   "discokey:3c6ab67bc26c3af7bbaf0cc62ba26046301a06afc6b9575b18714f958ec4d63d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43960", "10.65.0.27:43960", "172.17.0.1:43960"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:54:04.755869816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4933316091817792,
+				"StableID":   "nVqpgCrJXf11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1b1826da75e0ee6b7c3ad8d3f78fbffeebd76b522be626413e351da37d76cb2c",
+				"DiscoKey":   "discokey:2b2652e3ad0cb594c652dbcc1f519f74918e5c33371c3df3908a3c7a2ce7753b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46754", "10.65.0.27:46754", "172.17.0.1:46754"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:54:05.303136385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2081235777602505,
+				"StableID":   "nGcxo1YbFH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dfec1e697305440ecad6c402549ea20aff00232d4a78bf6f2e0b88475089e32f",
+				"DiscoKey":   "discokey:670d0512e171b368e2051223595caeadf2be201bdbeb4f3076073e14b42ef62a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57876", "10.65.0.27:57876", "172.17.0.1:57876"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:54:05.834271944Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5212428115072722,
+				"StableID":   "nXfdQaeihh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1b76b6aa0c9b3036124de49d83e06e6d421c218b59a5c5277acb444b7ee51033",
+				"DiscoKey":   "discokey:6afc8e170cf8b697f74bed884ff9122bab8371d24ab452ae9eb2e515e00aa114",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:58787", "10.65.0.27:58787", "172.17.0.1:58787"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:54:06.908388851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4978826387343245,
+				"StableID":   "nifFfwKvsf11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5251252bbb1c935682c8cec620295d1c6f30090c7ec0f49e42d61a152b9e72e",
+				"KeyExpiry":  "2026-10-26T10:54:07Z",
+				"DiscoKey":   "discokey:682023d9fb58948c79d45bc2015c36d7a6f899057cf129c242e93a94a224d244",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49840", "10.65.0.27:49840", "172.17.0.1:49840"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:54:07.466686051Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         365001491087147,
+				"StableID":   "nxDxsGyJr311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f32b0a4f92ee27d5a21c0b41ae2210feb100c14725c5306b3575d7c43b22c65a",
+				"KeyExpiry":  "2026-10-26T10:54:07Z",
+				"DiscoKey":   "discokey:7fe1ca8b066b917a24db8b740c8764d4579cb39581250eed13d46da18515d12b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50387", "10.65.0.27:50387", "172.17.0.1:50387"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:54:07.993502885Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4355757344027596,
+				"StableID":   "nwQHuqMj1b11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f115257ae45de14fb0d5872d3bf96ec9641f658c9b16e2be887b16fb94a1372",
+				"KeyExpiry":  "2026-10-26T10:54:08Z",
+				"DiscoKey":   "discokey:ab65dbf3cf8ff354880cd5859d2be610f8eb5dcb92df0d3bb978b40db9e13d48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41037", "10.65.0.27:41037", "172.17.0.1:41037"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:54:08.564480112Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "646735944207144": {
+				"ID":          646735944207144,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4933316091817792,
+				"StableID":   "nVqpgCrJXf11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       4933316091817792,
+				"Key":        "nodekey:1b1826da75e0ee6b7c3ad8d3f78fbffeebd76b522be626413e351da37d76cb2c",
+				"DiscoKey":   "discokey:2b2652e3ad0cb594c652dbcc1f519f74918e5c33371c3df3908a3c7a2ce7753b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46754", "10.65.0.27:46754", "172.17.0.1:46754"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:54:05.303136385Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1b1826da75e0ee6b7c3ad8d3f78fbffeebd76b522be626413e351da37d76cb2c",
+			"MachineKey": "mkey:f7ca572ac5a6aac7cc22e32b7c3c2d6675cb5890106fbc9a417297567046b525",
+			"Peers": [{
+				"ID":         1658444280491370,
+				"StableID":   "nd2Wz6X7xD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:130363cdc39f67cc8b0d57325bb16f0eb3e290ba2359a4384306497fa286ab7c",
+				"DiscoKey":   "discokey:3c6ab67bc26c3af7bbaf0cc62ba26046301a06afc6b9575b18714f958ec4d63d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43960", "10.65.0.27:43960", "172.17.0.1:43960"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:54:04.755869816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2081235777602505,
+				"StableID":   "nGcxo1YbFH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dfec1e697305440ecad6c402549ea20aff00232d4a78bf6f2e0b88475089e32f",
+				"DiscoKey":   "discokey:670d0512e171b368e2051223595caeadf2be201bdbeb4f3076073e14b42ef62a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57876", "10.65.0.27:57876", "172.17.0.1:57876"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:54:05.834271944Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         646735944207144,
+				"StableID":   "nPrHk5fu3611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00cf617fb0547a8c8d196822cfc39d3bc9e84957d9ca0a03ccac83c2db75df38",
+				"DiscoKey":   "discokey:d0e2bd6bdb887cee3b7e7470c1b1c573a00e20cc7aec76e0ee165d19e2ef7308",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:54:06.393814867Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5212428115072722,
+				"StableID":   "nXfdQaeihh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1b76b6aa0c9b3036124de49d83e06e6d421c218b59a5c5277acb444b7ee51033",
+				"DiscoKey":   "discokey:6afc8e170cf8b697f74bed884ff9122bab8371d24ab452ae9eb2e515e00aa114",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:58787", "10.65.0.27:58787", "172.17.0.1:58787"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:54:06.908388851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4978826387343245,
+				"StableID":   "nifFfwKvsf11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5251252bbb1c935682c8cec620295d1c6f30090c7ec0f49e42d61a152b9e72e",
+				"KeyExpiry":  "2026-10-26T10:54:07Z",
+				"DiscoKey":   "discokey:682023d9fb58948c79d45bc2015c36d7a6f899057cf129c242e93a94a224d244",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49840", "10.65.0.27:49840", "172.17.0.1:49840"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:54:07.466686051Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         365001491087147,
+				"StableID":   "nxDxsGyJr311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f32b0a4f92ee27d5a21c0b41ae2210feb100c14725c5306b3575d7c43b22c65a",
+				"KeyExpiry":  "2026-10-26T10:54:07Z",
+				"DiscoKey":   "discokey:7fe1ca8b066b917a24db8b740c8764d4579cb39581250eed13d46da18515d12b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50387", "10.65.0.27:50387", "172.17.0.1:50387"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:54:07.993502885Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4355757344027596,
+				"StableID":   "nwQHuqMj1b11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f115257ae45de14fb0d5872d3bf96ec9641f658c9b16e2be887b16fb94a1372",
+				"KeyExpiry":  "2026-10-26T10:54:08Z",
+				"DiscoKey":   "discokey:ab65dbf3cf8ff354880cd5859d2be610f8eb5dcb92df0d3bb978b40db9e13d48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41037", "10.65.0.27:41037", "172.17.0.1:41037"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:54:08.564480112Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4933316091817792": {
+				"ID":          4933316091817792,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         365001491087147,
+				"StableID":   "nxDxsGyJr311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f32b0a4f92ee27d5a21c0b41ae2210feb100c14725c5306b3575d7c43b22c65a",
+				"KeyExpiry":  "2026-10-26T10:54:07Z",
+				"DiscoKey":   "discokey:7fe1ca8b066b917a24db8b740c8764d4579cb39581250eed13d46da18515d12b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50387", "10.65.0.27:50387", "172.17.0.1:50387"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:54:07.993502885Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f32b0a4f92ee27d5a21c0b41ae2210feb100c14725c5306b3575d7c43b22c65a",
+			"MachineKey": "mkey:e2357b05f743519e0d9f8dc41f4d3dbef530fa74e0a8576480e3a95e64f0e102",
+			"Peers": [{
+				"ID":         1658444280491370,
+				"StableID":   "nd2Wz6X7xD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:130363cdc39f67cc8b0d57325bb16f0eb3e290ba2359a4384306497fa286ab7c",
+				"DiscoKey":   "discokey:3c6ab67bc26c3af7bbaf0cc62ba26046301a06afc6b9575b18714f958ec4d63d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43960", "10.65.0.27:43960", "172.17.0.1:43960"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:54:04.755869816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4933316091817792,
+				"StableID":   "nVqpgCrJXf11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1b1826da75e0ee6b7c3ad8d3f78fbffeebd76b522be626413e351da37d76cb2c",
+				"DiscoKey":   "discokey:2b2652e3ad0cb594c652dbcc1f519f74918e5c33371c3df3908a3c7a2ce7753b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46754", "10.65.0.27:46754", "172.17.0.1:46754"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:54:05.303136385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2081235777602505,
+				"StableID":   "nGcxo1YbFH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dfec1e697305440ecad6c402549ea20aff00232d4a78bf6f2e0b88475089e32f",
+				"DiscoKey":   "discokey:670d0512e171b368e2051223595caeadf2be201bdbeb4f3076073e14b42ef62a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57876", "10.65.0.27:57876", "172.17.0.1:57876"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:54:05.834271944Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         646735944207144,
+				"StableID":   "nPrHk5fu3611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00cf617fb0547a8c8d196822cfc39d3bc9e84957d9ca0a03ccac83c2db75df38",
+				"DiscoKey":   "discokey:d0e2bd6bdb887cee3b7e7470c1b1c573a00e20cc7aec76e0ee165d19e2ef7308",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:54:06.393814867Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5212428115072722,
+				"StableID":   "nXfdQaeihh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1b76b6aa0c9b3036124de49d83e06e6d421c218b59a5c5277acb444b7ee51033",
+				"DiscoKey":   "discokey:6afc8e170cf8b697f74bed884ff9122bab8371d24ab452ae9eb2e515e00aa114",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:58787", "10.65.0.27:58787", "172.17.0.1:58787"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:54:06.908388851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4978826387343245,
+				"StableID":   "nifFfwKvsf11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5251252bbb1c935682c8cec620295d1c6f30090c7ec0f49e42d61a152b9e72e",
+				"KeyExpiry":  "2026-10-26T10:54:07Z",
+				"DiscoKey":   "discokey:682023d9fb58948c79d45bc2015c36d7a6f899057cf129c242e93a94a224d244",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49840", "10.65.0.27:49840", "172.17.0.1:49840"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:54:07.466686051Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4355757344027596,
+				"StableID":   "nwQHuqMj1b11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f115257ae45de14fb0d5872d3bf96ec9641f658c9b16e2be887b16fb94a1372",
+				"KeyExpiry":  "2026-10-26T10:54:08Z",
+				"DiscoKey":   "discokey:ab65dbf3cf8ff354880cd5859d2be610f8eb5dcb92df0d3bb978b40db9e13d48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41037", "10.65.0.27:41037", "172.17.0.1:41037"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:54:08.564480112Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2081235777602505,
+				"StableID":   "nGcxo1YbFH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       2081235777602505,
+				"Key":        "nodekey:dfec1e697305440ecad6c402549ea20aff00232d4a78bf6f2e0b88475089e32f",
+				"DiscoKey":   "discokey:670d0512e171b368e2051223595caeadf2be201bdbeb4f3076073e14b42ef62a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57876", "10.65.0.27:57876", "172.17.0.1:57876"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:54:05.834271944Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dfec1e697305440ecad6c402549ea20aff00232d4a78bf6f2e0b88475089e32f",
+			"MachineKey": "mkey:86ee156d9f380969038258a2f4c5324c123b4e4b64aee97655fec0765b98900b",
+			"Peers": [{
+				"ID":         1658444280491370,
+				"StableID":   "nd2Wz6X7xD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:130363cdc39f67cc8b0d57325bb16f0eb3e290ba2359a4384306497fa286ab7c",
+				"DiscoKey":   "discokey:3c6ab67bc26c3af7bbaf0cc62ba26046301a06afc6b9575b18714f958ec4d63d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:43960", "10.65.0.27:43960", "172.17.0.1:43960"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:54:04.755869816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4933316091817792,
+				"StableID":   "nVqpgCrJXf11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1b1826da75e0ee6b7c3ad8d3f78fbffeebd76b522be626413e351da37d76cb2c",
+				"DiscoKey":   "discokey:2b2652e3ad0cb594c652dbcc1f519f74918e5c33371c3df3908a3c7a2ce7753b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46754", "10.65.0.27:46754", "172.17.0.1:46754"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:54:05.303136385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         646735944207144,
+				"StableID":   "nPrHk5fu3611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00cf617fb0547a8c8d196822cfc39d3bc9e84957d9ca0a03ccac83c2db75df38",
+				"DiscoKey":   "discokey:d0e2bd6bdb887cee3b7e7470c1b1c573a00e20cc7aec76e0ee165d19e2ef7308",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:54:06.393814867Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5212428115072722,
+				"StableID":   "nXfdQaeihh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1b76b6aa0c9b3036124de49d83e06e6d421c218b59a5c5277acb444b7ee51033",
+				"DiscoKey":   "discokey:6afc8e170cf8b697f74bed884ff9122bab8371d24ab452ae9eb2e515e00aa114",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:58787", "10.65.0.27:58787", "172.17.0.1:58787"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:54:06.908388851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4978826387343245,
+				"StableID":   "nifFfwKvsf11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5251252bbb1c935682c8cec620295d1c6f30090c7ec0f49e42d61a152b9e72e",
+				"KeyExpiry":  "2026-10-26T10:54:07Z",
+				"DiscoKey":   "discokey:682023d9fb58948c79d45bc2015c36d7a6f899057cf129c242e93a94a224d244",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49840", "10.65.0.27:49840", "172.17.0.1:49840"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:54:07.466686051Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         365001491087147,
+				"StableID":   "nxDxsGyJr311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f32b0a4f92ee27d5a21c0b41ae2210feb100c14725c5306b3575d7c43b22c65a",
+				"KeyExpiry":  "2026-10-26T10:54:07Z",
+				"DiscoKey":   "discokey:7fe1ca8b066b917a24db8b740c8764d4579cb39581250eed13d46da18515d12b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50387", "10.65.0.27:50387", "172.17.0.1:50387"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:54:07.993502885Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4355757344027596,
+				"StableID":   "nwQHuqMj1b11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f115257ae45de14fb0d5872d3bf96ec9641f658c9b16e2be887b16fb94a1372",
+				"KeyExpiry":  "2026-10-26T10:54:08Z",
+				"DiscoKey":   "discokey:ab65dbf3cf8ff354880cd5859d2be610f8eb5dcb92df0d3bb978b40db9e13d48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41037", "10.65.0.27:41037", "172.17.0.1:41037"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:54:08.564480112Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2081235777602505": {
+				"ID":          2081235777602505,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-malformed-test-port-negative.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-malformed-test-port-negative.hujson
@@ -1,0 +1,8839 @@
+// policytest-malformed-test-port-negative
+//
+// tests block malformed: dst port is negative
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:54:30Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-malformed-test-port-negative",
+	"description":    "tests block malformed: dst port is negative",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:54:30.272429425Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                          \n  \n                                                               \n{\n\t\"id\":          \"policytest-malformed-test-port-negative\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block malformed: dst port is negative\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"thor@example.org\"], \"dst\": [\"webserver:80\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"accept\": [\"webserver:-1\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-malformed-test-port-negative.hujson",
+		"full_policy": {"acls": [
+			{"action": "accept", "dst": ["webserver:80"], "src": ["thor@example.org"]}
+		], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [{"accept": ["webserver:-1"], "src": "thor@example.org"}]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2127905378781679,
+				"StableID":   "nvgte2UjcH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       2127905378781679,
+				"Key":        "nodekey:dd8de4544e975c1975b024fb55c889fffa600ac2e4191aad6d6dd82af89a1b6e",
+				"DiscoKey":   "discokey:b3883010e07344d925257d2ff91d502ba57f17292acd3f5f48298bb01ccdf911",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:51933", "10.65.0.27:51933", "172.17.0.1:51933"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:54:33.890182756Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dd8de4544e975c1975b024fb55c889fffa600ac2e4191aad6d6dd82af89a1b6e",
+			"MachineKey": "mkey:bd724c65f7234373b1c825bfdcf727cc74d524e5c76a7757251c1e1125edcc76",
+			"Peers": [{
+				"ID":         2722514995768186,
+				"StableID":   "n9pxMSr2GN11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8595433979a4972f3a3e8b8d3abcb91f4e7deddd1cbf9dbf193fbe4f2672b47b",
+				"DiscoKey":   "discokey:90432b39cf909e79261d3c5617d67db6309c7eb1739ae490ab82c3516ce2884b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:40381", "10.65.0.27:40381", "172.17.0.1:40381"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:54:31.763927374Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2915344900920843,
+				"StableID":   "nvgMmgANmP11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bc7ec2c46a082ad91d2b8fb98a48cee355b75314e7c1a5fdedce536350f91a26",
+				"DiscoKey":   "discokey:c3793594623efb609af324d248f95d02cac63d598fa46495fe699a2d16592823",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:49366", "10.65.0.27:49366", "172.17.0.1:49366"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:54:32.270518361Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2839072992651715,
+				"StableID":   "n4ftQjdpAP11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d99c52664723eb7601de0dd23bc58a2365f1a48333003723c92c6cf789c7225b",
+				"DiscoKey":   "discokey:973aa6911a423d6ae4955714c5b71adf52f8f64f3ff7bbd5364b95f523f85a0c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59026", "10.65.0.27:59026", "172.17.0.1:59026"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:54:32.841442749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3207837995480895,
+				"StableID":   "nL1GwwTq3S11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:45ebacd8d61be7ad9e03eaec9700adee703a2cea6047741fdcec3548a5e02454",
+				"DiscoKey":   "discokey:03530d628f5d3cc7205967f60a04d3f2179a34363a27778ca01dd1e508786e4a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:60459", "10.65.0.27:60459", "172.17.0.1:60459"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:54:33.365531752Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3839178424447153,
+				"StableID":   "nQSji1imyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:29e06cc1ee394296a533c78e6705592c06b390368458edcc32e2320b85379f02",
+				"KeyExpiry":  "2026-10-26T10:54:34Z",
+				"DiscoKey":   "discokey:b273a5c187962dcc625485c13bfca4b6914ccf8990eca52c584bb4887bb93979",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34643", "10.65.0.27:34643", "172.17.0.1:34643"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:54:34.437643375Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7068083868349418,
+				"StableID":   "nhEwvWa9Cx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:219532ddc75c9652f4a6d18f9c5b6c762b4f1d777efe54e888f837a5b807b210",
+				"KeyExpiry":  "2026-10-26T10:54:34Z",
+				"DiscoKey":   "discokey:36acb6c3b3a34d17fa3b9831639f3b5f5fe8147d74c80ae2aba1c7b3cf2c8830",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38760", "10.65.0.27:38760", "172.17.0.1:38760"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:54:34.981142278Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1152104143470772,
+				"StableID":   "nXGsxgpnz911CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7ff914a3b11fc3e5fca46ff7aba68b8cfe1695011f55166c33ccaede24e44f25",
+				"KeyExpiry":  "2026-10-26T10:54:35Z",
+				"DiscoKey":   "discokey:435ea3e26faffbf0e1d48ab00fb8b3cdf783f2f3624f6c7ae0b8fb4c145ca344",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:48502", "10.65.0.27:48502", "172.17.0.1:48502"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:54:35.508278705Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2127905378781679": {
+				"ID":          2127905378781679,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1152104143470772,
+				"StableID":   "nXGsxgpnz911CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7ff914a3b11fc3e5fca46ff7aba68b8cfe1695011f55166c33ccaede24e44f25",
+				"KeyExpiry":  "2026-10-26T10:54:35Z",
+				"DiscoKey":   "discokey:435ea3e26faffbf0e1d48ab00fb8b3cdf783f2f3624f6c7ae0b8fb4c145ca344",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:48502", "10.65.0.27:48502", "172.17.0.1:48502"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:54:35.508278705Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7ff914a3b11fc3e5fca46ff7aba68b8cfe1695011f55166c33ccaede24e44f25",
+			"MachineKey": "mkey:2d7247b7b2a379411b130b34509735167d2f95d47fb32832de4570eb9ff90711",
+			"Peers": [{
+				"ID":         2722514995768186,
+				"StableID":   "n9pxMSr2GN11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8595433979a4972f3a3e8b8d3abcb91f4e7deddd1cbf9dbf193fbe4f2672b47b",
+				"DiscoKey":   "discokey:90432b39cf909e79261d3c5617d67db6309c7eb1739ae490ab82c3516ce2884b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:40381", "10.65.0.27:40381", "172.17.0.1:40381"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:54:31.763927374Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2915344900920843,
+				"StableID":   "nvgMmgANmP11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bc7ec2c46a082ad91d2b8fb98a48cee355b75314e7c1a5fdedce536350f91a26",
+				"DiscoKey":   "discokey:c3793594623efb609af324d248f95d02cac63d598fa46495fe699a2d16592823",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:49366", "10.65.0.27:49366", "172.17.0.1:49366"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:54:32.270518361Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2839072992651715,
+				"StableID":   "n4ftQjdpAP11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d99c52664723eb7601de0dd23bc58a2365f1a48333003723c92c6cf789c7225b",
+				"DiscoKey":   "discokey:973aa6911a423d6ae4955714c5b71adf52f8f64f3ff7bbd5364b95f523f85a0c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59026", "10.65.0.27:59026", "172.17.0.1:59026"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:54:32.841442749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3207837995480895,
+				"StableID":   "nL1GwwTq3S11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:45ebacd8d61be7ad9e03eaec9700adee703a2cea6047741fdcec3548a5e02454",
+				"DiscoKey":   "discokey:03530d628f5d3cc7205967f60a04d3f2179a34363a27778ca01dd1e508786e4a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:60459", "10.65.0.27:60459", "172.17.0.1:60459"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:54:33.365531752Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2127905378781679,
+				"StableID":   "nvgte2UjcH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dd8de4544e975c1975b024fb55c889fffa600ac2e4191aad6d6dd82af89a1b6e",
+				"DiscoKey":   "discokey:b3883010e07344d925257d2ff91d502ba57f17292acd3f5f48298bb01ccdf911",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:51933", "10.65.0.27:51933", "172.17.0.1:51933"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:54:33.890182756Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3839178424447153,
+				"StableID":   "nQSji1imyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:29e06cc1ee394296a533c78e6705592c06b390368458edcc32e2320b85379f02",
+				"KeyExpiry":  "2026-10-26T10:54:34Z",
+				"DiscoKey":   "discokey:b273a5c187962dcc625485c13bfca4b6914ccf8990eca52c584bb4887bb93979",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34643", "10.65.0.27:34643", "172.17.0.1:34643"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:54:34.437643375Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7068083868349418,
+				"StableID":   "nhEwvWa9Cx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:219532ddc75c9652f4a6d18f9c5b6c762b4f1d777efe54e888f837a5b807b210",
+				"KeyExpiry":  "2026-10-26T10:54:34Z",
+				"DiscoKey":   "discokey:36acb6c3b3a34d17fa3b9831639f3b5f5fe8147d74c80ae2aba1c7b3cf2c8830",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38760", "10.65.0.27:38760", "172.17.0.1:38760"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:54:34.981142278Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2722514995768186,
+				"StableID":   "n9pxMSr2GN11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       2722514995768186,
+				"Key":        "nodekey:8595433979a4972f3a3e8b8d3abcb91f4e7deddd1cbf9dbf193fbe4f2672b47b",
+				"DiscoKey":   "discokey:90432b39cf909e79261d3c5617d67db6309c7eb1739ae490ab82c3516ce2884b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:40381", "10.65.0.27:40381", "172.17.0.1:40381"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:54:31.763927374Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8595433979a4972f3a3e8b8d3abcb91f4e7deddd1cbf9dbf193fbe4f2672b47b",
+			"MachineKey": "mkey:d2cef19878e50bf76c51929eb2a8ea1aabe6d936ab0e235b8831fb7ca87d005b",
+			"Peers": [{
+				"ID":         2915344900920843,
+				"StableID":   "nvgMmgANmP11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bc7ec2c46a082ad91d2b8fb98a48cee355b75314e7c1a5fdedce536350f91a26",
+				"DiscoKey":   "discokey:c3793594623efb609af324d248f95d02cac63d598fa46495fe699a2d16592823",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:49366", "10.65.0.27:49366", "172.17.0.1:49366"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:54:32.270518361Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2839072992651715,
+				"StableID":   "n4ftQjdpAP11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d99c52664723eb7601de0dd23bc58a2365f1a48333003723c92c6cf789c7225b",
+				"DiscoKey":   "discokey:973aa6911a423d6ae4955714c5b71adf52f8f64f3ff7bbd5364b95f523f85a0c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59026", "10.65.0.27:59026", "172.17.0.1:59026"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:54:32.841442749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3207837995480895,
+				"StableID":   "nL1GwwTq3S11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:45ebacd8d61be7ad9e03eaec9700adee703a2cea6047741fdcec3548a5e02454",
+				"DiscoKey":   "discokey:03530d628f5d3cc7205967f60a04d3f2179a34363a27778ca01dd1e508786e4a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:60459", "10.65.0.27:60459", "172.17.0.1:60459"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:54:33.365531752Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2127905378781679,
+				"StableID":   "nvgte2UjcH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dd8de4544e975c1975b024fb55c889fffa600ac2e4191aad6d6dd82af89a1b6e",
+				"DiscoKey":   "discokey:b3883010e07344d925257d2ff91d502ba57f17292acd3f5f48298bb01ccdf911",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:51933", "10.65.0.27:51933", "172.17.0.1:51933"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:54:33.890182756Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3839178424447153,
+				"StableID":   "nQSji1imyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:29e06cc1ee394296a533c78e6705592c06b390368458edcc32e2320b85379f02",
+				"KeyExpiry":  "2026-10-26T10:54:34Z",
+				"DiscoKey":   "discokey:b273a5c187962dcc625485c13bfca4b6914ccf8990eca52c584bb4887bb93979",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34643", "10.65.0.27:34643", "172.17.0.1:34643"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:54:34.437643375Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7068083868349418,
+				"StableID":   "nhEwvWa9Cx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:219532ddc75c9652f4a6d18f9c5b6c762b4f1d777efe54e888f837a5b807b210",
+				"KeyExpiry":  "2026-10-26T10:54:34Z",
+				"DiscoKey":   "discokey:36acb6c3b3a34d17fa3b9831639f3b5f5fe8147d74c80ae2aba1c7b3cf2c8830",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38760", "10.65.0.27:38760", "172.17.0.1:38760"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:54:34.981142278Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1152104143470772,
+				"StableID":   "nXGsxgpnz911CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7ff914a3b11fc3e5fca46ff7aba68b8cfe1695011f55166c33ccaede24e44f25",
+				"KeyExpiry":  "2026-10-26T10:54:35Z",
+				"DiscoKey":   "discokey:435ea3e26faffbf0e1d48ab00fb8b3cdf783f2f3624f6c7ae0b8fb4c145ca344",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:48502", "10.65.0.27:48502", "172.17.0.1:48502"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:54:35.508278705Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2722514995768186": {
+				"ID":          2722514995768186,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3839178424447153,
+				"StableID":   "nQSji1imyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:29e06cc1ee394296a533c78e6705592c06b390368458edcc32e2320b85379f02",
+				"KeyExpiry":  "2026-10-26T10:54:34Z",
+				"DiscoKey":   "discokey:b273a5c187962dcc625485c13bfca4b6914ccf8990eca52c584bb4887bb93979",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34643", "10.65.0.27:34643", "172.17.0.1:34643"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:54:34.437643375Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:29e06cc1ee394296a533c78e6705592c06b390368458edcc32e2320b85379f02",
+			"MachineKey": "mkey:d5d3778adbd47f1b75ec7a6a5a3e04489349eec41ee56a80fedfe10a65567c55",
+			"Peers": [{
+				"ID":         2722514995768186,
+				"StableID":   "n9pxMSr2GN11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8595433979a4972f3a3e8b8d3abcb91f4e7deddd1cbf9dbf193fbe4f2672b47b",
+				"DiscoKey":   "discokey:90432b39cf909e79261d3c5617d67db6309c7eb1739ae490ab82c3516ce2884b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:40381", "10.65.0.27:40381", "172.17.0.1:40381"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:54:31.763927374Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2915344900920843,
+				"StableID":   "nvgMmgANmP11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bc7ec2c46a082ad91d2b8fb98a48cee355b75314e7c1a5fdedce536350f91a26",
+				"DiscoKey":   "discokey:c3793594623efb609af324d248f95d02cac63d598fa46495fe699a2d16592823",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:49366", "10.65.0.27:49366", "172.17.0.1:49366"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:54:32.270518361Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2839072992651715,
+				"StableID":   "n4ftQjdpAP11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d99c52664723eb7601de0dd23bc58a2365f1a48333003723c92c6cf789c7225b",
+				"DiscoKey":   "discokey:973aa6911a423d6ae4955714c5b71adf52f8f64f3ff7bbd5364b95f523f85a0c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59026", "10.65.0.27:59026", "172.17.0.1:59026"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:54:32.841442749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3207837995480895,
+				"StableID":   "nL1GwwTq3S11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:45ebacd8d61be7ad9e03eaec9700adee703a2cea6047741fdcec3548a5e02454",
+				"DiscoKey":   "discokey:03530d628f5d3cc7205967f60a04d3f2179a34363a27778ca01dd1e508786e4a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:60459", "10.65.0.27:60459", "172.17.0.1:60459"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:54:33.365531752Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2127905378781679,
+				"StableID":   "nvgte2UjcH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dd8de4544e975c1975b024fb55c889fffa600ac2e4191aad6d6dd82af89a1b6e",
+				"DiscoKey":   "discokey:b3883010e07344d925257d2ff91d502ba57f17292acd3f5f48298bb01ccdf911",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:51933", "10.65.0.27:51933", "172.17.0.1:51933"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:54:33.890182756Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7068083868349418,
+				"StableID":   "nhEwvWa9Cx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:219532ddc75c9652f4a6d18f9c5b6c762b4f1d777efe54e888f837a5b807b210",
+				"KeyExpiry":  "2026-10-26T10:54:34Z",
+				"DiscoKey":   "discokey:36acb6c3b3a34d17fa3b9831639f3b5f5fe8147d74c80ae2aba1c7b3cf2c8830",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38760", "10.65.0.27:38760", "172.17.0.1:38760"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:54:34.981142278Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1152104143470772,
+				"StableID":   "nXGsxgpnz911CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7ff914a3b11fc3e5fca46ff7aba68b8cfe1695011f55166c33ccaede24e44f25",
+				"KeyExpiry":  "2026-10-26T10:54:35Z",
+				"DiscoKey":   "discokey:435ea3e26faffbf0e1d48ab00fb8b3cdf783f2f3624f6c7ae0b8fb4c145ca344",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:48502", "10.65.0.27:48502", "172.17.0.1:48502"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:54:35.508278705Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3207837995480895,
+				"StableID":   "nL1GwwTq3S11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       3207837995480895,
+				"Key":        "nodekey:45ebacd8d61be7ad9e03eaec9700adee703a2cea6047741fdcec3548a5e02454",
+				"DiscoKey":   "discokey:03530d628f5d3cc7205967f60a04d3f2179a34363a27778ca01dd1e508786e4a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:60459", "10.65.0.27:60459", "172.17.0.1:60459"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:54:33.365531752Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:45ebacd8d61be7ad9e03eaec9700adee703a2cea6047741fdcec3548a5e02454",
+			"MachineKey": "mkey:31e405bde9c8748f9ab7db9537099ebcbfb04a6eb148dd94181cd91dc541c64b",
+			"Peers": [{
+				"ID":         2722514995768186,
+				"StableID":   "n9pxMSr2GN11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8595433979a4972f3a3e8b8d3abcb91f4e7deddd1cbf9dbf193fbe4f2672b47b",
+				"DiscoKey":   "discokey:90432b39cf909e79261d3c5617d67db6309c7eb1739ae490ab82c3516ce2884b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:40381", "10.65.0.27:40381", "172.17.0.1:40381"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:54:31.763927374Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2915344900920843,
+				"StableID":   "nvgMmgANmP11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bc7ec2c46a082ad91d2b8fb98a48cee355b75314e7c1a5fdedce536350f91a26",
+				"DiscoKey":   "discokey:c3793594623efb609af324d248f95d02cac63d598fa46495fe699a2d16592823",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:49366", "10.65.0.27:49366", "172.17.0.1:49366"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:54:32.270518361Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2839072992651715,
+				"StableID":   "n4ftQjdpAP11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d99c52664723eb7601de0dd23bc58a2365f1a48333003723c92c6cf789c7225b",
+				"DiscoKey":   "discokey:973aa6911a423d6ae4955714c5b71adf52f8f64f3ff7bbd5364b95f523f85a0c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59026", "10.65.0.27:59026", "172.17.0.1:59026"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:54:32.841442749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2127905378781679,
+				"StableID":   "nvgte2UjcH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dd8de4544e975c1975b024fb55c889fffa600ac2e4191aad6d6dd82af89a1b6e",
+				"DiscoKey":   "discokey:b3883010e07344d925257d2ff91d502ba57f17292acd3f5f48298bb01ccdf911",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:51933", "10.65.0.27:51933", "172.17.0.1:51933"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:54:33.890182756Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3839178424447153,
+				"StableID":   "nQSji1imyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:29e06cc1ee394296a533c78e6705592c06b390368458edcc32e2320b85379f02",
+				"KeyExpiry":  "2026-10-26T10:54:34Z",
+				"DiscoKey":   "discokey:b273a5c187962dcc625485c13bfca4b6914ccf8990eca52c584bb4887bb93979",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34643", "10.65.0.27:34643", "172.17.0.1:34643"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:54:34.437643375Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7068083868349418,
+				"StableID":   "nhEwvWa9Cx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:219532ddc75c9652f4a6d18f9c5b6c762b4f1d777efe54e888f837a5b807b210",
+				"KeyExpiry":  "2026-10-26T10:54:34Z",
+				"DiscoKey":   "discokey:36acb6c3b3a34d17fa3b9831639f3b5f5fe8147d74c80ae2aba1c7b3cf2c8830",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38760", "10.65.0.27:38760", "172.17.0.1:38760"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:54:34.981142278Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1152104143470772,
+				"StableID":   "nXGsxgpnz911CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7ff914a3b11fc3e5fca46ff7aba68b8cfe1695011f55166c33ccaede24e44f25",
+				"KeyExpiry":  "2026-10-26T10:54:35Z",
+				"DiscoKey":   "discokey:435ea3e26faffbf0e1d48ab00fb8b3cdf783f2f3624f6c7ae0b8fb4c145ca344",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:48502", "10.65.0.27:48502", "172.17.0.1:48502"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:54:35.508278705Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3207837995480895": {
+				"ID":          3207837995480895,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2915344900920843,
+				"StableID":   "nvgMmgANmP11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       2915344900920843,
+				"Key":        "nodekey:bc7ec2c46a082ad91d2b8fb98a48cee355b75314e7c1a5fdedce536350f91a26",
+				"DiscoKey":   "discokey:c3793594623efb609af324d248f95d02cac63d598fa46495fe699a2d16592823",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:49366", "10.65.0.27:49366", "172.17.0.1:49366"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:54:32.270518361Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bc7ec2c46a082ad91d2b8fb98a48cee355b75314e7c1a5fdedce536350f91a26",
+			"MachineKey": "mkey:dc7be9f00d3b9a31111a16eb301dd5a10212f6a1f028149b674be083c726c629",
+			"Peers": [{
+				"ID":         2722514995768186,
+				"StableID":   "n9pxMSr2GN11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8595433979a4972f3a3e8b8d3abcb91f4e7deddd1cbf9dbf193fbe4f2672b47b",
+				"DiscoKey":   "discokey:90432b39cf909e79261d3c5617d67db6309c7eb1739ae490ab82c3516ce2884b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:40381", "10.65.0.27:40381", "172.17.0.1:40381"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:54:31.763927374Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2839072992651715,
+				"StableID":   "n4ftQjdpAP11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d99c52664723eb7601de0dd23bc58a2365f1a48333003723c92c6cf789c7225b",
+				"DiscoKey":   "discokey:973aa6911a423d6ae4955714c5b71adf52f8f64f3ff7bbd5364b95f523f85a0c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59026", "10.65.0.27:59026", "172.17.0.1:59026"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:54:32.841442749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3207837995480895,
+				"StableID":   "nL1GwwTq3S11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:45ebacd8d61be7ad9e03eaec9700adee703a2cea6047741fdcec3548a5e02454",
+				"DiscoKey":   "discokey:03530d628f5d3cc7205967f60a04d3f2179a34363a27778ca01dd1e508786e4a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:60459", "10.65.0.27:60459", "172.17.0.1:60459"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:54:33.365531752Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2127905378781679,
+				"StableID":   "nvgte2UjcH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dd8de4544e975c1975b024fb55c889fffa600ac2e4191aad6d6dd82af89a1b6e",
+				"DiscoKey":   "discokey:b3883010e07344d925257d2ff91d502ba57f17292acd3f5f48298bb01ccdf911",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:51933", "10.65.0.27:51933", "172.17.0.1:51933"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:54:33.890182756Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3839178424447153,
+				"StableID":   "nQSji1imyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:29e06cc1ee394296a533c78e6705592c06b390368458edcc32e2320b85379f02",
+				"KeyExpiry":  "2026-10-26T10:54:34Z",
+				"DiscoKey":   "discokey:b273a5c187962dcc625485c13bfca4b6914ccf8990eca52c584bb4887bb93979",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34643", "10.65.0.27:34643", "172.17.0.1:34643"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:54:34.437643375Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7068083868349418,
+				"StableID":   "nhEwvWa9Cx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:219532ddc75c9652f4a6d18f9c5b6c762b4f1d777efe54e888f837a5b807b210",
+				"KeyExpiry":  "2026-10-26T10:54:34Z",
+				"DiscoKey":   "discokey:36acb6c3b3a34d17fa3b9831639f3b5f5fe8147d74c80ae2aba1c7b3cf2c8830",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38760", "10.65.0.27:38760", "172.17.0.1:38760"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:54:34.981142278Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1152104143470772,
+				"StableID":   "nXGsxgpnz911CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7ff914a3b11fc3e5fca46ff7aba68b8cfe1695011f55166c33ccaede24e44f25",
+				"KeyExpiry":  "2026-10-26T10:54:35Z",
+				"DiscoKey":   "discokey:435ea3e26faffbf0e1d48ab00fb8b3cdf783f2f3624f6c7ae0b8fb4c145ca344",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:48502", "10.65.0.27:48502", "172.17.0.1:48502"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:54:35.508278705Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2915344900920843": {
+				"ID":          2915344900920843,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7068083868349418,
+				"StableID":   "nhEwvWa9Cx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:219532ddc75c9652f4a6d18f9c5b6c762b4f1d777efe54e888f837a5b807b210",
+				"KeyExpiry":  "2026-10-26T10:54:34Z",
+				"DiscoKey":   "discokey:36acb6c3b3a34d17fa3b9831639f3b5f5fe8147d74c80ae2aba1c7b3cf2c8830",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38760", "10.65.0.27:38760", "172.17.0.1:38760"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:54:34.981142278Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:219532ddc75c9652f4a6d18f9c5b6c762b4f1d777efe54e888f837a5b807b210",
+			"MachineKey": "mkey:241489354977f29841f272c7a288d62f9ab1678b270168a95b4c1969572a0e4d",
+			"Peers": [{
+				"ID":         2722514995768186,
+				"StableID":   "n9pxMSr2GN11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8595433979a4972f3a3e8b8d3abcb91f4e7deddd1cbf9dbf193fbe4f2672b47b",
+				"DiscoKey":   "discokey:90432b39cf909e79261d3c5617d67db6309c7eb1739ae490ab82c3516ce2884b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:40381", "10.65.0.27:40381", "172.17.0.1:40381"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:54:31.763927374Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2915344900920843,
+				"StableID":   "nvgMmgANmP11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bc7ec2c46a082ad91d2b8fb98a48cee355b75314e7c1a5fdedce536350f91a26",
+				"DiscoKey":   "discokey:c3793594623efb609af324d248f95d02cac63d598fa46495fe699a2d16592823",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:49366", "10.65.0.27:49366", "172.17.0.1:49366"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:54:32.270518361Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2839072992651715,
+				"StableID":   "n4ftQjdpAP11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d99c52664723eb7601de0dd23bc58a2365f1a48333003723c92c6cf789c7225b",
+				"DiscoKey":   "discokey:973aa6911a423d6ae4955714c5b71adf52f8f64f3ff7bbd5364b95f523f85a0c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59026", "10.65.0.27:59026", "172.17.0.1:59026"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:54:32.841442749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3207837995480895,
+				"StableID":   "nL1GwwTq3S11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:45ebacd8d61be7ad9e03eaec9700adee703a2cea6047741fdcec3548a5e02454",
+				"DiscoKey":   "discokey:03530d628f5d3cc7205967f60a04d3f2179a34363a27778ca01dd1e508786e4a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:60459", "10.65.0.27:60459", "172.17.0.1:60459"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:54:33.365531752Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2127905378781679,
+				"StableID":   "nvgte2UjcH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dd8de4544e975c1975b024fb55c889fffa600ac2e4191aad6d6dd82af89a1b6e",
+				"DiscoKey":   "discokey:b3883010e07344d925257d2ff91d502ba57f17292acd3f5f48298bb01ccdf911",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:51933", "10.65.0.27:51933", "172.17.0.1:51933"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:54:33.890182756Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3839178424447153,
+				"StableID":   "nQSji1imyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:29e06cc1ee394296a533c78e6705592c06b390368458edcc32e2320b85379f02",
+				"KeyExpiry":  "2026-10-26T10:54:34Z",
+				"DiscoKey":   "discokey:b273a5c187962dcc625485c13bfca4b6914ccf8990eca52c584bb4887bb93979",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34643", "10.65.0.27:34643", "172.17.0.1:34643"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:54:34.437643375Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1152104143470772,
+				"StableID":   "nXGsxgpnz911CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7ff914a3b11fc3e5fca46ff7aba68b8cfe1695011f55166c33ccaede24e44f25",
+				"KeyExpiry":  "2026-10-26T10:54:35Z",
+				"DiscoKey":   "discokey:435ea3e26faffbf0e1d48ab00fb8b3cdf783f2f3624f6c7ae0b8fb4c145ca344",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:48502", "10.65.0.27:48502", "172.17.0.1:48502"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:54:35.508278705Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2839072992651715,
+				"StableID":   "n4ftQjdpAP11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       2839072992651715,
+				"Key":        "nodekey:d99c52664723eb7601de0dd23bc58a2365f1a48333003723c92c6cf789c7225b",
+				"DiscoKey":   "discokey:973aa6911a423d6ae4955714c5b71adf52f8f64f3ff7bbd5364b95f523f85a0c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59026", "10.65.0.27:59026", "172.17.0.1:59026"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:54:32.841442749Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d99c52664723eb7601de0dd23bc58a2365f1a48333003723c92c6cf789c7225b",
+			"MachineKey": "mkey:f4ae75ba205895a62c5264768291f17fd916f4bebbba617959161c86f2885532",
+			"Peers": [{
+				"ID":         2722514995768186,
+				"StableID":   "n9pxMSr2GN11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8595433979a4972f3a3e8b8d3abcb91f4e7deddd1cbf9dbf193fbe4f2672b47b",
+				"DiscoKey":   "discokey:90432b39cf909e79261d3c5617d67db6309c7eb1739ae490ab82c3516ce2884b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:40381", "10.65.0.27:40381", "172.17.0.1:40381"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:54:31.763927374Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2915344900920843,
+				"StableID":   "nvgMmgANmP11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bc7ec2c46a082ad91d2b8fb98a48cee355b75314e7c1a5fdedce536350f91a26",
+				"DiscoKey":   "discokey:c3793594623efb609af324d248f95d02cac63d598fa46495fe699a2d16592823",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:49366", "10.65.0.27:49366", "172.17.0.1:49366"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:54:32.270518361Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3207837995480895,
+				"StableID":   "nL1GwwTq3S11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:45ebacd8d61be7ad9e03eaec9700adee703a2cea6047741fdcec3548a5e02454",
+				"DiscoKey":   "discokey:03530d628f5d3cc7205967f60a04d3f2179a34363a27778ca01dd1e508786e4a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:60459", "10.65.0.27:60459", "172.17.0.1:60459"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:54:33.365531752Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2127905378781679,
+				"StableID":   "nvgte2UjcH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dd8de4544e975c1975b024fb55c889fffa600ac2e4191aad6d6dd82af89a1b6e",
+				"DiscoKey":   "discokey:b3883010e07344d925257d2ff91d502ba57f17292acd3f5f48298bb01ccdf911",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:51933", "10.65.0.27:51933", "172.17.0.1:51933"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:54:33.890182756Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3839178424447153,
+				"StableID":   "nQSji1imyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:29e06cc1ee394296a533c78e6705592c06b390368458edcc32e2320b85379f02",
+				"KeyExpiry":  "2026-10-26T10:54:34Z",
+				"DiscoKey":   "discokey:b273a5c187962dcc625485c13bfca4b6914ccf8990eca52c584bb4887bb93979",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34643", "10.65.0.27:34643", "172.17.0.1:34643"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:54:34.437643375Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7068083868349418,
+				"StableID":   "nhEwvWa9Cx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:219532ddc75c9652f4a6d18f9c5b6c762b4f1d777efe54e888f837a5b807b210",
+				"KeyExpiry":  "2026-10-26T10:54:34Z",
+				"DiscoKey":   "discokey:36acb6c3b3a34d17fa3b9831639f3b5f5fe8147d74c80ae2aba1c7b3cf2c8830",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38760", "10.65.0.27:38760", "172.17.0.1:38760"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:54:34.981142278Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1152104143470772,
+				"StableID":   "nXGsxgpnz911CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7ff914a3b11fc3e5fca46ff7aba68b8cfe1695011f55166c33ccaede24e44f25",
+				"KeyExpiry":  "2026-10-26T10:54:35Z",
+				"DiscoKey":   "discokey:435ea3e26faffbf0e1d48ab00fb8b3cdf783f2f3624f6c7ae0b8fb4c145ca344",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:48502", "10.65.0.27:48502", "172.17.0.1:48502"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:54:35.508278705Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2839072992651715": {
+				"ID":          2839072992651715,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-malformed-test-port-out-of-range.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-malformed-test-port-out-of-range.hujson
@@ -1,0 +1,8845 @@
+// policytest-malformed-test-port-out-of-range
+//
+// tests block malformed: dst port > 65535
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:54:57Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-malformed-test-port-out-of-range",
+	"description":    "tests block malformed: dst port > 65535",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:54:57.212572695Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                              \n  \n                                                                 \n{\n\t\"id\":          \"policytest-malformed-test-port-out-of-range\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block malformed: dst port > 65535\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"thor@example.org\"], \"dst\": [\"webserver:80\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"accept\": [\"webserver:99999\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-malformed-test-port-out-of-range.hujson",
+		"full_policy": {
+			"acls": [
+				{"action": "accept", "dst": ["webserver:80"], "src": ["thor@example.org"]}
+			],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["webserver:99999"], "src": "thor@example.org"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3441525286983777,
+				"StableID":   "neqLfw2gsT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       3441525286983777,
+				"Key":        "nodekey:17167b49c564e3d6461f5017e2a7e906a0807db1919381a0b6d9c0d4ffdaad64",
+				"DiscoKey":   "discokey:9cd124c0f098ebc59dd475886be41b818bef81f5f84eb02dc29cbb3f909ccf1d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55198", "10.65.0.27:55198", "172.17.0.1:55198"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:55:00.869610846Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:17167b49c564e3d6461f5017e2a7e906a0807db1919381a0b6d9c0d4ffdaad64",
+			"MachineKey": "mkey:0c6600b40f1c4d5135ade03ff967858bda1b205b988f955807dfc45c5c14a31e",
+			"Peers": [{
+				"ID":         1576288904486390,
+				"StableID":   "nm42kKSuJD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c805a2b01fa31cfa2338bf394bc5037c70b29923a7097d5b2e5ba71daa7a842e",
+				"DiscoKey":   "discokey:eb34c8ac6178f4fbd760ae95aa85e9f33fa551da65e7e560df58f211b714b63f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37316", "10.65.0.27:37316", "172.17.0.1:37316"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:54:58.66090945Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7661821002985827,
+				"StableID":   "nJWuMe34q221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af827fab095d10aca92bcaf50d6d9ac84148bfec6c7cc802c79ba7e4d428c63e",
+				"DiscoKey":   "discokey:468328eb54a945e161bf609047228ba9d2f91fe4e1b8f0de2e5c3de3d62e232c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:54:59.210495737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3815969058684745,
+				"StableID":   "nCSYY73GoW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f145d57e916c7f8f05095ac3aa2b4b437afb268ef76308f5a7b0e3372e2db07",
+				"DiscoKey":   "discokey:f003a157bfbdc81622c1353e50b849bd3a3570fad8d6ffeb4367987ffedaeb7b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40530", "10.65.0.27:40530", "172.17.0.1:40530"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:54:59.737746478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6528640237405801,
+				"StableID":   "n8a5WtJqys11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d539acc3a2f6f97c47ca4c75928279560e488996b865e58dcaf6035962524451",
+				"DiscoKey":   "discokey:42ef369c1b96b7a925114c5139c3da4060a77f3096690d896eba69a89edb4676",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59335", "10.65.0.27:59335", "172.17.0.1:59335"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:55:00.294696928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8962153087722711,
+				"StableID":   "nNGpujZyyC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b818057b40cf00ca7a6fdb490a0574c6e20b38251ad8a36841f1778d8a40ab2c",
+				"KeyExpiry":  "2026-10-26T10:55:01Z",
+				"DiscoKey":   "discokey:23714ef10c7fb57f470507391144e96a639d17641d48f2af25048c92440f8410",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:40398", "10.65.0.27:40398", "172.17.0.1:40398"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:55:01.388467617Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1209030831225512,
+				"StableID":   "nZjaR1CaSA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e1b71263cd336ab743b3ac5155213156221d0d9074a0f6be5a6b6cad19a7037a",
+				"KeyExpiry":  "2026-10-26T10:55:01Z",
+				"DiscoKey":   "discokey:56d1370bd09b4d010c11cc6d1a462902abdda0b71c01ece555f801757c8f4116",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:46034", "10.65.0.27:46034", "172.17.0.1:46034"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:55:01.908987676Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1007156714733759,
+				"StableID":   "nWL23MJ9s811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:263637159d1e9cecd7740100e130f6136b650946964a6ca163a0142ede2d9813",
+				"KeyExpiry":  "2026-10-26T10:55:02Z",
+				"DiscoKey":   "discokey:10ebd85b7acb99323c93bcc4bef9cc3281b643469869043eb9e13dc7a4d5833a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36575", "10.65.0.27:36575", "172.17.0.1:36575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:55:02.465764877Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3441525286983777": {
+				"ID":          3441525286983777,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1007156714733759,
+				"StableID":   "nWL23MJ9s811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:263637159d1e9cecd7740100e130f6136b650946964a6ca163a0142ede2d9813",
+				"KeyExpiry":  "2026-10-26T10:55:02Z",
+				"DiscoKey":   "discokey:10ebd85b7acb99323c93bcc4bef9cc3281b643469869043eb9e13dc7a4d5833a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36575", "10.65.0.27:36575", "172.17.0.1:36575"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:55:02.465764877Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:263637159d1e9cecd7740100e130f6136b650946964a6ca163a0142ede2d9813",
+			"MachineKey": "mkey:a80a1eb036470e82fbce467565a8a47dc92d9b33e1f266abf166b03afb9a413e",
+			"Peers": [{
+				"ID":         1576288904486390,
+				"StableID":   "nm42kKSuJD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c805a2b01fa31cfa2338bf394bc5037c70b29923a7097d5b2e5ba71daa7a842e",
+				"DiscoKey":   "discokey:eb34c8ac6178f4fbd760ae95aa85e9f33fa551da65e7e560df58f211b714b63f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37316", "10.65.0.27:37316", "172.17.0.1:37316"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:54:58.66090945Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7661821002985827,
+				"StableID":   "nJWuMe34q221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af827fab095d10aca92bcaf50d6d9ac84148bfec6c7cc802c79ba7e4d428c63e",
+				"DiscoKey":   "discokey:468328eb54a945e161bf609047228ba9d2f91fe4e1b8f0de2e5c3de3d62e232c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:54:59.210495737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3815969058684745,
+				"StableID":   "nCSYY73GoW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f145d57e916c7f8f05095ac3aa2b4b437afb268ef76308f5a7b0e3372e2db07",
+				"DiscoKey":   "discokey:f003a157bfbdc81622c1353e50b849bd3a3570fad8d6ffeb4367987ffedaeb7b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40530", "10.65.0.27:40530", "172.17.0.1:40530"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:54:59.737746478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6528640237405801,
+				"StableID":   "n8a5WtJqys11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d539acc3a2f6f97c47ca4c75928279560e488996b865e58dcaf6035962524451",
+				"DiscoKey":   "discokey:42ef369c1b96b7a925114c5139c3da4060a77f3096690d896eba69a89edb4676",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59335", "10.65.0.27:59335", "172.17.0.1:59335"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:55:00.294696928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3441525286983777,
+				"StableID":   "neqLfw2gsT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:17167b49c564e3d6461f5017e2a7e906a0807db1919381a0b6d9c0d4ffdaad64",
+				"DiscoKey":   "discokey:9cd124c0f098ebc59dd475886be41b818bef81f5f84eb02dc29cbb3f909ccf1d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55198", "10.65.0.27:55198", "172.17.0.1:55198"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:55:00.869610846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8962153087722711,
+				"StableID":   "nNGpujZyyC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b818057b40cf00ca7a6fdb490a0574c6e20b38251ad8a36841f1778d8a40ab2c",
+				"KeyExpiry":  "2026-10-26T10:55:01Z",
+				"DiscoKey":   "discokey:23714ef10c7fb57f470507391144e96a639d17641d48f2af25048c92440f8410",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:40398", "10.65.0.27:40398", "172.17.0.1:40398"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:55:01.388467617Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1209030831225512,
+				"StableID":   "nZjaR1CaSA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e1b71263cd336ab743b3ac5155213156221d0d9074a0f6be5a6b6cad19a7037a",
+				"KeyExpiry":  "2026-10-26T10:55:01Z",
+				"DiscoKey":   "discokey:56d1370bd09b4d010c11cc6d1a462902abdda0b71c01ece555f801757c8f4116",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:46034", "10.65.0.27:46034", "172.17.0.1:46034"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:55:01.908987676Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1576288904486390,
+				"StableID":   "nm42kKSuJD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1576288904486390,
+				"Key":        "nodekey:c805a2b01fa31cfa2338bf394bc5037c70b29923a7097d5b2e5ba71daa7a842e",
+				"DiscoKey":   "discokey:eb34c8ac6178f4fbd760ae95aa85e9f33fa551da65e7e560df58f211b714b63f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37316", "10.65.0.27:37316", "172.17.0.1:37316"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:54:58.66090945Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c805a2b01fa31cfa2338bf394bc5037c70b29923a7097d5b2e5ba71daa7a842e",
+			"MachineKey": "mkey:b917d191fc8cb04313e8cd1f933e518da30787d1b50e894d29e0032cd836690c",
+			"Peers": [{
+				"ID":         7661821002985827,
+				"StableID":   "nJWuMe34q221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af827fab095d10aca92bcaf50d6d9ac84148bfec6c7cc802c79ba7e4d428c63e",
+				"DiscoKey":   "discokey:468328eb54a945e161bf609047228ba9d2f91fe4e1b8f0de2e5c3de3d62e232c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:54:59.210495737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3815969058684745,
+				"StableID":   "nCSYY73GoW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f145d57e916c7f8f05095ac3aa2b4b437afb268ef76308f5a7b0e3372e2db07",
+				"DiscoKey":   "discokey:f003a157bfbdc81622c1353e50b849bd3a3570fad8d6ffeb4367987ffedaeb7b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40530", "10.65.0.27:40530", "172.17.0.1:40530"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:54:59.737746478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6528640237405801,
+				"StableID":   "n8a5WtJqys11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d539acc3a2f6f97c47ca4c75928279560e488996b865e58dcaf6035962524451",
+				"DiscoKey":   "discokey:42ef369c1b96b7a925114c5139c3da4060a77f3096690d896eba69a89edb4676",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59335", "10.65.0.27:59335", "172.17.0.1:59335"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:55:00.294696928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3441525286983777,
+				"StableID":   "neqLfw2gsT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:17167b49c564e3d6461f5017e2a7e906a0807db1919381a0b6d9c0d4ffdaad64",
+				"DiscoKey":   "discokey:9cd124c0f098ebc59dd475886be41b818bef81f5f84eb02dc29cbb3f909ccf1d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55198", "10.65.0.27:55198", "172.17.0.1:55198"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:55:00.869610846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8962153087722711,
+				"StableID":   "nNGpujZyyC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b818057b40cf00ca7a6fdb490a0574c6e20b38251ad8a36841f1778d8a40ab2c",
+				"KeyExpiry":  "2026-10-26T10:55:01Z",
+				"DiscoKey":   "discokey:23714ef10c7fb57f470507391144e96a639d17641d48f2af25048c92440f8410",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:40398", "10.65.0.27:40398", "172.17.0.1:40398"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:55:01.388467617Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1209030831225512,
+				"StableID":   "nZjaR1CaSA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e1b71263cd336ab743b3ac5155213156221d0d9074a0f6be5a6b6cad19a7037a",
+				"KeyExpiry":  "2026-10-26T10:55:01Z",
+				"DiscoKey":   "discokey:56d1370bd09b4d010c11cc6d1a462902abdda0b71c01ece555f801757c8f4116",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:46034", "10.65.0.27:46034", "172.17.0.1:46034"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:55:01.908987676Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1007156714733759,
+				"StableID":   "nWL23MJ9s811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:263637159d1e9cecd7740100e130f6136b650946964a6ca163a0142ede2d9813",
+				"KeyExpiry":  "2026-10-26T10:55:02Z",
+				"DiscoKey":   "discokey:10ebd85b7acb99323c93bcc4bef9cc3281b643469869043eb9e13dc7a4d5833a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36575", "10.65.0.27:36575", "172.17.0.1:36575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:55:02.465764877Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1576288904486390": {
+				"ID":          1576288904486390,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8962153087722711,
+				"StableID":   "nNGpujZyyC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b818057b40cf00ca7a6fdb490a0574c6e20b38251ad8a36841f1778d8a40ab2c",
+				"KeyExpiry":  "2026-10-26T10:55:01Z",
+				"DiscoKey":   "discokey:23714ef10c7fb57f470507391144e96a639d17641d48f2af25048c92440f8410",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:40398", "10.65.0.27:40398", "172.17.0.1:40398"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:55:01.388467617Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b818057b40cf00ca7a6fdb490a0574c6e20b38251ad8a36841f1778d8a40ab2c",
+			"MachineKey": "mkey:bec9d9268c658568e37d4df121830d636cbc23e596e62d75ea24990ac4d60f46",
+			"Peers": [{
+				"ID":         1576288904486390,
+				"StableID":   "nm42kKSuJD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c805a2b01fa31cfa2338bf394bc5037c70b29923a7097d5b2e5ba71daa7a842e",
+				"DiscoKey":   "discokey:eb34c8ac6178f4fbd760ae95aa85e9f33fa551da65e7e560df58f211b714b63f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37316", "10.65.0.27:37316", "172.17.0.1:37316"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:54:58.66090945Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7661821002985827,
+				"StableID":   "nJWuMe34q221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af827fab095d10aca92bcaf50d6d9ac84148bfec6c7cc802c79ba7e4d428c63e",
+				"DiscoKey":   "discokey:468328eb54a945e161bf609047228ba9d2f91fe4e1b8f0de2e5c3de3d62e232c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:54:59.210495737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3815969058684745,
+				"StableID":   "nCSYY73GoW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f145d57e916c7f8f05095ac3aa2b4b437afb268ef76308f5a7b0e3372e2db07",
+				"DiscoKey":   "discokey:f003a157bfbdc81622c1353e50b849bd3a3570fad8d6ffeb4367987ffedaeb7b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40530", "10.65.0.27:40530", "172.17.0.1:40530"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:54:59.737746478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6528640237405801,
+				"StableID":   "n8a5WtJqys11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d539acc3a2f6f97c47ca4c75928279560e488996b865e58dcaf6035962524451",
+				"DiscoKey":   "discokey:42ef369c1b96b7a925114c5139c3da4060a77f3096690d896eba69a89edb4676",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59335", "10.65.0.27:59335", "172.17.0.1:59335"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:55:00.294696928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3441525286983777,
+				"StableID":   "neqLfw2gsT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:17167b49c564e3d6461f5017e2a7e906a0807db1919381a0b6d9c0d4ffdaad64",
+				"DiscoKey":   "discokey:9cd124c0f098ebc59dd475886be41b818bef81f5f84eb02dc29cbb3f909ccf1d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55198", "10.65.0.27:55198", "172.17.0.1:55198"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:55:00.869610846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1209030831225512,
+				"StableID":   "nZjaR1CaSA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e1b71263cd336ab743b3ac5155213156221d0d9074a0f6be5a6b6cad19a7037a",
+				"KeyExpiry":  "2026-10-26T10:55:01Z",
+				"DiscoKey":   "discokey:56d1370bd09b4d010c11cc6d1a462902abdda0b71c01ece555f801757c8f4116",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:46034", "10.65.0.27:46034", "172.17.0.1:46034"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:55:01.908987676Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1007156714733759,
+				"StableID":   "nWL23MJ9s811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:263637159d1e9cecd7740100e130f6136b650946964a6ca163a0142ede2d9813",
+				"KeyExpiry":  "2026-10-26T10:55:02Z",
+				"DiscoKey":   "discokey:10ebd85b7acb99323c93bcc4bef9cc3281b643469869043eb9e13dc7a4d5833a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36575", "10.65.0.27:36575", "172.17.0.1:36575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:55:02.465764877Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6528640237405801,
+				"StableID":   "n8a5WtJqys11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       6528640237405801,
+				"Key":        "nodekey:d539acc3a2f6f97c47ca4c75928279560e488996b865e58dcaf6035962524451",
+				"DiscoKey":   "discokey:42ef369c1b96b7a925114c5139c3da4060a77f3096690d896eba69a89edb4676",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59335", "10.65.0.27:59335", "172.17.0.1:59335"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:55:00.294696928Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d539acc3a2f6f97c47ca4c75928279560e488996b865e58dcaf6035962524451",
+			"MachineKey": "mkey:86bc9b7846f47baebd9f49d3cb6caf45949ff8c77cfc734e7a311c8b131cd079",
+			"Peers": [{
+				"ID":         1576288904486390,
+				"StableID":   "nm42kKSuJD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c805a2b01fa31cfa2338bf394bc5037c70b29923a7097d5b2e5ba71daa7a842e",
+				"DiscoKey":   "discokey:eb34c8ac6178f4fbd760ae95aa85e9f33fa551da65e7e560df58f211b714b63f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37316", "10.65.0.27:37316", "172.17.0.1:37316"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:54:58.66090945Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7661821002985827,
+				"StableID":   "nJWuMe34q221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af827fab095d10aca92bcaf50d6d9ac84148bfec6c7cc802c79ba7e4d428c63e",
+				"DiscoKey":   "discokey:468328eb54a945e161bf609047228ba9d2f91fe4e1b8f0de2e5c3de3d62e232c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:54:59.210495737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3815969058684745,
+				"StableID":   "nCSYY73GoW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f145d57e916c7f8f05095ac3aa2b4b437afb268ef76308f5a7b0e3372e2db07",
+				"DiscoKey":   "discokey:f003a157bfbdc81622c1353e50b849bd3a3570fad8d6ffeb4367987ffedaeb7b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40530", "10.65.0.27:40530", "172.17.0.1:40530"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:54:59.737746478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3441525286983777,
+				"StableID":   "neqLfw2gsT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:17167b49c564e3d6461f5017e2a7e906a0807db1919381a0b6d9c0d4ffdaad64",
+				"DiscoKey":   "discokey:9cd124c0f098ebc59dd475886be41b818bef81f5f84eb02dc29cbb3f909ccf1d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55198", "10.65.0.27:55198", "172.17.0.1:55198"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:55:00.869610846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8962153087722711,
+				"StableID":   "nNGpujZyyC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b818057b40cf00ca7a6fdb490a0574c6e20b38251ad8a36841f1778d8a40ab2c",
+				"KeyExpiry":  "2026-10-26T10:55:01Z",
+				"DiscoKey":   "discokey:23714ef10c7fb57f470507391144e96a639d17641d48f2af25048c92440f8410",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:40398", "10.65.0.27:40398", "172.17.0.1:40398"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:55:01.388467617Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1209030831225512,
+				"StableID":   "nZjaR1CaSA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e1b71263cd336ab743b3ac5155213156221d0d9074a0f6be5a6b6cad19a7037a",
+				"KeyExpiry":  "2026-10-26T10:55:01Z",
+				"DiscoKey":   "discokey:56d1370bd09b4d010c11cc6d1a462902abdda0b71c01ece555f801757c8f4116",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:46034", "10.65.0.27:46034", "172.17.0.1:46034"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:55:01.908987676Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1007156714733759,
+				"StableID":   "nWL23MJ9s811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:263637159d1e9cecd7740100e130f6136b650946964a6ca163a0142ede2d9813",
+				"KeyExpiry":  "2026-10-26T10:55:02Z",
+				"DiscoKey":   "discokey:10ebd85b7acb99323c93bcc4bef9cc3281b643469869043eb9e13dc7a4d5833a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36575", "10.65.0.27:36575", "172.17.0.1:36575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:55:02.465764877Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6528640237405801": {
+				"ID":          6528640237405801,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7661821002985827,
+				"StableID":   "nJWuMe34q221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       7661821002985827,
+				"Key":        "nodekey:af827fab095d10aca92bcaf50d6d9ac84148bfec6c7cc802c79ba7e4d428c63e",
+				"DiscoKey":   "discokey:468328eb54a945e161bf609047228ba9d2f91fe4e1b8f0de2e5c3de3d62e232c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:54:59.210495737Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:af827fab095d10aca92bcaf50d6d9ac84148bfec6c7cc802c79ba7e4d428c63e",
+			"MachineKey": "mkey:d09e02f1feaa942b34ce653848b91ab52af53540af0094ba1945b0528bcfb947",
+			"Peers": [{
+				"ID":         1576288904486390,
+				"StableID":   "nm42kKSuJD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c805a2b01fa31cfa2338bf394bc5037c70b29923a7097d5b2e5ba71daa7a842e",
+				"DiscoKey":   "discokey:eb34c8ac6178f4fbd760ae95aa85e9f33fa551da65e7e560df58f211b714b63f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37316", "10.65.0.27:37316", "172.17.0.1:37316"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:54:58.66090945Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3815969058684745,
+				"StableID":   "nCSYY73GoW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f145d57e916c7f8f05095ac3aa2b4b437afb268ef76308f5a7b0e3372e2db07",
+				"DiscoKey":   "discokey:f003a157bfbdc81622c1353e50b849bd3a3570fad8d6ffeb4367987ffedaeb7b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40530", "10.65.0.27:40530", "172.17.0.1:40530"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:54:59.737746478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6528640237405801,
+				"StableID":   "n8a5WtJqys11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d539acc3a2f6f97c47ca4c75928279560e488996b865e58dcaf6035962524451",
+				"DiscoKey":   "discokey:42ef369c1b96b7a925114c5139c3da4060a77f3096690d896eba69a89edb4676",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59335", "10.65.0.27:59335", "172.17.0.1:59335"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:55:00.294696928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3441525286983777,
+				"StableID":   "neqLfw2gsT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:17167b49c564e3d6461f5017e2a7e906a0807db1919381a0b6d9c0d4ffdaad64",
+				"DiscoKey":   "discokey:9cd124c0f098ebc59dd475886be41b818bef81f5f84eb02dc29cbb3f909ccf1d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55198", "10.65.0.27:55198", "172.17.0.1:55198"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:55:00.869610846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8962153087722711,
+				"StableID":   "nNGpujZyyC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b818057b40cf00ca7a6fdb490a0574c6e20b38251ad8a36841f1778d8a40ab2c",
+				"KeyExpiry":  "2026-10-26T10:55:01Z",
+				"DiscoKey":   "discokey:23714ef10c7fb57f470507391144e96a639d17641d48f2af25048c92440f8410",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:40398", "10.65.0.27:40398", "172.17.0.1:40398"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:55:01.388467617Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1209030831225512,
+				"StableID":   "nZjaR1CaSA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e1b71263cd336ab743b3ac5155213156221d0d9074a0f6be5a6b6cad19a7037a",
+				"KeyExpiry":  "2026-10-26T10:55:01Z",
+				"DiscoKey":   "discokey:56d1370bd09b4d010c11cc6d1a462902abdda0b71c01ece555f801757c8f4116",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:46034", "10.65.0.27:46034", "172.17.0.1:46034"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:55:01.908987676Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1007156714733759,
+				"StableID":   "nWL23MJ9s811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:263637159d1e9cecd7740100e130f6136b650946964a6ca163a0142ede2d9813",
+				"KeyExpiry":  "2026-10-26T10:55:02Z",
+				"DiscoKey":   "discokey:10ebd85b7acb99323c93bcc4bef9cc3281b643469869043eb9e13dc7a4d5833a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36575", "10.65.0.27:36575", "172.17.0.1:36575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:55:02.465764877Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7661821002985827": {
+				"ID":          7661821002985827,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1209030831225512,
+				"StableID":   "nZjaR1CaSA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e1b71263cd336ab743b3ac5155213156221d0d9074a0f6be5a6b6cad19a7037a",
+				"KeyExpiry":  "2026-10-26T10:55:01Z",
+				"DiscoKey":   "discokey:56d1370bd09b4d010c11cc6d1a462902abdda0b71c01ece555f801757c8f4116",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:46034", "10.65.0.27:46034", "172.17.0.1:46034"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:55:01.908987676Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e1b71263cd336ab743b3ac5155213156221d0d9074a0f6be5a6b6cad19a7037a",
+			"MachineKey": "mkey:8d3cf0225c76f26dabcf9c2842260f066cc34e6b9a9e84c95c4d442dfca4104d",
+			"Peers": [{
+				"ID":         1576288904486390,
+				"StableID":   "nm42kKSuJD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c805a2b01fa31cfa2338bf394bc5037c70b29923a7097d5b2e5ba71daa7a842e",
+				"DiscoKey":   "discokey:eb34c8ac6178f4fbd760ae95aa85e9f33fa551da65e7e560df58f211b714b63f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37316", "10.65.0.27:37316", "172.17.0.1:37316"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:54:58.66090945Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7661821002985827,
+				"StableID":   "nJWuMe34q221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af827fab095d10aca92bcaf50d6d9ac84148bfec6c7cc802c79ba7e4d428c63e",
+				"DiscoKey":   "discokey:468328eb54a945e161bf609047228ba9d2f91fe4e1b8f0de2e5c3de3d62e232c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:54:59.210495737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3815969058684745,
+				"StableID":   "nCSYY73GoW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f145d57e916c7f8f05095ac3aa2b4b437afb268ef76308f5a7b0e3372e2db07",
+				"DiscoKey":   "discokey:f003a157bfbdc81622c1353e50b849bd3a3570fad8d6ffeb4367987ffedaeb7b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40530", "10.65.0.27:40530", "172.17.0.1:40530"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:54:59.737746478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6528640237405801,
+				"StableID":   "n8a5WtJqys11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d539acc3a2f6f97c47ca4c75928279560e488996b865e58dcaf6035962524451",
+				"DiscoKey":   "discokey:42ef369c1b96b7a925114c5139c3da4060a77f3096690d896eba69a89edb4676",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59335", "10.65.0.27:59335", "172.17.0.1:59335"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:55:00.294696928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3441525286983777,
+				"StableID":   "neqLfw2gsT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:17167b49c564e3d6461f5017e2a7e906a0807db1919381a0b6d9c0d4ffdaad64",
+				"DiscoKey":   "discokey:9cd124c0f098ebc59dd475886be41b818bef81f5f84eb02dc29cbb3f909ccf1d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55198", "10.65.0.27:55198", "172.17.0.1:55198"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:55:00.869610846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8962153087722711,
+				"StableID":   "nNGpujZyyC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b818057b40cf00ca7a6fdb490a0574c6e20b38251ad8a36841f1778d8a40ab2c",
+				"KeyExpiry":  "2026-10-26T10:55:01Z",
+				"DiscoKey":   "discokey:23714ef10c7fb57f470507391144e96a639d17641d48f2af25048c92440f8410",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:40398", "10.65.0.27:40398", "172.17.0.1:40398"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:55:01.388467617Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1007156714733759,
+				"StableID":   "nWL23MJ9s811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:263637159d1e9cecd7740100e130f6136b650946964a6ca163a0142ede2d9813",
+				"KeyExpiry":  "2026-10-26T10:55:02Z",
+				"DiscoKey":   "discokey:10ebd85b7acb99323c93bcc4bef9cc3281b643469869043eb9e13dc7a4d5833a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36575", "10.65.0.27:36575", "172.17.0.1:36575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:55:02.465764877Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3815969058684745,
+				"StableID":   "nCSYY73GoW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       3815969058684745,
+				"Key":        "nodekey:7f145d57e916c7f8f05095ac3aa2b4b437afb268ef76308f5a7b0e3372e2db07",
+				"DiscoKey":   "discokey:f003a157bfbdc81622c1353e50b849bd3a3570fad8d6ffeb4367987ffedaeb7b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40530", "10.65.0.27:40530", "172.17.0.1:40530"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:54:59.737746478Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7f145d57e916c7f8f05095ac3aa2b4b437afb268ef76308f5a7b0e3372e2db07",
+			"MachineKey": "mkey:da71c13b0c8e092437fc290e1ee913a206d6e821e3d810b7544cbe5a7a50b45f",
+			"Peers": [{
+				"ID":         1576288904486390,
+				"StableID":   "nm42kKSuJD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c805a2b01fa31cfa2338bf394bc5037c70b29923a7097d5b2e5ba71daa7a842e",
+				"DiscoKey":   "discokey:eb34c8ac6178f4fbd760ae95aa85e9f33fa551da65e7e560df58f211b714b63f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37316", "10.65.0.27:37316", "172.17.0.1:37316"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:54:58.66090945Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7661821002985827,
+				"StableID":   "nJWuMe34q221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af827fab095d10aca92bcaf50d6d9ac84148bfec6c7cc802c79ba7e4d428c63e",
+				"DiscoKey":   "discokey:468328eb54a945e161bf609047228ba9d2f91fe4e1b8f0de2e5c3de3d62e232c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43305", "10.65.0.27:43305", "172.17.0.1:43305"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:54:59.210495737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6528640237405801,
+				"StableID":   "n8a5WtJqys11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d539acc3a2f6f97c47ca4c75928279560e488996b865e58dcaf6035962524451",
+				"DiscoKey":   "discokey:42ef369c1b96b7a925114c5139c3da4060a77f3096690d896eba69a89edb4676",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:59335", "10.65.0.27:59335", "172.17.0.1:59335"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:55:00.294696928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3441525286983777,
+				"StableID":   "neqLfw2gsT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:17167b49c564e3d6461f5017e2a7e906a0807db1919381a0b6d9c0d4ffdaad64",
+				"DiscoKey":   "discokey:9cd124c0f098ebc59dd475886be41b818bef81f5f84eb02dc29cbb3f909ccf1d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55198", "10.65.0.27:55198", "172.17.0.1:55198"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:55:00.869610846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8962153087722711,
+				"StableID":   "nNGpujZyyC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b818057b40cf00ca7a6fdb490a0574c6e20b38251ad8a36841f1778d8a40ab2c",
+				"KeyExpiry":  "2026-10-26T10:55:01Z",
+				"DiscoKey":   "discokey:23714ef10c7fb57f470507391144e96a639d17641d48f2af25048c92440f8410",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:40398", "10.65.0.27:40398", "172.17.0.1:40398"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:55:01.388467617Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1209030831225512,
+				"StableID":   "nZjaR1CaSA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e1b71263cd336ab743b3ac5155213156221d0d9074a0f6be5a6b6cad19a7037a",
+				"KeyExpiry":  "2026-10-26T10:55:01Z",
+				"DiscoKey":   "discokey:56d1370bd09b4d010c11cc6d1a462902abdda0b71c01ece555f801757c8f4116",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:46034", "10.65.0.27:46034", "172.17.0.1:46034"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:55:01.908987676Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1007156714733759,
+				"StableID":   "nWL23MJ9s811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:263637159d1e9cecd7740100e130f6136b650946964a6ca163a0142ede2d9813",
+				"KeyExpiry":  "2026-10-26T10:55:02Z",
+				"DiscoKey":   "discokey:10ebd85b7acb99323c93bcc4bef9cc3281b643469869043eb9e13dc7a4d5833a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36575", "10.65.0.27:36575", "172.17.0.1:36575"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:55:02.465764877Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3815969058684745": {
+				"ID":          3815969058684745,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-mixed-three-entries.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-mixed-three-entries.hujson
@@ -1,0 +1,8843 @@
+// policytest-mixed-three-entries
+//
+// tests block mixed: three entries, two failing, one passing
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:55:24Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-mixed-three-entries",
+	"description":    "tests block mixed: three entries, two failing, one passing",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:55:24.177953238Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                 \n  \n                                                                      \n                                                                   \n{\n\t\"id\":          \"policytest-mixed-three-entries\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block mixed: three entries, two failing, one passing\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"group:developers\"], \"dst\": [\"webserver:80\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"accept\": [\"webserver:80\"]},\n\t\t\t{\"src\": \"thor@example.org\", \"accept\": [\"webserver:443\"]},\n\t\t\t{\"src\": \"thor@example.org\", \"deny\": [\"webserver:80\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-mixed-three-entries.hujson",
+		"full_policy": {"acls": [
+			{"action": "accept", "dst": ["webserver:80"], "src": ["group:developers"]}
+		], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [
+			{"accept": ["webserver:80"], "src": "thor@example.org"},
+			{"accept": ["webserver:443"], "src": "thor@example.org"},
+			{"deny": ["webserver:80"], "src": "thor@example.org"}
+		]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4086913044043260,
+				"StableID":   "nsp6jyGyuY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       4086913044043260,
+				"Key":        "nodekey:30854851c59ba81a5c87c0b8026b1ffcd3d2bd8edc19948d2f58198c0ad6d264",
+				"DiscoKey":   "discokey:032bef4223b6a88a492ea6288ea0af353e6bfe0edf43bfbf4b33587cded1e747",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:38877", "10.65.0.27:38877", "172.17.0.1:38877"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:55:27.841291214Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:30854851c59ba81a5c87c0b8026b1ffcd3d2bd8edc19948d2f58198c0ad6d264",
+			"MachineKey": "mkey:6680981bb9eb81eabfbe60321e672a9a9778aa7e1ac1102a0588db0a10c52025",
+			"Peers": [{
+				"ID":         6853796373664458,
+				"StableID":   "nobRpJc6Xv11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee21f4f1dd6883b8567a01c6cf69244dc85ccc9c40001c9cd048108c73edd751",
+				"DiscoKey":   "discokey:9dc7302dd672324053ceb2423a828050f3c263c34d7ae00dec3fe74985509054",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:48177", "10.65.0.27:48177", "172.17.0.1:48177"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:55:25.696658606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2444583299945459,
+				"StableID":   "n8bm8N4A6L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99150cd07f0893056f5efc03119cfb7063f62d1ae555bdc06ea1553727316270",
+				"DiscoKey":   "discokey:aebd991fc9a9376f8241b4bd3c4fa0b653c0850ccb88850f77ce419770c7cf22",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:33861", "10.65.0.27:33861", "172.17.0.1:33861"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:55:26.239712808Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4744138972426281,
+				"StableID":   "n4cFTCVd3e11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd6082c26a962eb34667c4f073b7fd7aa94b0c989c25e9eb7022a098b1db847e",
+				"DiscoKey":   "discokey:86ef45bd1ec921f56b8983eed6140e8e16b2fba31c344d33b704cf9bc0751b04",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:43730", "10.65.0.27:43730", "172.17.0.1:43730"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:55:26.769601258Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3674366352526422,
+				"StableID":   "nFmBJfN8hV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08062e2ba222dd6a1207658770e33de4a122de28d84a28dfbc62528fce146917",
+				"DiscoKey":   "discokey:ec2303510d337da4f469424bc8fc0c9f99c6c01f12996f10f6f79f267d3c047a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:35806", "10.65.0.27:35806", "172.17.0.1:35806"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:55:27.288534314Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6147976900075570,
+				"StableID":   "nsoJupvR1q11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ccc872fb6deacbc170be7a75021715d471b3de40f978e71693d5e33621fbf7a",
+				"KeyExpiry":  "2026-10-26T10:55:28Z",
+				"DiscoKey":   "discokey:272977d959a9cfd9abb8315a6d5d2f2b17396467c58c02f8ab21aa5403cf9654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:59661", "10.65.0.27:59661", "172.17.0.1:59661"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:55:28.409188543Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1342562052328637,
+				"StableID":   "n4pEB4q3VB11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1d3f874cd25913da219771d98a107530d042763d940849ec59a9908a04280579",
+				"KeyExpiry":  "2026-10-26T10:55:28Z",
+				"DiscoKey":   "discokey:640e257100273762df39bba259ec78358605d4049a4069510183bb7c612f9467",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52740", "10.65.0.27:52740", "172.17.0.1:52740"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:55:28.9386399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2349280710343785,
+				"StableID":   "nYN5ezczLK11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5b475b4a9d918afc4c74c78833f833d1fa8f5833e16c674708d552c1a8134c68",
+				"KeyExpiry":  "2026-10-26T10:55:29Z",
+				"DiscoKey":   "discokey:ef6ccdd833caa7dd6046d45c345b504c1e6a07935666924314f67cf9f6608837",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:42891", "10.65.0.27:42891", "172.17.0.1:42891"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:55:29.475012217Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4086913044043260": {
+				"ID":          4086913044043260,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2349280710343785,
+				"StableID":   "nYN5ezczLK11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5b475b4a9d918afc4c74c78833f833d1fa8f5833e16c674708d552c1a8134c68",
+				"KeyExpiry":  "2026-10-26T10:55:29Z",
+				"DiscoKey":   "discokey:ef6ccdd833caa7dd6046d45c345b504c1e6a07935666924314f67cf9f6608837",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:42891", "10.65.0.27:42891", "172.17.0.1:42891"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:55:29.475012217Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5b475b4a9d918afc4c74c78833f833d1fa8f5833e16c674708d552c1a8134c68",
+			"MachineKey": "mkey:6d4e9a489016d9baa24287455d7c5b8c2c6e21d04d0122fc1c1932c1f6575f03",
+			"Peers": [{
+				"ID":         6853796373664458,
+				"StableID":   "nobRpJc6Xv11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee21f4f1dd6883b8567a01c6cf69244dc85ccc9c40001c9cd048108c73edd751",
+				"DiscoKey":   "discokey:9dc7302dd672324053ceb2423a828050f3c263c34d7ae00dec3fe74985509054",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:48177", "10.65.0.27:48177", "172.17.0.1:48177"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:55:25.696658606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2444583299945459,
+				"StableID":   "n8bm8N4A6L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99150cd07f0893056f5efc03119cfb7063f62d1ae555bdc06ea1553727316270",
+				"DiscoKey":   "discokey:aebd991fc9a9376f8241b4bd3c4fa0b653c0850ccb88850f77ce419770c7cf22",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:33861", "10.65.0.27:33861", "172.17.0.1:33861"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:55:26.239712808Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4744138972426281,
+				"StableID":   "n4cFTCVd3e11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd6082c26a962eb34667c4f073b7fd7aa94b0c989c25e9eb7022a098b1db847e",
+				"DiscoKey":   "discokey:86ef45bd1ec921f56b8983eed6140e8e16b2fba31c344d33b704cf9bc0751b04",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:43730", "10.65.0.27:43730", "172.17.0.1:43730"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:55:26.769601258Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3674366352526422,
+				"StableID":   "nFmBJfN8hV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08062e2ba222dd6a1207658770e33de4a122de28d84a28dfbc62528fce146917",
+				"DiscoKey":   "discokey:ec2303510d337da4f469424bc8fc0c9f99c6c01f12996f10f6f79f267d3c047a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:35806", "10.65.0.27:35806", "172.17.0.1:35806"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:55:27.288534314Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4086913044043260,
+				"StableID":   "nsp6jyGyuY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30854851c59ba81a5c87c0b8026b1ffcd3d2bd8edc19948d2f58198c0ad6d264",
+				"DiscoKey":   "discokey:032bef4223b6a88a492ea6288ea0af353e6bfe0edf43bfbf4b33587cded1e747",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:38877", "10.65.0.27:38877", "172.17.0.1:38877"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:55:27.841291214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6147976900075570,
+				"StableID":   "nsoJupvR1q11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ccc872fb6deacbc170be7a75021715d471b3de40f978e71693d5e33621fbf7a",
+				"KeyExpiry":  "2026-10-26T10:55:28Z",
+				"DiscoKey":   "discokey:272977d959a9cfd9abb8315a6d5d2f2b17396467c58c02f8ab21aa5403cf9654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:59661", "10.65.0.27:59661", "172.17.0.1:59661"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:55:28.409188543Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1342562052328637,
+				"StableID":   "n4pEB4q3VB11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1d3f874cd25913da219771d98a107530d042763d940849ec59a9908a04280579",
+				"KeyExpiry":  "2026-10-26T10:55:28Z",
+				"DiscoKey":   "discokey:640e257100273762df39bba259ec78358605d4049a4069510183bb7c612f9467",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52740", "10.65.0.27:52740", "172.17.0.1:52740"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:55:28.9386399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6853796373664458,
+				"StableID":   "nobRpJc6Xv11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       6853796373664458,
+				"Key":        "nodekey:ee21f4f1dd6883b8567a01c6cf69244dc85ccc9c40001c9cd048108c73edd751",
+				"DiscoKey":   "discokey:9dc7302dd672324053ceb2423a828050f3c263c34d7ae00dec3fe74985509054",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:48177", "10.65.0.27:48177", "172.17.0.1:48177"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:55:25.696658606Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ee21f4f1dd6883b8567a01c6cf69244dc85ccc9c40001c9cd048108c73edd751",
+			"MachineKey": "mkey:df340e2779edea46a19d614ceb7ad1e1299433439e546ec04412015d58ed5357",
+			"Peers": [{
+				"ID":         2444583299945459,
+				"StableID":   "n8bm8N4A6L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99150cd07f0893056f5efc03119cfb7063f62d1ae555bdc06ea1553727316270",
+				"DiscoKey":   "discokey:aebd991fc9a9376f8241b4bd3c4fa0b653c0850ccb88850f77ce419770c7cf22",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:33861", "10.65.0.27:33861", "172.17.0.1:33861"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:55:26.239712808Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4744138972426281,
+				"StableID":   "n4cFTCVd3e11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd6082c26a962eb34667c4f073b7fd7aa94b0c989c25e9eb7022a098b1db847e",
+				"DiscoKey":   "discokey:86ef45bd1ec921f56b8983eed6140e8e16b2fba31c344d33b704cf9bc0751b04",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:43730", "10.65.0.27:43730", "172.17.0.1:43730"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:55:26.769601258Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3674366352526422,
+				"StableID":   "nFmBJfN8hV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08062e2ba222dd6a1207658770e33de4a122de28d84a28dfbc62528fce146917",
+				"DiscoKey":   "discokey:ec2303510d337da4f469424bc8fc0c9f99c6c01f12996f10f6f79f267d3c047a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:35806", "10.65.0.27:35806", "172.17.0.1:35806"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:55:27.288534314Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4086913044043260,
+				"StableID":   "nsp6jyGyuY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30854851c59ba81a5c87c0b8026b1ffcd3d2bd8edc19948d2f58198c0ad6d264",
+				"DiscoKey":   "discokey:032bef4223b6a88a492ea6288ea0af353e6bfe0edf43bfbf4b33587cded1e747",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:38877", "10.65.0.27:38877", "172.17.0.1:38877"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:55:27.841291214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6147976900075570,
+				"StableID":   "nsoJupvR1q11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ccc872fb6deacbc170be7a75021715d471b3de40f978e71693d5e33621fbf7a",
+				"KeyExpiry":  "2026-10-26T10:55:28Z",
+				"DiscoKey":   "discokey:272977d959a9cfd9abb8315a6d5d2f2b17396467c58c02f8ab21aa5403cf9654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:59661", "10.65.0.27:59661", "172.17.0.1:59661"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:55:28.409188543Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1342562052328637,
+				"StableID":   "n4pEB4q3VB11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1d3f874cd25913da219771d98a107530d042763d940849ec59a9908a04280579",
+				"KeyExpiry":  "2026-10-26T10:55:28Z",
+				"DiscoKey":   "discokey:640e257100273762df39bba259ec78358605d4049a4069510183bb7c612f9467",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52740", "10.65.0.27:52740", "172.17.0.1:52740"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:55:28.9386399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2349280710343785,
+				"StableID":   "nYN5ezczLK11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5b475b4a9d918afc4c74c78833f833d1fa8f5833e16c674708d552c1a8134c68",
+				"KeyExpiry":  "2026-10-26T10:55:29Z",
+				"DiscoKey":   "discokey:ef6ccdd833caa7dd6046d45c345b504c1e6a07935666924314f67cf9f6608837",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:42891", "10.65.0.27:42891", "172.17.0.1:42891"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:55:29.475012217Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6853796373664458": {
+				"ID":          6853796373664458,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6147976900075570,
+				"StableID":   "nsoJupvR1q11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ccc872fb6deacbc170be7a75021715d471b3de40f978e71693d5e33621fbf7a",
+				"KeyExpiry":  "2026-10-26T10:55:28Z",
+				"DiscoKey":   "discokey:272977d959a9cfd9abb8315a6d5d2f2b17396467c58c02f8ab21aa5403cf9654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:59661", "10.65.0.27:59661", "172.17.0.1:59661"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:55:28.409188543Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5ccc872fb6deacbc170be7a75021715d471b3de40f978e71693d5e33621fbf7a",
+			"MachineKey": "mkey:db4c731b155acd81f1193feb7005e9be668b7c7129c7b712e01244f601beb06d",
+			"Peers": [{
+				"ID":         6853796373664458,
+				"StableID":   "nobRpJc6Xv11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee21f4f1dd6883b8567a01c6cf69244dc85ccc9c40001c9cd048108c73edd751",
+				"DiscoKey":   "discokey:9dc7302dd672324053ceb2423a828050f3c263c34d7ae00dec3fe74985509054",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:48177", "10.65.0.27:48177", "172.17.0.1:48177"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:55:25.696658606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2444583299945459,
+				"StableID":   "n8bm8N4A6L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99150cd07f0893056f5efc03119cfb7063f62d1ae555bdc06ea1553727316270",
+				"DiscoKey":   "discokey:aebd991fc9a9376f8241b4bd3c4fa0b653c0850ccb88850f77ce419770c7cf22",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:33861", "10.65.0.27:33861", "172.17.0.1:33861"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:55:26.239712808Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4744138972426281,
+				"StableID":   "n4cFTCVd3e11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd6082c26a962eb34667c4f073b7fd7aa94b0c989c25e9eb7022a098b1db847e",
+				"DiscoKey":   "discokey:86ef45bd1ec921f56b8983eed6140e8e16b2fba31c344d33b704cf9bc0751b04",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:43730", "10.65.0.27:43730", "172.17.0.1:43730"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:55:26.769601258Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3674366352526422,
+				"StableID":   "nFmBJfN8hV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08062e2ba222dd6a1207658770e33de4a122de28d84a28dfbc62528fce146917",
+				"DiscoKey":   "discokey:ec2303510d337da4f469424bc8fc0c9f99c6c01f12996f10f6f79f267d3c047a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:35806", "10.65.0.27:35806", "172.17.0.1:35806"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:55:27.288534314Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4086913044043260,
+				"StableID":   "nsp6jyGyuY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30854851c59ba81a5c87c0b8026b1ffcd3d2bd8edc19948d2f58198c0ad6d264",
+				"DiscoKey":   "discokey:032bef4223b6a88a492ea6288ea0af353e6bfe0edf43bfbf4b33587cded1e747",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:38877", "10.65.0.27:38877", "172.17.0.1:38877"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:55:27.841291214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1342562052328637,
+				"StableID":   "n4pEB4q3VB11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1d3f874cd25913da219771d98a107530d042763d940849ec59a9908a04280579",
+				"KeyExpiry":  "2026-10-26T10:55:28Z",
+				"DiscoKey":   "discokey:640e257100273762df39bba259ec78358605d4049a4069510183bb7c612f9467",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52740", "10.65.0.27:52740", "172.17.0.1:52740"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:55:28.9386399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2349280710343785,
+				"StableID":   "nYN5ezczLK11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5b475b4a9d918afc4c74c78833f833d1fa8f5833e16c674708d552c1a8134c68",
+				"KeyExpiry":  "2026-10-26T10:55:29Z",
+				"DiscoKey":   "discokey:ef6ccdd833caa7dd6046d45c345b504c1e6a07935666924314f67cf9f6608837",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:42891", "10.65.0.27:42891", "172.17.0.1:42891"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:55:29.475012217Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3674366352526422,
+				"StableID":   "nFmBJfN8hV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       3674366352526422,
+				"Key":        "nodekey:08062e2ba222dd6a1207658770e33de4a122de28d84a28dfbc62528fce146917",
+				"DiscoKey":   "discokey:ec2303510d337da4f469424bc8fc0c9f99c6c01f12996f10f6f79f267d3c047a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:35806", "10.65.0.27:35806", "172.17.0.1:35806"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:55:27.288534314Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:08062e2ba222dd6a1207658770e33de4a122de28d84a28dfbc62528fce146917",
+			"MachineKey": "mkey:8fad913799f0cdf295dbfb5343c31349256fb3eb86346adfd6fc9680258d2871",
+			"Peers": [{
+				"ID":         6853796373664458,
+				"StableID":   "nobRpJc6Xv11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee21f4f1dd6883b8567a01c6cf69244dc85ccc9c40001c9cd048108c73edd751",
+				"DiscoKey":   "discokey:9dc7302dd672324053ceb2423a828050f3c263c34d7ae00dec3fe74985509054",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:48177", "10.65.0.27:48177", "172.17.0.1:48177"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:55:25.696658606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2444583299945459,
+				"StableID":   "n8bm8N4A6L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99150cd07f0893056f5efc03119cfb7063f62d1ae555bdc06ea1553727316270",
+				"DiscoKey":   "discokey:aebd991fc9a9376f8241b4bd3c4fa0b653c0850ccb88850f77ce419770c7cf22",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:33861", "10.65.0.27:33861", "172.17.0.1:33861"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:55:26.239712808Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4744138972426281,
+				"StableID":   "n4cFTCVd3e11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd6082c26a962eb34667c4f073b7fd7aa94b0c989c25e9eb7022a098b1db847e",
+				"DiscoKey":   "discokey:86ef45bd1ec921f56b8983eed6140e8e16b2fba31c344d33b704cf9bc0751b04",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:43730", "10.65.0.27:43730", "172.17.0.1:43730"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:55:26.769601258Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4086913044043260,
+				"StableID":   "nsp6jyGyuY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30854851c59ba81a5c87c0b8026b1ffcd3d2bd8edc19948d2f58198c0ad6d264",
+				"DiscoKey":   "discokey:032bef4223b6a88a492ea6288ea0af353e6bfe0edf43bfbf4b33587cded1e747",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:38877", "10.65.0.27:38877", "172.17.0.1:38877"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:55:27.841291214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6147976900075570,
+				"StableID":   "nsoJupvR1q11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ccc872fb6deacbc170be7a75021715d471b3de40f978e71693d5e33621fbf7a",
+				"KeyExpiry":  "2026-10-26T10:55:28Z",
+				"DiscoKey":   "discokey:272977d959a9cfd9abb8315a6d5d2f2b17396467c58c02f8ab21aa5403cf9654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:59661", "10.65.0.27:59661", "172.17.0.1:59661"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:55:28.409188543Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1342562052328637,
+				"StableID":   "n4pEB4q3VB11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1d3f874cd25913da219771d98a107530d042763d940849ec59a9908a04280579",
+				"KeyExpiry":  "2026-10-26T10:55:28Z",
+				"DiscoKey":   "discokey:640e257100273762df39bba259ec78358605d4049a4069510183bb7c612f9467",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52740", "10.65.0.27:52740", "172.17.0.1:52740"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:55:28.9386399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2349280710343785,
+				"StableID":   "nYN5ezczLK11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5b475b4a9d918afc4c74c78833f833d1fa8f5833e16c674708d552c1a8134c68",
+				"KeyExpiry":  "2026-10-26T10:55:29Z",
+				"DiscoKey":   "discokey:ef6ccdd833caa7dd6046d45c345b504c1e6a07935666924314f67cf9f6608837",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:42891", "10.65.0.27:42891", "172.17.0.1:42891"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:55:29.475012217Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3674366352526422": {
+				"ID":          3674366352526422,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2444583299945459,
+				"StableID":   "n8bm8N4A6L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       2444583299945459,
+				"Key":        "nodekey:99150cd07f0893056f5efc03119cfb7063f62d1ae555bdc06ea1553727316270",
+				"DiscoKey":   "discokey:aebd991fc9a9376f8241b4bd3c4fa0b653c0850ccb88850f77ce419770c7cf22",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:33861", "10.65.0.27:33861", "172.17.0.1:33861"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:55:26.239712808Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:99150cd07f0893056f5efc03119cfb7063f62d1ae555bdc06ea1553727316270",
+			"MachineKey": "mkey:4e80c074a65515376f84c44c333ffb22d739f690b9bece5a41f4ee9f65ff3f2f",
+			"Peers": [{
+				"ID":         6853796373664458,
+				"StableID":   "nobRpJc6Xv11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee21f4f1dd6883b8567a01c6cf69244dc85ccc9c40001c9cd048108c73edd751",
+				"DiscoKey":   "discokey:9dc7302dd672324053ceb2423a828050f3c263c34d7ae00dec3fe74985509054",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:48177", "10.65.0.27:48177", "172.17.0.1:48177"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:55:25.696658606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4744138972426281,
+				"StableID":   "n4cFTCVd3e11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd6082c26a962eb34667c4f073b7fd7aa94b0c989c25e9eb7022a098b1db847e",
+				"DiscoKey":   "discokey:86ef45bd1ec921f56b8983eed6140e8e16b2fba31c344d33b704cf9bc0751b04",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:43730", "10.65.0.27:43730", "172.17.0.1:43730"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:55:26.769601258Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3674366352526422,
+				"StableID":   "nFmBJfN8hV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08062e2ba222dd6a1207658770e33de4a122de28d84a28dfbc62528fce146917",
+				"DiscoKey":   "discokey:ec2303510d337da4f469424bc8fc0c9f99c6c01f12996f10f6f79f267d3c047a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:35806", "10.65.0.27:35806", "172.17.0.1:35806"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:55:27.288534314Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4086913044043260,
+				"StableID":   "nsp6jyGyuY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30854851c59ba81a5c87c0b8026b1ffcd3d2bd8edc19948d2f58198c0ad6d264",
+				"DiscoKey":   "discokey:032bef4223b6a88a492ea6288ea0af353e6bfe0edf43bfbf4b33587cded1e747",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:38877", "10.65.0.27:38877", "172.17.0.1:38877"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:55:27.841291214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6147976900075570,
+				"StableID":   "nsoJupvR1q11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ccc872fb6deacbc170be7a75021715d471b3de40f978e71693d5e33621fbf7a",
+				"KeyExpiry":  "2026-10-26T10:55:28Z",
+				"DiscoKey":   "discokey:272977d959a9cfd9abb8315a6d5d2f2b17396467c58c02f8ab21aa5403cf9654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:59661", "10.65.0.27:59661", "172.17.0.1:59661"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:55:28.409188543Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1342562052328637,
+				"StableID":   "n4pEB4q3VB11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1d3f874cd25913da219771d98a107530d042763d940849ec59a9908a04280579",
+				"KeyExpiry":  "2026-10-26T10:55:28Z",
+				"DiscoKey":   "discokey:640e257100273762df39bba259ec78358605d4049a4069510183bb7c612f9467",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52740", "10.65.0.27:52740", "172.17.0.1:52740"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:55:28.9386399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2349280710343785,
+				"StableID":   "nYN5ezczLK11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5b475b4a9d918afc4c74c78833f833d1fa8f5833e16c674708d552c1a8134c68",
+				"KeyExpiry":  "2026-10-26T10:55:29Z",
+				"DiscoKey":   "discokey:ef6ccdd833caa7dd6046d45c345b504c1e6a07935666924314f67cf9f6608837",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:42891", "10.65.0.27:42891", "172.17.0.1:42891"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:55:29.475012217Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2444583299945459": {
+				"ID":          2444583299945459,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1342562052328637,
+				"StableID":   "n4pEB4q3VB11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1d3f874cd25913da219771d98a107530d042763d940849ec59a9908a04280579",
+				"KeyExpiry":  "2026-10-26T10:55:28Z",
+				"DiscoKey":   "discokey:640e257100273762df39bba259ec78358605d4049a4069510183bb7c612f9467",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52740", "10.65.0.27:52740", "172.17.0.1:52740"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:55:28.9386399Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1d3f874cd25913da219771d98a107530d042763d940849ec59a9908a04280579",
+			"MachineKey": "mkey:8bfafd0e442cca3d295606fe3933b39794cadd33aab837cfdfb4893ea8405609",
+			"Peers": [{
+				"ID":         6853796373664458,
+				"StableID":   "nobRpJc6Xv11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee21f4f1dd6883b8567a01c6cf69244dc85ccc9c40001c9cd048108c73edd751",
+				"DiscoKey":   "discokey:9dc7302dd672324053ceb2423a828050f3c263c34d7ae00dec3fe74985509054",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:48177", "10.65.0.27:48177", "172.17.0.1:48177"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:55:25.696658606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2444583299945459,
+				"StableID":   "n8bm8N4A6L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99150cd07f0893056f5efc03119cfb7063f62d1ae555bdc06ea1553727316270",
+				"DiscoKey":   "discokey:aebd991fc9a9376f8241b4bd3c4fa0b653c0850ccb88850f77ce419770c7cf22",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:33861", "10.65.0.27:33861", "172.17.0.1:33861"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:55:26.239712808Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4744138972426281,
+				"StableID":   "n4cFTCVd3e11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd6082c26a962eb34667c4f073b7fd7aa94b0c989c25e9eb7022a098b1db847e",
+				"DiscoKey":   "discokey:86ef45bd1ec921f56b8983eed6140e8e16b2fba31c344d33b704cf9bc0751b04",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:43730", "10.65.0.27:43730", "172.17.0.1:43730"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:55:26.769601258Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3674366352526422,
+				"StableID":   "nFmBJfN8hV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08062e2ba222dd6a1207658770e33de4a122de28d84a28dfbc62528fce146917",
+				"DiscoKey":   "discokey:ec2303510d337da4f469424bc8fc0c9f99c6c01f12996f10f6f79f267d3c047a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:35806", "10.65.0.27:35806", "172.17.0.1:35806"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:55:27.288534314Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4086913044043260,
+				"StableID":   "nsp6jyGyuY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30854851c59ba81a5c87c0b8026b1ffcd3d2bd8edc19948d2f58198c0ad6d264",
+				"DiscoKey":   "discokey:032bef4223b6a88a492ea6288ea0af353e6bfe0edf43bfbf4b33587cded1e747",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:38877", "10.65.0.27:38877", "172.17.0.1:38877"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:55:27.841291214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6147976900075570,
+				"StableID":   "nsoJupvR1q11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ccc872fb6deacbc170be7a75021715d471b3de40f978e71693d5e33621fbf7a",
+				"KeyExpiry":  "2026-10-26T10:55:28Z",
+				"DiscoKey":   "discokey:272977d959a9cfd9abb8315a6d5d2f2b17396467c58c02f8ab21aa5403cf9654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:59661", "10.65.0.27:59661", "172.17.0.1:59661"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:55:28.409188543Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2349280710343785,
+				"StableID":   "nYN5ezczLK11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5b475b4a9d918afc4c74c78833f833d1fa8f5833e16c674708d552c1a8134c68",
+				"KeyExpiry":  "2026-10-26T10:55:29Z",
+				"DiscoKey":   "discokey:ef6ccdd833caa7dd6046d45c345b504c1e6a07935666924314f67cf9f6608837",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:42891", "10.65.0.27:42891", "172.17.0.1:42891"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:55:29.475012217Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4744138972426281,
+				"StableID":   "n4cFTCVd3e11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       4744138972426281,
+				"Key":        "nodekey:fd6082c26a962eb34667c4f073b7fd7aa94b0c989c25e9eb7022a098b1db847e",
+				"DiscoKey":   "discokey:86ef45bd1ec921f56b8983eed6140e8e16b2fba31c344d33b704cf9bc0751b04",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:43730", "10.65.0.27:43730", "172.17.0.1:43730"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:55:26.769601258Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fd6082c26a962eb34667c4f073b7fd7aa94b0c989c25e9eb7022a098b1db847e",
+			"MachineKey": "mkey:a62eec4232d4584fc5a50ca07638d8273d5182c6bcc4032f4714ab2210d46960",
+			"Peers": [{
+				"ID":         6853796373664458,
+				"StableID":   "nobRpJc6Xv11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee21f4f1dd6883b8567a01c6cf69244dc85ccc9c40001c9cd048108c73edd751",
+				"DiscoKey":   "discokey:9dc7302dd672324053ceb2423a828050f3c263c34d7ae00dec3fe74985509054",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:48177", "10.65.0.27:48177", "172.17.0.1:48177"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:55:25.696658606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2444583299945459,
+				"StableID":   "n8bm8N4A6L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99150cd07f0893056f5efc03119cfb7063f62d1ae555bdc06ea1553727316270",
+				"DiscoKey":   "discokey:aebd991fc9a9376f8241b4bd3c4fa0b653c0850ccb88850f77ce419770c7cf22",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:33861", "10.65.0.27:33861", "172.17.0.1:33861"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:55:26.239712808Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3674366352526422,
+				"StableID":   "nFmBJfN8hV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08062e2ba222dd6a1207658770e33de4a122de28d84a28dfbc62528fce146917",
+				"DiscoKey":   "discokey:ec2303510d337da4f469424bc8fc0c9f99c6c01f12996f10f6f79f267d3c047a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:35806", "10.65.0.27:35806", "172.17.0.1:35806"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:55:27.288534314Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4086913044043260,
+				"StableID":   "nsp6jyGyuY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30854851c59ba81a5c87c0b8026b1ffcd3d2bd8edc19948d2f58198c0ad6d264",
+				"DiscoKey":   "discokey:032bef4223b6a88a492ea6288ea0af353e6bfe0edf43bfbf4b33587cded1e747",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:38877", "10.65.0.27:38877", "172.17.0.1:38877"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:55:27.841291214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6147976900075570,
+				"StableID":   "nsoJupvR1q11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ccc872fb6deacbc170be7a75021715d471b3de40f978e71693d5e33621fbf7a",
+				"KeyExpiry":  "2026-10-26T10:55:28Z",
+				"DiscoKey":   "discokey:272977d959a9cfd9abb8315a6d5d2f2b17396467c58c02f8ab21aa5403cf9654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:59661", "10.65.0.27:59661", "172.17.0.1:59661"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:55:28.409188543Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1342562052328637,
+				"StableID":   "n4pEB4q3VB11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1d3f874cd25913da219771d98a107530d042763d940849ec59a9908a04280579",
+				"KeyExpiry":  "2026-10-26T10:55:28Z",
+				"DiscoKey":   "discokey:640e257100273762df39bba259ec78358605d4049a4069510183bb7c612f9467",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:52740", "10.65.0.27:52740", "172.17.0.1:52740"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:55:28.9386399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2349280710343785,
+				"StableID":   "nYN5ezczLK11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5b475b4a9d918afc4c74c78833f833d1fa8f5833e16c674708d552c1a8134c68",
+				"KeyExpiry":  "2026-10-26T10:55:29Z",
+				"DiscoKey":   "discokey:ef6ccdd833caa7dd6046d45c345b504c1e6a07935666924314f67cf9f6608837",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:42891", "10.65.0.27:42891", "172.17.0.1:42891"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:55:29.475012217Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4744138972426281": {
+				"ID":          4744138972426281,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-mixed-two-entries.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-mixed-two-entries.hujson
@@ -1,0 +1,8842 @@
+// policytest-mixed-two-entries
+//
+// tests block mixed: one passing entry, one failing entry
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:55:51Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-mixed-two-entries",
+	"description":    "tests block mixed: one passing entry, one failing entry",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:55:51.160108583Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                               \n  \n                                                                      \n                                                        \n{\n\t\"id\":          \"policytest-mixed-two-entries\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block mixed: one passing entry, one failing entry\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"thor@example.org\"], \"dst\": [\"webserver:80\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"accept\": [\"webserver:80\"]},\n\t\t\t{\"src\": \"thor@example.org\", \"accept\": [\"webserver:443\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-mixed-two-entries.hujson",
+		"full_policy": {"acls": [
+			{"action": "accept", "dst": ["webserver:80"], "src": ["thor@example.org"]}
+		], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [
+			{"accept": ["webserver:80"], "src": "thor@example.org"},
+			{"accept": ["webserver:443"], "src": "thor@example.org"}
+		]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3641088979485426,
+				"StableID":   "nbw2oXE4SV11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       3641088979485426,
+				"Key":        "nodekey:0fea939ad470be541ca626891eb2eb7ec1fdaca02ad13777561d85acbdf7a144",
+				"DiscoKey":   "discokey:6a3422dd72cb8f9d10c7319bf07fe851fed206504687e8a1f2c8beadce72540e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:58694", "10.65.0.27:58694", "172.17.0.1:58694"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:55:54.822178993Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0fea939ad470be541ca626891eb2eb7ec1fdaca02ad13777561d85acbdf7a144",
+			"MachineKey": "mkey:1e93a4cc05ca513adcdf1e6fb500647c3810fdc45b8084d13814146b15a07013",
+			"Peers": [{
+				"ID":         3894704281720475,
+				"StableID":   "npy4b5HvQX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6da47d8d63caf8101854623533638510ef706dac00390f9da4898662477f517",
+				"DiscoKey":   "discokey:72983f699c5fab067f70439f20d2d52cbd9f884f4fd214b8eacbd66b980f2433",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60666", "10.65.0.27:60666", "172.17.0.1:60666"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:55:52.665854158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2036142731382634,
+				"StableID":   "nZaHjy1BuG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8321e5df967cf3dfe2d75825314ccaacc14166a7ae98ce2915d5d91a34d02900",
+				"DiscoKey":   "discokey:a5a0dfb58e9bb780b96de4fd518f03a54e72d880ee02132d295eb961f71dcc4c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58462", "10.65.0.27:58462", "172.17.0.1:58462"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:55:53.211502291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         578353739844834,
+				"StableID":   "nHAdWaNwW511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30e6cea56aed6553e302b2d17632f0bcf6f6a57ec6092ab51317e8ed41c8fb6f",
+				"DiscoKey":   "discokey:860f6e8e1ac0acae90b673248e98f3bd22315730d6dfb65487d116a6681b021b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:43156", "10.65.0.27:43156", "172.17.0.1:43156"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:55:53.763196637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4395169440272458,
+				"StableID":   "nRCQtbeaKb11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65ee31d5fd8f70039c003e486bbbc549691edd2d02cad343030ef31d6b38481a",
+				"DiscoKey":   "discokey:e7083097433736216d045c9207efcbf8ec7f0f0b08bcf6e476f21919a220a17d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40358", "10.65.0.27:40358", "172.17.0.1:40358"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:55:54.271983011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4230872210812181,
+				"StableID":   "n2B3LeqA3a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e1556dd0abd1a6347eaafa7c7507e808d79956f9475c488ac1656fb0c84db15e",
+				"KeyExpiry":  "2026-10-26T10:55:55Z",
+				"DiscoKey":   "discokey:8000bfe4b83927f77d42bbc0538d07909440d3a49e5142f052c64299f1652e2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55184", "10.65.0.27:55184", "172.17.0.1:55184"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:55:55.384034076Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8468323099941934,
+				"StableID":   "n3T3wJVK8921CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:cc61d78e1d09a13486989b2002498557061047d129cdc71e7ad0bb3be13d593d",
+				"KeyExpiry":  "2026-10-26T10:55:55Z",
+				"DiscoKey":   "discokey:391eb689a1dcca9c3f5a7a76ecf8d5b76419d6d2c0d7f29d9072c833a68f1c42",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38731", "10.65.0.27:38731", "172.17.0.1:38731"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:55:55.930226301Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8304594567773170,
+				"StableID":   "nP5xCocAr721CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:650a5ad556cad89c99ab08cf00880da23a5cafe65b2c232599cb247b19257e58",
+				"KeyExpiry":  "2026-10-26T10:55:56Z",
+				"DiscoKey":   "discokey:d36d737c1fb5c08a1e765ed340706511605f8eb5d13fc26b553ae7e6ab7a5470",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50939", "10.65.0.27:50939", "172.17.0.1:50939"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:55:56.467634654Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3641088979485426": {
+				"ID":          3641088979485426,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8304594567773170,
+				"StableID":   "nP5xCocAr721CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:650a5ad556cad89c99ab08cf00880da23a5cafe65b2c232599cb247b19257e58",
+				"KeyExpiry":  "2026-10-26T10:55:56Z",
+				"DiscoKey":   "discokey:d36d737c1fb5c08a1e765ed340706511605f8eb5d13fc26b553ae7e6ab7a5470",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50939", "10.65.0.27:50939", "172.17.0.1:50939"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:55:56.467634654Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:650a5ad556cad89c99ab08cf00880da23a5cafe65b2c232599cb247b19257e58",
+			"MachineKey": "mkey:c62130d152f08334eaae768a36b7f1f6baeaac4c854a94e8b22959e50e90bb45",
+			"Peers": [{
+				"ID":         3894704281720475,
+				"StableID":   "npy4b5HvQX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6da47d8d63caf8101854623533638510ef706dac00390f9da4898662477f517",
+				"DiscoKey":   "discokey:72983f699c5fab067f70439f20d2d52cbd9f884f4fd214b8eacbd66b980f2433",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60666", "10.65.0.27:60666", "172.17.0.1:60666"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:55:52.665854158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2036142731382634,
+				"StableID":   "nZaHjy1BuG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8321e5df967cf3dfe2d75825314ccaacc14166a7ae98ce2915d5d91a34d02900",
+				"DiscoKey":   "discokey:a5a0dfb58e9bb780b96de4fd518f03a54e72d880ee02132d295eb961f71dcc4c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58462", "10.65.0.27:58462", "172.17.0.1:58462"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:55:53.211502291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         578353739844834,
+				"StableID":   "nHAdWaNwW511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30e6cea56aed6553e302b2d17632f0bcf6f6a57ec6092ab51317e8ed41c8fb6f",
+				"DiscoKey":   "discokey:860f6e8e1ac0acae90b673248e98f3bd22315730d6dfb65487d116a6681b021b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:43156", "10.65.0.27:43156", "172.17.0.1:43156"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:55:53.763196637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4395169440272458,
+				"StableID":   "nRCQtbeaKb11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65ee31d5fd8f70039c003e486bbbc549691edd2d02cad343030ef31d6b38481a",
+				"DiscoKey":   "discokey:e7083097433736216d045c9207efcbf8ec7f0f0b08bcf6e476f21919a220a17d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40358", "10.65.0.27:40358", "172.17.0.1:40358"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:55:54.271983011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3641088979485426,
+				"StableID":   "nbw2oXE4SV11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0fea939ad470be541ca626891eb2eb7ec1fdaca02ad13777561d85acbdf7a144",
+				"DiscoKey":   "discokey:6a3422dd72cb8f9d10c7319bf07fe851fed206504687e8a1f2c8beadce72540e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:58694", "10.65.0.27:58694", "172.17.0.1:58694"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:55:54.822178993Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4230872210812181,
+				"StableID":   "n2B3LeqA3a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e1556dd0abd1a6347eaafa7c7507e808d79956f9475c488ac1656fb0c84db15e",
+				"KeyExpiry":  "2026-10-26T10:55:55Z",
+				"DiscoKey":   "discokey:8000bfe4b83927f77d42bbc0538d07909440d3a49e5142f052c64299f1652e2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55184", "10.65.0.27:55184", "172.17.0.1:55184"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:55:55.384034076Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8468323099941934,
+				"StableID":   "n3T3wJVK8921CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:cc61d78e1d09a13486989b2002498557061047d129cdc71e7ad0bb3be13d593d",
+				"KeyExpiry":  "2026-10-26T10:55:55Z",
+				"DiscoKey":   "discokey:391eb689a1dcca9c3f5a7a76ecf8d5b76419d6d2c0d7f29d9072c833a68f1c42",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38731", "10.65.0.27:38731", "172.17.0.1:38731"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:55:55.930226301Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3894704281720475,
+				"StableID":   "npy4b5HvQX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       3894704281720475,
+				"Key":        "nodekey:f6da47d8d63caf8101854623533638510ef706dac00390f9da4898662477f517",
+				"DiscoKey":   "discokey:72983f699c5fab067f70439f20d2d52cbd9f884f4fd214b8eacbd66b980f2433",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60666", "10.65.0.27:60666", "172.17.0.1:60666"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:55:52.665854158Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f6da47d8d63caf8101854623533638510ef706dac00390f9da4898662477f517",
+			"MachineKey": "mkey:aa0853654d11a9935cab995b392832912afbee6616c4560f0ac903d3c8f8365b",
+			"Peers": [{
+				"ID":         2036142731382634,
+				"StableID":   "nZaHjy1BuG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8321e5df967cf3dfe2d75825314ccaacc14166a7ae98ce2915d5d91a34d02900",
+				"DiscoKey":   "discokey:a5a0dfb58e9bb780b96de4fd518f03a54e72d880ee02132d295eb961f71dcc4c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58462", "10.65.0.27:58462", "172.17.0.1:58462"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:55:53.211502291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         578353739844834,
+				"StableID":   "nHAdWaNwW511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30e6cea56aed6553e302b2d17632f0bcf6f6a57ec6092ab51317e8ed41c8fb6f",
+				"DiscoKey":   "discokey:860f6e8e1ac0acae90b673248e98f3bd22315730d6dfb65487d116a6681b021b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:43156", "10.65.0.27:43156", "172.17.0.1:43156"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:55:53.763196637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4395169440272458,
+				"StableID":   "nRCQtbeaKb11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65ee31d5fd8f70039c003e486bbbc549691edd2d02cad343030ef31d6b38481a",
+				"DiscoKey":   "discokey:e7083097433736216d045c9207efcbf8ec7f0f0b08bcf6e476f21919a220a17d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40358", "10.65.0.27:40358", "172.17.0.1:40358"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:55:54.271983011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3641088979485426,
+				"StableID":   "nbw2oXE4SV11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0fea939ad470be541ca626891eb2eb7ec1fdaca02ad13777561d85acbdf7a144",
+				"DiscoKey":   "discokey:6a3422dd72cb8f9d10c7319bf07fe851fed206504687e8a1f2c8beadce72540e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:58694", "10.65.0.27:58694", "172.17.0.1:58694"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:55:54.822178993Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4230872210812181,
+				"StableID":   "n2B3LeqA3a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e1556dd0abd1a6347eaafa7c7507e808d79956f9475c488ac1656fb0c84db15e",
+				"KeyExpiry":  "2026-10-26T10:55:55Z",
+				"DiscoKey":   "discokey:8000bfe4b83927f77d42bbc0538d07909440d3a49e5142f052c64299f1652e2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55184", "10.65.0.27:55184", "172.17.0.1:55184"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:55:55.384034076Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8468323099941934,
+				"StableID":   "n3T3wJVK8921CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:cc61d78e1d09a13486989b2002498557061047d129cdc71e7ad0bb3be13d593d",
+				"KeyExpiry":  "2026-10-26T10:55:55Z",
+				"DiscoKey":   "discokey:391eb689a1dcca9c3f5a7a76ecf8d5b76419d6d2c0d7f29d9072c833a68f1c42",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38731", "10.65.0.27:38731", "172.17.0.1:38731"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:55:55.930226301Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8304594567773170,
+				"StableID":   "nP5xCocAr721CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:650a5ad556cad89c99ab08cf00880da23a5cafe65b2c232599cb247b19257e58",
+				"KeyExpiry":  "2026-10-26T10:55:56Z",
+				"DiscoKey":   "discokey:d36d737c1fb5c08a1e765ed340706511605f8eb5d13fc26b553ae7e6ab7a5470",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50939", "10.65.0.27:50939", "172.17.0.1:50939"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:55:56.467634654Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3894704281720475": {
+				"ID":          3894704281720475,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4230872210812181,
+				"StableID":   "n2B3LeqA3a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e1556dd0abd1a6347eaafa7c7507e808d79956f9475c488ac1656fb0c84db15e",
+				"KeyExpiry":  "2026-10-26T10:55:55Z",
+				"DiscoKey":   "discokey:8000bfe4b83927f77d42bbc0538d07909440d3a49e5142f052c64299f1652e2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55184", "10.65.0.27:55184", "172.17.0.1:55184"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:55:55.384034076Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e1556dd0abd1a6347eaafa7c7507e808d79956f9475c488ac1656fb0c84db15e",
+			"MachineKey": "mkey:b0e1884a51a2b12201f19400a139d177d5aa9b8ecd0886db5af91734d0fd3937",
+			"Peers": [{
+				"ID":         3894704281720475,
+				"StableID":   "npy4b5HvQX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6da47d8d63caf8101854623533638510ef706dac00390f9da4898662477f517",
+				"DiscoKey":   "discokey:72983f699c5fab067f70439f20d2d52cbd9f884f4fd214b8eacbd66b980f2433",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60666", "10.65.0.27:60666", "172.17.0.1:60666"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:55:52.665854158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2036142731382634,
+				"StableID":   "nZaHjy1BuG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8321e5df967cf3dfe2d75825314ccaacc14166a7ae98ce2915d5d91a34d02900",
+				"DiscoKey":   "discokey:a5a0dfb58e9bb780b96de4fd518f03a54e72d880ee02132d295eb961f71dcc4c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58462", "10.65.0.27:58462", "172.17.0.1:58462"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:55:53.211502291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         578353739844834,
+				"StableID":   "nHAdWaNwW511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30e6cea56aed6553e302b2d17632f0bcf6f6a57ec6092ab51317e8ed41c8fb6f",
+				"DiscoKey":   "discokey:860f6e8e1ac0acae90b673248e98f3bd22315730d6dfb65487d116a6681b021b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:43156", "10.65.0.27:43156", "172.17.0.1:43156"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:55:53.763196637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4395169440272458,
+				"StableID":   "nRCQtbeaKb11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65ee31d5fd8f70039c003e486bbbc549691edd2d02cad343030ef31d6b38481a",
+				"DiscoKey":   "discokey:e7083097433736216d045c9207efcbf8ec7f0f0b08bcf6e476f21919a220a17d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40358", "10.65.0.27:40358", "172.17.0.1:40358"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:55:54.271983011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3641088979485426,
+				"StableID":   "nbw2oXE4SV11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0fea939ad470be541ca626891eb2eb7ec1fdaca02ad13777561d85acbdf7a144",
+				"DiscoKey":   "discokey:6a3422dd72cb8f9d10c7319bf07fe851fed206504687e8a1f2c8beadce72540e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:58694", "10.65.0.27:58694", "172.17.0.1:58694"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:55:54.822178993Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8468323099941934,
+				"StableID":   "n3T3wJVK8921CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:cc61d78e1d09a13486989b2002498557061047d129cdc71e7ad0bb3be13d593d",
+				"KeyExpiry":  "2026-10-26T10:55:55Z",
+				"DiscoKey":   "discokey:391eb689a1dcca9c3f5a7a76ecf8d5b76419d6d2c0d7f29d9072c833a68f1c42",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38731", "10.65.0.27:38731", "172.17.0.1:38731"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:55:55.930226301Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8304594567773170,
+				"StableID":   "nP5xCocAr721CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:650a5ad556cad89c99ab08cf00880da23a5cafe65b2c232599cb247b19257e58",
+				"KeyExpiry":  "2026-10-26T10:55:56Z",
+				"DiscoKey":   "discokey:d36d737c1fb5c08a1e765ed340706511605f8eb5d13fc26b553ae7e6ab7a5470",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50939", "10.65.0.27:50939", "172.17.0.1:50939"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:55:56.467634654Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4395169440272458,
+				"StableID":   "nRCQtbeaKb11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       4395169440272458,
+				"Key":        "nodekey:65ee31d5fd8f70039c003e486bbbc549691edd2d02cad343030ef31d6b38481a",
+				"DiscoKey":   "discokey:e7083097433736216d045c9207efcbf8ec7f0f0b08bcf6e476f21919a220a17d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40358", "10.65.0.27:40358", "172.17.0.1:40358"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:55:54.271983011Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:65ee31d5fd8f70039c003e486bbbc549691edd2d02cad343030ef31d6b38481a",
+			"MachineKey": "mkey:10f297c02d1d80f4d958a2e7c77d2bf1704a8490347f3f4bc9d28bec78f6dc07",
+			"Peers": [{
+				"ID":         3894704281720475,
+				"StableID":   "npy4b5HvQX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6da47d8d63caf8101854623533638510ef706dac00390f9da4898662477f517",
+				"DiscoKey":   "discokey:72983f699c5fab067f70439f20d2d52cbd9f884f4fd214b8eacbd66b980f2433",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60666", "10.65.0.27:60666", "172.17.0.1:60666"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:55:52.665854158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2036142731382634,
+				"StableID":   "nZaHjy1BuG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8321e5df967cf3dfe2d75825314ccaacc14166a7ae98ce2915d5d91a34d02900",
+				"DiscoKey":   "discokey:a5a0dfb58e9bb780b96de4fd518f03a54e72d880ee02132d295eb961f71dcc4c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58462", "10.65.0.27:58462", "172.17.0.1:58462"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:55:53.211502291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         578353739844834,
+				"StableID":   "nHAdWaNwW511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30e6cea56aed6553e302b2d17632f0bcf6f6a57ec6092ab51317e8ed41c8fb6f",
+				"DiscoKey":   "discokey:860f6e8e1ac0acae90b673248e98f3bd22315730d6dfb65487d116a6681b021b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:43156", "10.65.0.27:43156", "172.17.0.1:43156"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:55:53.763196637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3641088979485426,
+				"StableID":   "nbw2oXE4SV11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0fea939ad470be541ca626891eb2eb7ec1fdaca02ad13777561d85acbdf7a144",
+				"DiscoKey":   "discokey:6a3422dd72cb8f9d10c7319bf07fe851fed206504687e8a1f2c8beadce72540e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:58694", "10.65.0.27:58694", "172.17.0.1:58694"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:55:54.822178993Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4230872210812181,
+				"StableID":   "n2B3LeqA3a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e1556dd0abd1a6347eaafa7c7507e808d79956f9475c488ac1656fb0c84db15e",
+				"KeyExpiry":  "2026-10-26T10:55:55Z",
+				"DiscoKey":   "discokey:8000bfe4b83927f77d42bbc0538d07909440d3a49e5142f052c64299f1652e2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55184", "10.65.0.27:55184", "172.17.0.1:55184"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:55:55.384034076Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8468323099941934,
+				"StableID":   "n3T3wJVK8921CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:cc61d78e1d09a13486989b2002498557061047d129cdc71e7ad0bb3be13d593d",
+				"KeyExpiry":  "2026-10-26T10:55:55Z",
+				"DiscoKey":   "discokey:391eb689a1dcca9c3f5a7a76ecf8d5b76419d6d2c0d7f29d9072c833a68f1c42",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38731", "10.65.0.27:38731", "172.17.0.1:38731"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:55:55.930226301Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8304594567773170,
+				"StableID":   "nP5xCocAr721CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:650a5ad556cad89c99ab08cf00880da23a5cafe65b2c232599cb247b19257e58",
+				"KeyExpiry":  "2026-10-26T10:55:56Z",
+				"DiscoKey":   "discokey:d36d737c1fb5c08a1e765ed340706511605f8eb5d13fc26b553ae7e6ab7a5470",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50939", "10.65.0.27:50939", "172.17.0.1:50939"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:55:56.467634654Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4395169440272458": {
+				"ID":          4395169440272458,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2036142731382634,
+				"StableID":   "nZaHjy1BuG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       2036142731382634,
+				"Key":        "nodekey:8321e5df967cf3dfe2d75825314ccaacc14166a7ae98ce2915d5d91a34d02900",
+				"DiscoKey":   "discokey:a5a0dfb58e9bb780b96de4fd518f03a54e72d880ee02132d295eb961f71dcc4c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58462", "10.65.0.27:58462", "172.17.0.1:58462"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:55:53.211502291Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8321e5df967cf3dfe2d75825314ccaacc14166a7ae98ce2915d5d91a34d02900",
+			"MachineKey": "mkey:4fabc1ad621a416ed4b6739c8ec804be46c8a6c1242e15b9088c8e74eb19fb26",
+			"Peers": [{
+				"ID":         3894704281720475,
+				"StableID":   "npy4b5HvQX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6da47d8d63caf8101854623533638510ef706dac00390f9da4898662477f517",
+				"DiscoKey":   "discokey:72983f699c5fab067f70439f20d2d52cbd9f884f4fd214b8eacbd66b980f2433",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60666", "10.65.0.27:60666", "172.17.0.1:60666"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:55:52.665854158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         578353739844834,
+				"StableID":   "nHAdWaNwW511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30e6cea56aed6553e302b2d17632f0bcf6f6a57ec6092ab51317e8ed41c8fb6f",
+				"DiscoKey":   "discokey:860f6e8e1ac0acae90b673248e98f3bd22315730d6dfb65487d116a6681b021b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:43156", "10.65.0.27:43156", "172.17.0.1:43156"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:55:53.763196637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4395169440272458,
+				"StableID":   "nRCQtbeaKb11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65ee31d5fd8f70039c003e486bbbc549691edd2d02cad343030ef31d6b38481a",
+				"DiscoKey":   "discokey:e7083097433736216d045c9207efcbf8ec7f0f0b08bcf6e476f21919a220a17d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40358", "10.65.0.27:40358", "172.17.0.1:40358"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:55:54.271983011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3641088979485426,
+				"StableID":   "nbw2oXE4SV11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0fea939ad470be541ca626891eb2eb7ec1fdaca02ad13777561d85acbdf7a144",
+				"DiscoKey":   "discokey:6a3422dd72cb8f9d10c7319bf07fe851fed206504687e8a1f2c8beadce72540e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:58694", "10.65.0.27:58694", "172.17.0.1:58694"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:55:54.822178993Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4230872210812181,
+				"StableID":   "n2B3LeqA3a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e1556dd0abd1a6347eaafa7c7507e808d79956f9475c488ac1656fb0c84db15e",
+				"KeyExpiry":  "2026-10-26T10:55:55Z",
+				"DiscoKey":   "discokey:8000bfe4b83927f77d42bbc0538d07909440d3a49e5142f052c64299f1652e2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55184", "10.65.0.27:55184", "172.17.0.1:55184"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:55:55.384034076Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8468323099941934,
+				"StableID":   "n3T3wJVK8921CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:cc61d78e1d09a13486989b2002498557061047d129cdc71e7ad0bb3be13d593d",
+				"KeyExpiry":  "2026-10-26T10:55:55Z",
+				"DiscoKey":   "discokey:391eb689a1dcca9c3f5a7a76ecf8d5b76419d6d2c0d7f29d9072c833a68f1c42",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38731", "10.65.0.27:38731", "172.17.0.1:38731"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:55:55.930226301Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8304594567773170,
+				"StableID":   "nP5xCocAr721CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:650a5ad556cad89c99ab08cf00880da23a5cafe65b2c232599cb247b19257e58",
+				"KeyExpiry":  "2026-10-26T10:55:56Z",
+				"DiscoKey":   "discokey:d36d737c1fb5c08a1e765ed340706511605f8eb5d13fc26b553ae7e6ab7a5470",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50939", "10.65.0.27:50939", "172.17.0.1:50939"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:55:56.467634654Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2036142731382634": {
+				"ID":          2036142731382634,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8468323099941934,
+				"StableID":   "n3T3wJVK8921CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:cc61d78e1d09a13486989b2002498557061047d129cdc71e7ad0bb3be13d593d",
+				"KeyExpiry":  "2026-10-26T10:55:55Z",
+				"DiscoKey":   "discokey:391eb689a1dcca9c3f5a7a76ecf8d5b76419d6d2c0d7f29d9072c833a68f1c42",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38731", "10.65.0.27:38731", "172.17.0.1:38731"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:55:55.930226301Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cc61d78e1d09a13486989b2002498557061047d129cdc71e7ad0bb3be13d593d",
+			"MachineKey": "mkey:75a85ad5fb267f456a8015645b3b88f7c1fabdc9d94afe9723ccd6cbe5965726",
+			"Peers": [{
+				"ID":         3894704281720475,
+				"StableID":   "npy4b5HvQX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6da47d8d63caf8101854623533638510ef706dac00390f9da4898662477f517",
+				"DiscoKey":   "discokey:72983f699c5fab067f70439f20d2d52cbd9f884f4fd214b8eacbd66b980f2433",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60666", "10.65.0.27:60666", "172.17.0.1:60666"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:55:52.665854158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2036142731382634,
+				"StableID":   "nZaHjy1BuG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8321e5df967cf3dfe2d75825314ccaacc14166a7ae98ce2915d5d91a34d02900",
+				"DiscoKey":   "discokey:a5a0dfb58e9bb780b96de4fd518f03a54e72d880ee02132d295eb961f71dcc4c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58462", "10.65.0.27:58462", "172.17.0.1:58462"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:55:53.211502291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         578353739844834,
+				"StableID":   "nHAdWaNwW511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30e6cea56aed6553e302b2d17632f0bcf6f6a57ec6092ab51317e8ed41c8fb6f",
+				"DiscoKey":   "discokey:860f6e8e1ac0acae90b673248e98f3bd22315730d6dfb65487d116a6681b021b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:43156", "10.65.0.27:43156", "172.17.0.1:43156"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:55:53.763196637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4395169440272458,
+				"StableID":   "nRCQtbeaKb11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65ee31d5fd8f70039c003e486bbbc549691edd2d02cad343030ef31d6b38481a",
+				"DiscoKey":   "discokey:e7083097433736216d045c9207efcbf8ec7f0f0b08bcf6e476f21919a220a17d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40358", "10.65.0.27:40358", "172.17.0.1:40358"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:55:54.271983011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3641088979485426,
+				"StableID":   "nbw2oXE4SV11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0fea939ad470be541ca626891eb2eb7ec1fdaca02ad13777561d85acbdf7a144",
+				"DiscoKey":   "discokey:6a3422dd72cb8f9d10c7319bf07fe851fed206504687e8a1f2c8beadce72540e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:58694", "10.65.0.27:58694", "172.17.0.1:58694"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:55:54.822178993Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4230872210812181,
+				"StableID":   "n2B3LeqA3a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e1556dd0abd1a6347eaafa7c7507e808d79956f9475c488ac1656fb0c84db15e",
+				"KeyExpiry":  "2026-10-26T10:55:55Z",
+				"DiscoKey":   "discokey:8000bfe4b83927f77d42bbc0538d07909440d3a49e5142f052c64299f1652e2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55184", "10.65.0.27:55184", "172.17.0.1:55184"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:55:55.384034076Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8304594567773170,
+				"StableID":   "nP5xCocAr721CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:650a5ad556cad89c99ab08cf00880da23a5cafe65b2c232599cb247b19257e58",
+				"KeyExpiry":  "2026-10-26T10:55:56Z",
+				"DiscoKey":   "discokey:d36d737c1fb5c08a1e765ed340706511605f8eb5d13fc26b553ae7e6ab7a5470",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50939", "10.65.0.27:50939", "172.17.0.1:50939"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:55:56.467634654Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         578353739844834,
+				"StableID":   "nHAdWaNwW511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       578353739844834,
+				"Key":        "nodekey:30e6cea56aed6553e302b2d17632f0bcf6f6a57ec6092ab51317e8ed41c8fb6f",
+				"DiscoKey":   "discokey:860f6e8e1ac0acae90b673248e98f3bd22315730d6dfb65487d116a6681b021b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:43156", "10.65.0.27:43156", "172.17.0.1:43156"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:55:53.763196637Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:30e6cea56aed6553e302b2d17632f0bcf6f6a57ec6092ab51317e8ed41c8fb6f",
+			"MachineKey": "mkey:7b22d15a746b8319d01a0363c8b67f29a0c83918686dabe99c318308eff45c7f",
+			"Peers": [{
+				"ID":         3894704281720475,
+				"StableID":   "npy4b5HvQX11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6da47d8d63caf8101854623533638510ef706dac00390f9da4898662477f517",
+				"DiscoKey":   "discokey:72983f699c5fab067f70439f20d2d52cbd9f884f4fd214b8eacbd66b980f2433",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:60666", "10.65.0.27:60666", "172.17.0.1:60666"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:55:52.665854158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2036142731382634,
+				"StableID":   "nZaHjy1BuG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8321e5df967cf3dfe2d75825314ccaacc14166a7ae98ce2915d5d91a34d02900",
+				"DiscoKey":   "discokey:a5a0dfb58e9bb780b96de4fd518f03a54e72d880ee02132d295eb961f71dcc4c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58462", "10.65.0.27:58462", "172.17.0.1:58462"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:55:53.211502291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4395169440272458,
+				"StableID":   "nRCQtbeaKb11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65ee31d5fd8f70039c003e486bbbc549691edd2d02cad343030ef31d6b38481a",
+				"DiscoKey":   "discokey:e7083097433736216d045c9207efcbf8ec7f0f0b08bcf6e476f21919a220a17d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40358", "10.65.0.27:40358", "172.17.0.1:40358"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:55:54.271983011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3641088979485426,
+				"StableID":   "nbw2oXE4SV11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0fea939ad470be541ca626891eb2eb7ec1fdaca02ad13777561d85acbdf7a144",
+				"DiscoKey":   "discokey:6a3422dd72cb8f9d10c7319bf07fe851fed206504687e8a1f2c8beadce72540e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:58694", "10.65.0.27:58694", "172.17.0.1:58694"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:55:54.822178993Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4230872210812181,
+				"StableID":   "n2B3LeqA3a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e1556dd0abd1a6347eaafa7c7507e808d79956f9475c488ac1656fb0c84db15e",
+				"KeyExpiry":  "2026-10-26T10:55:55Z",
+				"DiscoKey":   "discokey:8000bfe4b83927f77d42bbc0538d07909440d3a49e5142f052c64299f1652e2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:55184", "10.65.0.27:55184", "172.17.0.1:55184"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:55:55.384034076Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8468323099941934,
+				"StableID":   "n3T3wJVK8921CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:cc61d78e1d09a13486989b2002498557061047d129cdc71e7ad0bb3be13d593d",
+				"KeyExpiry":  "2026-10-26T10:55:55Z",
+				"DiscoKey":   "discokey:391eb689a1dcca9c3f5a7a76ecf8d5b76419d6d2c0d7f29d9072c833a68f1c42",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38731", "10.65.0.27:38731", "172.17.0.1:38731"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:55:55.930226301Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8304594567773170,
+				"StableID":   "nP5xCocAr721CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:650a5ad556cad89c99ab08cf00880da23a5cafe65b2c232599cb247b19257e58",
+				"KeyExpiry":  "2026-10-26T10:55:56Z",
+				"DiscoKey":   "discokey:d36d737c1fb5c08a1e765ed340706511605f8eb5d13fc26b553ae7e6ab7a5470",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50939", "10.65.0.27:50939", "172.17.0.1:50939"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:55:56.467634654Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "578353739844834": {
+				"ID":          578353739844834,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-port-shape-list.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-port-shape-list.hujson
@@ -1,0 +1,8847 @@
+// policytest-port-shape-list
+//
+// tests block port-shape: dst port list (80,443,8080)
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:56:18Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-port-shape-list",
+	"description":    "tests block port-shape: dst port list (80,443,8080)",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:56:18.214870834Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                             \n  \n                                                                      \n                                                        \n{\n\t\"id\":          \"policytest-port-shape-list\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block port-shape: dst port list (80,443,8080)\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": false},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"thor@example.org\"], \"dst\": [\"webserver:80,443,8080\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"accept\": [\"webserver:80,443,8080\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-port-shape-list.hujson",
+		"full_policy": {
+			"acls": [{
+				"action": "accept",
+				"dst":    ["webserver:80,443,8080"],
+				"src":    ["thor@example.org"]
+			}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["webserver:80,443,8080"], "src": "thor@example.org"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         218548206506705,
+				"StableID":   "ngGJdftyh211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       218548206506705,
+				"Key":        "nodekey:0c627d97c9afc9a388aa6e7cb1c7b929b7727bbf7a0b8c21a8e49ef375cc4749",
+				"DiscoKey":   "discokey:24053ed118af7429c44d9c8170445497941dc57e5100fa041590685b10db3d23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:33693", "10.65.0.27:33693", "172.17.0.1:33693"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:56:21.779977399Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0c627d97c9afc9a388aa6e7cb1c7b929b7727bbf7a0b8c21a8e49ef375cc4749",
+			"MachineKey": "mkey:223f02a24ca4d2132cf514af3418ce7791a03d680a58069069f6cd668eee0f7a",
+			"Peers": [{
+				"ID":         5746798450115314,
+				"StableID":   "nuvt3jejsm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d950c80808fb5af72b6d425e3ccf725687426f98ab9f35ac1a2d572aa0d5da39",
+				"DiscoKey":   "discokey:f61a620e4058c275dfb826397cfb5541fd86773c86ef3208380b5ded6aa5d17d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56229", "10.65.0.27:56229", "172.17.0.1:56229"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:56:19.635356569Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2019943557616926,
+				"StableID":   "nomTDYVqmG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78983f5249706617ab2114952487514c8fd46dfccbeff3ae18cffe4d90955704",
+				"DiscoKey":   "discokey:5b2805ba16e42611ac9d21ed11187ab44fad469fb46dd96cd19c7da86eb0f550",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:33293", "10.65.0.27:33293", "172.17.0.1:33293"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:56:20.183152183Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2396647086087891,
+				"StableID":   "nzLn4brSiK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0a44c7f1d7cc4ff3a027ec0430841314f98f23248acf3bd3528b02c52ed85806",
+				"DiscoKey":   "discokey:e768119481c35cee5914f57a4321253498c325e4630a500a2b7df81703e88b26",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60286", "10.65.0.27:60286", "172.17.0.1:60286"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:56:20.713400737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2334800798516358,
+				"StableID":   "nXd5RxFSEK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ae3ef73d1b4babb0d4dff55b8bd6d424a61d98f1323746b3a9d687507d6734c",
+				"DiscoKey":   "discokey:c0df43c085a3ca7514fc3aeb7463071eb496bee659eecd4873147b4e34e1713b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53122", "10.65.0.27:53122", "172.17.0.1:53122"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:56:21.260935948Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3873189112829444,
+				"StableID":   "nRugnP7BFX11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:45933dc251c3018d89ffd354f9a33acab1f2663dc268d59d15ee5eadc290700e",
+				"KeyExpiry":  "2026-10-26T10:56:22Z",
+				"DiscoKey":   "discokey:dd8836d50bf9e8933c16018043a23854bf3649b1849ba61f8117b2087189fe7f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58136", "10.65.0.27:58136", "172.17.0.1:58136"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:56:22.313287681Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8597001142266879,
+				"StableID":   "n2zttEeb8A21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:53f18e5211eb12ee7ac5c105dceea48b341ad675093a64208125230a79a3f65a",
+				"KeyExpiry":  "2026-10-26T10:56:22Z",
+				"DiscoKey":   "discokey:5d8be329df797bc3861654a99f2a51a37276d4fe1a98f7f98ec15f5ec4c18672",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50162", "10.65.0.27:50162", "172.17.0.1:50162"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:56:22.876486752Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7285107743722076,
+				"StableID":   "nhFjdmRSty11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:991b4775194b6a1c7a2ece6f688473466b87913054e42082693c8ca52b5e0979",
+				"KeyExpiry":  "2026-10-26T10:56:23Z",
+				"DiscoKey":   "discokey:b0bce3a420803a790e9374c69826417456a50376a9e0d6f12c31f9f86da81e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51755", "10.65.0.27:51755", "172.17.0.1:51755"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:56:23.429607825Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "218548206506705": {
+				"ID":          218548206506705,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7285107743722076,
+				"StableID":   "nhFjdmRSty11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:991b4775194b6a1c7a2ece6f688473466b87913054e42082693c8ca52b5e0979",
+				"KeyExpiry":  "2026-10-26T10:56:23Z",
+				"DiscoKey":   "discokey:b0bce3a420803a790e9374c69826417456a50376a9e0d6f12c31f9f86da81e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51755", "10.65.0.27:51755", "172.17.0.1:51755"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:56:23.429607825Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:991b4775194b6a1c7a2ece6f688473466b87913054e42082693c8ca52b5e0979",
+			"MachineKey": "mkey:de588c502c32a2f6ee697fee901a3407aeda46a1337e178884437f82e85d205d",
+			"Peers": [{
+				"ID":         5746798450115314,
+				"StableID":   "nuvt3jejsm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d950c80808fb5af72b6d425e3ccf725687426f98ab9f35ac1a2d572aa0d5da39",
+				"DiscoKey":   "discokey:f61a620e4058c275dfb826397cfb5541fd86773c86ef3208380b5ded6aa5d17d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56229", "10.65.0.27:56229", "172.17.0.1:56229"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:56:19.635356569Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2019943557616926,
+				"StableID":   "nomTDYVqmG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78983f5249706617ab2114952487514c8fd46dfccbeff3ae18cffe4d90955704",
+				"DiscoKey":   "discokey:5b2805ba16e42611ac9d21ed11187ab44fad469fb46dd96cd19c7da86eb0f550",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:33293", "10.65.0.27:33293", "172.17.0.1:33293"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:56:20.183152183Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2396647086087891,
+				"StableID":   "nzLn4brSiK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0a44c7f1d7cc4ff3a027ec0430841314f98f23248acf3bd3528b02c52ed85806",
+				"DiscoKey":   "discokey:e768119481c35cee5914f57a4321253498c325e4630a500a2b7df81703e88b26",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60286", "10.65.0.27:60286", "172.17.0.1:60286"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:56:20.713400737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2334800798516358,
+				"StableID":   "nXd5RxFSEK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ae3ef73d1b4babb0d4dff55b8bd6d424a61d98f1323746b3a9d687507d6734c",
+				"DiscoKey":   "discokey:c0df43c085a3ca7514fc3aeb7463071eb496bee659eecd4873147b4e34e1713b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53122", "10.65.0.27:53122", "172.17.0.1:53122"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:56:21.260935948Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         218548206506705,
+				"StableID":   "ngGJdftyh211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c627d97c9afc9a388aa6e7cb1c7b929b7727bbf7a0b8c21a8e49ef375cc4749",
+				"DiscoKey":   "discokey:24053ed118af7429c44d9c8170445497941dc57e5100fa041590685b10db3d23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:33693", "10.65.0.27:33693", "172.17.0.1:33693"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:56:21.779977399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3873189112829444,
+				"StableID":   "nRugnP7BFX11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:45933dc251c3018d89ffd354f9a33acab1f2663dc268d59d15ee5eadc290700e",
+				"KeyExpiry":  "2026-10-26T10:56:22Z",
+				"DiscoKey":   "discokey:dd8836d50bf9e8933c16018043a23854bf3649b1849ba61f8117b2087189fe7f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58136", "10.65.0.27:58136", "172.17.0.1:58136"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:56:22.313287681Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8597001142266879,
+				"StableID":   "n2zttEeb8A21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:53f18e5211eb12ee7ac5c105dceea48b341ad675093a64208125230a79a3f65a",
+				"KeyExpiry":  "2026-10-26T10:56:22Z",
+				"DiscoKey":   "discokey:5d8be329df797bc3861654a99f2a51a37276d4fe1a98f7f98ec15f5ec4c18672",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50162", "10.65.0.27:50162", "172.17.0.1:50162"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:56:22.876486752Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5746798450115314,
+				"StableID":   "nuvt3jejsm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       5746798450115314,
+				"Key":        "nodekey:d950c80808fb5af72b6d425e3ccf725687426f98ab9f35ac1a2d572aa0d5da39",
+				"DiscoKey":   "discokey:f61a620e4058c275dfb826397cfb5541fd86773c86ef3208380b5ded6aa5d17d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56229", "10.65.0.27:56229", "172.17.0.1:56229"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:56:19.635356569Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d950c80808fb5af72b6d425e3ccf725687426f98ab9f35ac1a2d572aa0d5da39",
+			"MachineKey": "mkey:6c92f23274cef7b2ecceec48afdb07654f5960530c76c051fcb4c878b4098529",
+			"Peers": [{
+				"ID":         2019943557616926,
+				"StableID":   "nomTDYVqmG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78983f5249706617ab2114952487514c8fd46dfccbeff3ae18cffe4d90955704",
+				"DiscoKey":   "discokey:5b2805ba16e42611ac9d21ed11187ab44fad469fb46dd96cd19c7da86eb0f550",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:33293", "10.65.0.27:33293", "172.17.0.1:33293"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:56:20.183152183Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2396647086087891,
+				"StableID":   "nzLn4brSiK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0a44c7f1d7cc4ff3a027ec0430841314f98f23248acf3bd3528b02c52ed85806",
+				"DiscoKey":   "discokey:e768119481c35cee5914f57a4321253498c325e4630a500a2b7df81703e88b26",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60286", "10.65.0.27:60286", "172.17.0.1:60286"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:56:20.713400737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2334800798516358,
+				"StableID":   "nXd5RxFSEK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ae3ef73d1b4babb0d4dff55b8bd6d424a61d98f1323746b3a9d687507d6734c",
+				"DiscoKey":   "discokey:c0df43c085a3ca7514fc3aeb7463071eb496bee659eecd4873147b4e34e1713b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53122", "10.65.0.27:53122", "172.17.0.1:53122"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:56:21.260935948Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         218548206506705,
+				"StableID":   "ngGJdftyh211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c627d97c9afc9a388aa6e7cb1c7b929b7727bbf7a0b8c21a8e49ef375cc4749",
+				"DiscoKey":   "discokey:24053ed118af7429c44d9c8170445497941dc57e5100fa041590685b10db3d23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:33693", "10.65.0.27:33693", "172.17.0.1:33693"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:56:21.779977399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3873189112829444,
+				"StableID":   "nRugnP7BFX11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:45933dc251c3018d89ffd354f9a33acab1f2663dc268d59d15ee5eadc290700e",
+				"KeyExpiry":  "2026-10-26T10:56:22Z",
+				"DiscoKey":   "discokey:dd8836d50bf9e8933c16018043a23854bf3649b1849ba61f8117b2087189fe7f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58136", "10.65.0.27:58136", "172.17.0.1:58136"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:56:22.313287681Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8597001142266879,
+				"StableID":   "n2zttEeb8A21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:53f18e5211eb12ee7ac5c105dceea48b341ad675093a64208125230a79a3f65a",
+				"KeyExpiry":  "2026-10-26T10:56:22Z",
+				"DiscoKey":   "discokey:5d8be329df797bc3861654a99f2a51a37276d4fe1a98f7f98ec15f5ec4c18672",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50162", "10.65.0.27:50162", "172.17.0.1:50162"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:56:22.876486752Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7285107743722076,
+				"StableID":   "nhFjdmRSty11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:991b4775194b6a1c7a2ece6f688473466b87913054e42082693c8ca52b5e0979",
+				"KeyExpiry":  "2026-10-26T10:56:23Z",
+				"DiscoKey":   "discokey:b0bce3a420803a790e9374c69826417456a50376a9e0d6f12c31f9f86da81e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51755", "10.65.0.27:51755", "172.17.0.1:51755"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:56:23.429607825Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5746798450115314": {
+				"ID":          5746798450115314,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3873189112829444,
+				"StableID":   "nRugnP7BFX11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:45933dc251c3018d89ffd354f9a33acab1f2663dc268d59d15ee5eadc290700e",
+				"KeyExpiry":  "2026-10-26T10:56:22Z",
+				"DiscoKey":   "discokey:dd8836d50bf9e8933c16018043a23854bf3649b1849ba61f8117b2087189fe7f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58136", "10.65.0.27:58136", "172.17.0.1:58136"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:56:22.313287681Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:45933dc251c3018d89ffd354f9a33acab1f2663dc268d59d15ee5eadc290700e",
+			"MachineKey": "mkey:e345f95fc74fb396623a4627dbb24d2462dab6ca2cdca96270ed47480bdbca36",
+			"Peers": [{
+				"ID":         5746798450115314,
+				"StableID":   "nuvt3jejsm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d950c80808fb5af72b6d425e3ccf725687426f98ab9f35ac1a2d572aa0d5da39",
+				"DiscoKey":   "discokey:f61a620e4058c275dfb826397cfb5541fd86773c86ef3208380b5ded6aa5d17d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56229", "10.65.0.27:56229", "172.17.0.1:56229"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:56:19.635356569Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2019943557616926,
+				"StableID":   "nomTDYVqmG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78983f5249706617ab2114952487514c8fd46dfccbeff3ae18cffe4d90955704",
+				"DiscoKey":   "discokey:5b2805ba16e42611ac9d21ed11187ab44fad469fb46dd96cd19c7da86eb0f550",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:33293", "10.65.0.27:33293", "172.17.0.1:33293"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:56:20.183152183Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2396647086087891,
+				"StableID":   "nzLn4brSiK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0a44c7f1d7cc4ff3a027ec0430841314f98f23248acf3bd3528b02c52ed85806",
+				"DiscoKey":   "discokey:e768119481c35cee5914f57a4321253498c325e4630a500a2b7df81703e88b26",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60286", "10.65.0.27:60286", "172.17.0.1:60286"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:56:20.713400737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2334800798516358,
+				"StableID":   "nXd5RxFSEK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ae3ef73d1b4babb0d4dff55b8bd6d424a61d98f1323746b3a9d687507d6734c",
+				"DiscoKey":   "discokey:c0df43c085a3ca7514fc3aeb7463071eb496bee659eecd4873147b4e34e1713b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53122", "10.65.0.27:53122", "172.17.0.1:53122"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:56:21.260935948Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         218548206506705,
+				"StableID":   "ngGJdftyh211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c627d97c9afc9a388aa6e7cb1c7b929b7727bbf7a0b8c21a8e49ef375cc4749",
+				"DiscoKey":   "discokey:24053ed118af7429c44d9c8170445497941dc57e5100fa041590685b10db3d23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:33693", "10.65.0.27:33693", "172.17.0.1:33693"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:56:21.779977399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8597001142266879,
+				"StableID":   "n2zttEeb8A21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:53f18e5211eb12ee7ac5c105dceea48b341ad675093a64208125230a79a3f65a",
+				"KeyExpiry":  "2026-10-26T10:56:22Z",
+				"DiscoKey":   "discokey:5d8be329df797bc3861654a99f2a51a37276d4fe1a98f7f98ec15f5ec4c18672",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50162", "10.65.0.27:50162", "172.17.0.1:50162"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:56:22.876486752Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7285107743722076,
+				"StableID":   "nhFjdmRSty11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:991b4775194b6a1c7a2ece6f688473466b87913054e42082693c8ca52b5e0979",
+				"KeyExpiry":  "2026-10-26T10:56:23Z",
+				"DiscoKey":   "discokey:b0bce3a420803a790e9374c69826417456a50376a9e0d6f12c31f9f86da81e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51755", "10.65.0.27:51755", "172.17.0.1:51755"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:56:23.429607825Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2334800798516358,
+				"StableID":   "nXd5RxFSEK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       2334800798516358,
+				"Key":        "nodekey:2ae3ef73d1b4babb0d4dff55b8bd6d424a61d98f1323746b3a9d687507d6734c",
+				"DiscoKey":   "discokey:c0df43c085a3ca7514fc3aeb7463071eb496bee659eecd4873147b4e34e1713b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53122", "10.65.0.27:53122", "172.17.0.1:53122"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:56:21.260935948Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2ae3ef73d1b4babb0d4dff55b8bd6d424a61d98f1323746b3a9d687507d6734c",
+			"MachineKey": "mkey:7a82018969864c191050c811441a4b653729e71683f366b28406e166fa32c128",
+			"Peers": [{
+				"ID":         5746798450115314,
+				"StableID":   "nuvt3jejsm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d950c80808fb5af72b6d425e3ccf725687426f98ab9f35ac1a2d572aa0d5da39",
+				"DiscoKey":   "discokey:f61a620e4058c275dfb826397cfb5541fd86773c86ef3208380b5ded6aa5d17d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56229", "10.65.0.27:56229", "172.17.0.1:56229"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:56:19.635356569Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2019943557616926,
+				"StableID":   "nomTDYVqmG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78983f5249706617ab2114952487514c8fd46dfccbeff3ae18cffe4d90955704",
+				"DiscoKey":   "discokey:5b2805ba16e42611ac9d21ed11187ab44fad469fb46dd96cd19c7da86eb0f550",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:33293", "10.65.0.27:33293", "172.17.0.1:33293"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:56:20.183152183Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2396647086087891,
+				"StableID":   "nzLn4brSiK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0a44c7f1d7cc4ff3a027ec0430841314f98f23248acf3bd3528b02c52ed85806",
+				"DiscoKey":   "discokey:e768119481c35cee5914f57a4321253498c325e4630a500a2b7df81703e88b26",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60286", "10.65.0.27:60286", "172.17.0.1:60286"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:56:20.713400737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         218548206506705,
+				"StableID":   "ngGJdftyh211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c627d97c9afc9a388aa6e7cb1c7b929b7727bbf7a0b8c21a8e49ef375cc4749",
+				"DiscoKey":   "discokey:24053ed118af7429c44d9c8170445497941dc57e5100fa041590685b10db3d23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:33693", "10.65.0.27:33693", "172.17.0.1:33693"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:56:21.779977399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3873189112829444,
+				"StableID":   "nRugnP7BFX11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:45933dc251c3018d89ffd354f9a33acab1f2663dc268d59d15ee5eadc290700e",
+				"KeyExpiry":  "2026-10-26T10:56:22Z",
+				"DiscoKey":   "discokey:dd8836d50bf9e8933c16018043a23854bf3649b1849ba61f8117b2087189fe7f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58136", "10.65.0.27:58136", "172.17.0.1:58136"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:56:22.313287681Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8597001142266879,
+				"StableID":   "n2zttEeb8A21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:53f18e5211eb12ee7ac5c105dceea48b341ad675093a64208125230a79a3f65a",
+				"KeyExpiry":  "2026-10-26T10:56:22Z",
+				"DiscoKey":   "discokey:5d8be329df797bc3861654a99f2a51a37276d4fe1a98f7f98ec15f5ec4c18672",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50162", "10.65.0.27:50162", "172.17.0.1:50162"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:56:22.876486752Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7285107743722076,
+				"StableID":   "nhFjdmRSty11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:991b4775194b6a1c7a2ece6f688473466b87913054e42082693c8ca52b5e0979",
+				"KeyExpiry":  "2026-10-26T10:56:23Z",
+				"DiscoKey":   "discokey:b0bce3a420803a790e9374c69826417456a50376a9e0d6f12c31f9f86da81e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51755", "10.65.0.27:51755", "172.17.0.1:51755"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:56:23.429607825Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2334800798516358": {
+				"ID":          2334800798516358,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2019943557616926,
+				"StableID":   "nomTDYVqmG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       2019943557616926,
+				"Key":        "nodekey:78983f5249706617ab2114952487514c8fd46dfccbeff3ae18cffe4d90955704",
+				"DiscoKey":   "discokey:5b2805ba16e42611ac9d21ed11187ab44fad469fb46dd96cd19c7da86eb0f550",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:33293", "10.65.0.27:33293", "172.17.0.1:33293"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:56:20.183152183Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:78983f5249706617ab2114952487514c8fd46dfccbeff3ae18cffe4d90955704",
+			"MachineKey": "mkey:d0ce77f0ff6555a4f8e7b26d637a605cc7a28e123a93c34973074af85cbade78",
+			"Peers": [{
+				"ID":         5746798450115314,
+				"StableID":   "nuvt3jejsm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d950c80808fb5af72b6d425e3ccf725687426f98ab9f35ac1a2d572aa0d5da39",
+				"DiscoKey":   "discokey:f61a620e4058c275dfb826397cfb5541fd86773c86ef3208380b5ded6aa5d17d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56229", "10.65.0.27:56229", "172.17.0.1:56229"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:56:19.635356569Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2396647086087891,
+				"StableID":   "nzLn4brSiK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0a44c7f1d7cc4ff3a027ec0430841314f98f23248acf3bd3528b02c52ed85806",
+				"DiscoKey":   "discokey:e768119481c35cee5914f57a4321253498c325e4630a500a2b7df81703e88b26",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60286", "10.65.0.27:60286", "172.17.0.1:60286"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:56:20.713400737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2334800798516358,
+				"StableID":   "nXd5RxFSEK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ae3ef73d1b4babb0d4dff55b8bd6d424a61d98f1323746b3a9d687507d6734c",
+				"DiscoKey":   "discokey:c0df43c085a3ca7514fc3aeb7463071eb496bee659eecd4873147b4e34e1713b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53122", "10.65.0.27:53122", "172.17.0.1:53122"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:56:21.260935948Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         218548206506705,
+				"StableID":   "ngGJdftyh211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c627d97c9afc9a388aa6e7cb1c7b929b7727bbf7a0b8c21a8e49ef375cc4749",
+				"DiscoKey":   "discokey:24053ed118af7429c44d9c8170445497941dc57e5100fa041590685b10db3d23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:33693", "10.65.0.27:33693", "172.17.0.1:33693"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:56:21.779977399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3873189112829444,
+				"StableID":   "nRugnP7BFX11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:45933dc251c3018d89ffd354f9a33acab1f2663dc268d59d15ee5eadc290700e",
+				"KeyExpiry":  "2026-10-26T10:56:22Z",
+				"DiscoKey":   "discokey:dd8836d50bf9e8933c16018043a23854bf3649b1849ba61f8117b2087189fe7f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58136", "10.65.0.27:58136", "172.17.0.1:58136"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:56:22.313287681Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8597001142266879,
+				"StableID":   "n2zttEeb8A21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:53f18e5211eb12ee7ac5c105dceea48b341ad675093a64208125230a79a3f65a",
+				"KeyExpiry":  "2026-10-26T10:56:22Z",
+				"DiscoKey":   "discokey:5d8be329df797bc3861654a99f2a51a37276d4fe1a98f7f98ec15f5ec4c18672",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50162", "10.65.0.27:50162", "172.17.0.1:50162"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:56:22.876486752Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7285107743722076,
+				"StableID":   "nhFjdmRSty11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:991b4775194b6a1c7a2ece6f688473466b87913054e42082693c8ca52b5e0979",
+				"KeyExpiry":  "2026-10-26T10:56:23Z",
+				"DiscoKey":   "discokey:b0bce3a420803a790e9374c69826417456a50376a9e0d6f12c31f9f86da81e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51755", "10.65.0.27:51755", "172.17.0.1:51755"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:56:23.429607825Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2019943557616926": {
+				"ID":          2019943557616926,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8597001142266879,
+				"StableID":   "n2zttEeb8A21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:53f18e5211eb12ee7ac5c105dceea48b341ad675093a64208125230a79a3f65a",
+				"KeyExpiry":  "2026-10-26T10:56:22Z",
+				"DiscoKey":   "discokey:5d8be329df797bc3861654a99f2a51a37276d4fe1a98f7f98ec15f5ec4c18672",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50162", "10.65.0.27:50162", "172.17.0.1:50162"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:56:22.876486752Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:53f18e5211eb12ee7ac5c105dceea48b341ad675093a64208125230a79a3f65a",
+			"MachineKey": "mkey:94783102770196c04b3af8966be8b5a9ef0f5f209fb1acbc441012025a49bf75",
+			"Peers": [{
+				"ID":         5746798450115314,
+				"StableID":   "nuvt3jejsm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d950c80808fb5af72b6d425e3ccf725687426f98ab9f35ac1a2d572aa0d5da39",
+				"DiscoKey":   "discokey:f61a620e4058c275dfb826397cfb5541fd86773c86ef3208380b5ded6aa5d17d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56229", "10.65.0.27:56229", "172.17.0.1:56229"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:56:19.635356569Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2019943557616926,
+				"StableID":   "nomTDYVqmG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78983f5249706617ab2114952487514c8fd46dfccbeff3ae18cffe4d90955704",
+				"DiscoKey":   "discokey:5b2805ba16e42611ac9d21ed11187ab44fad469fb46dd96cd19c7da86eb0f550",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:33293", "10.65.0.27:33293", "172.17.0.1:33293"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:56:20.183152183Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2396647086087891,
+				"StableID":   "nzLn4brSiK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0a44c7f1d7cc4ff3a027ec0430841314f98f23248acf3bd3528b02c52ed85806",
+				"DiscoKey":   "discokey:e768119481c35cee5914f57a4321253498c325e4630a500a2b7df81703e88b26",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60286", "10.65.0.27:60286", "172.17.0.1:60286"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:56:20.713400737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2334800798516358,
+				"StableID":   "nXd5RxFSEK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ae3ef73d1b4babb0d4dff55b8bd6d424a61d98f1323746b3a9d687507d6734c",
+				"DiscoKey":   "discokey:c0df43c085a3ca7514fc3aeb7463071eb496bee659eecd4873147b4e34e1713b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53122", "10.65.0.27:53122", "172.17.0.1:53122"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:56:21.260935948Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         218548206506705,
+				"StableID":   "ngGJdftyh211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c627d97c9afc9a388aa6e7cb1c7b929b7727bbf7a0b8c21a8e49ef375cc4749",
+				"DiscoKey":   "discokey:24053ed118af7429c44d9c8170445497941dc57e5100fa041590685b10db3d23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:33693", "10.65.0.27:33693", "172.17.0.1:33693"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:56:21.779977399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3873189112829444,
+				"StableID":   "nRugnP7BFX11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:45933dc251c3018d89ffd354f9a33acab1f2663dc268d59d15ee5eadc290700e",
+				"KeyExpiry":  "2026-10-26T10:56:22Z",
+				"DiscoKey":   "discokey:dd8836d50bf9e8933c16018043a23854bf3649b1849ba61f8117b2087189fe7f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58136", "10.65.0.27:58136", "172.17.0.1:58136"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:56:22.313287681Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7285107743722076,
+				"StableID":   "nhFjdmRSty11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:991b4775194b6a1c7a2ece6f688473466b87913054e42082693c8ca52b5e0979",
+				"KeyExpiry":  "2026-10-26T10:56:23Z",
+				"DiscoKey":   "discokey:b0bce3a420803a790e9374c69826417456a50376a9e0d6f12c31f9f86da81e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51755", "10.65.0.27:51755", "172.17.0.1:51755"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:56:23.429607825Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2396647086087891,
+				"StableID":   "nzLn4brSiK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       2396647086087891,
+				"Key":        "nodekey:0a44c7f1d7cc4ff3a027ec0430841314f98f23248acf3bd3528b02c52ed85806",
+				"DiscoKey":   "discokey:e768119481c35cee5914f57a4321253498c325e4630a500a2b7df81703e88b26",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60286", "10.65.0.27:60286", "172.17.0.1:60286"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:56:20.713400737Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0a44c7f1d7cc4ff3a027ec0430841314f98f23248acf3bd3528b02c52ed85806",
+			"MachineKey": "mkey:b83fac82e0a1971e814ea927f75a6ee1aeff063f5596bf5915e4693b8bab0440",
+			"Peers": [{
+				"ID":         5746798450115314,
+				"StableID":   "nuvt3jejsm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d950c80808fb5af72b6d425e3ccf725687426f98ab9f35ac1a2d572aa0d5da39",
+				"DiscoKey":   "discokey:f61a620e4058c275dfb826397cfb5541fd86773c86ef3208380b5ded6aa5d17d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56229", "10.65.0.27:56229", "172.17.0.1:56229"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:56:19.635356569Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2019943557616926,
+				"StableID":   "nomTDYVqmG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78983f5249706617ab2114952487514c8fd46dfccbeff3ae18cffe4d90955704",
+				"DiscoKey":   "discokey:5b2805ba16e42611ac9d21ed11187ab44fad469fb46dd96cd19c7da86eb0f550",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:33293", "10.65.0.27:33293", "172.17.0.1:33293"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:56:20.183152183Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2334800798516358,
+				"StableID":   "nXd5RxFSEK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ae3ef73d1b4babb0d4dff55b8bd6d424a61d98f1323746b3a9d687507d6734c",
+				"DiscoKey":   "discokey:c0df43c085a3ca7514fc3aeb7463071eb496bee659eecd4873147b4e34e1713b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53122", "10.65.0.27:53122", "172.17.0.1:53122"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:56:21.260935948Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         218548206506705,
+				"StableID":   "ngGJdftyh211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c627d97c9afc9a388aa6e7cb1c7b929b7727bbf7a0b8c21a8e49ef375cc4749",
+				"DiscoKey":   "discokey:24053ed118af7429c44d9c8170445497941dc57e5100fa041590685b10db3d23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:33693", "10.65.0.27:33693", "172.17.0.1:33693"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:56:21.779977399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3873189112829444,
+				"StableID":   "nRugnP7BFX11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:45933dc251c3018d89ffd354f9a33acab1f2663dc268d59d15ee5eadc290700e",
+				"KeyExpiry":  "2026-10-26T10:56:22Z",
+				"DiscoKey":   "discokey:dd8836d50bf9e8933c16018043a23854bf3649b1849ba61f8117b2087189fe7f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58136", "10.65.0.27:58136", "172.17.0.1:58136"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:56:22.313287681Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8597001142266879,
+				"StableID":   "n2zttEeb8A21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:53f18e5211eb12ee7ac5c105dceea48b341ad675093a64208125230a79a3f65a",
+				"KeyExpiry":  "2026-10-26T10:56:22Z",
+				"DiscoKey":   "discokey:5d8be329df797bc3861654a99f2a51a37276d4fe1a98f7f98ec15f5ec4c18672",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:50162", "10.65.0.27:50162", "172.17.0.1:50162"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:56:22.876486752Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7285107743722076,
+				"StableID":   "nhFjdmRSty11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:991b4775194b6a1c7a2ece6f688473466b87913054e42082693c8ca52b5e0979",
+				"KeyExpiry":  "2026-10-26T10:56:23Z",
+				"DiscoKey":   "discokey:b0bce3a420803a790e9374c69826417456a50376a9e0d6f12c31f9f86da81e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51755", "10.65.0.27:51755", "172.17.0.1:51755"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:56:23.429607825Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2396647086087891": {
+				"ID":          2396647086087891,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-port-shape-range.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-port-shape-range.hujson
@@ -1,0 +1,8847 @@
+// policytest-port-shape-range
+//
+// tests block port-shape: dst port range (8000-8100)
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:56:45Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-port-shape-range",
+	"description":    "tests block port-shape: dst port range (8000-8100)",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:56:45.303456393Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                              \n  \n                                                                      \n                                          \n{\n\t\"id\":          \"policytest-port-shape-range\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block port-shape: dst port range (8000-8100)\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": false},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"thor@example.org\"], \"dst\": [\"webserver:8000-8100\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"accept\": [\"webserver:8000-8100\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-port-shape-range.hujson",
+		"full_policy": {
+			"acls": [{
+				"action": "accept",
+				"dst":    ["webserver:8000-8100"],
+				"src":    ["thor@example.org"]
+			}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["webserver:8000-8100"], "src": "thor@example.org"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3396467607152915,
+				"StableID":   "ng7fnnSGXT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       3396467607152915,
+				"Key":        "nodekey:46fbe8911b754c0aa5a80df32ed93b708039b0eb4b64ae3631adade92a862f06",
+				"DiscoKey":   "discokey:7d014b9382943b99708fe3897b553d452653a81eb8a0ce2e2d10d90cc1d23d11",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:59808", "10.65.0.27:59808", "172.17.0.1:59808"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:56:49.062683271Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:46fbe8911b754c0aa5a80df32ed93b708039b0eb4b64ae3631adade92a862f06",
+			"MachineKey": "mkey:d04189278fbdb2456f72e2ff0dcb8168f133d78d9e6f6f8db7500e3a9af90157",
+			"Peers": [{
+				"ID":         7558377688744346,
+				"StableID":   "njTYuNmC2221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ab840d63b782ab25fafa203be7a104674a1bf2f34db8d9883dd532a65086400",
+				"DiscoKey":   "discokey:0727c1316d45af9a36830f2019d42efcc69b3bd1dc3469eb62504966925d3819",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34585", "10.65.0.27:34585", "172.17.0.1:34585"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:56:46.933886946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2296397784649359,
+				"StableID":   "nAtuabU3wJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e6749b97fcc8dd8ba31d125546f8ceada020871eff7e68f6df32f47b0bc997e",
+				"DiscoKey":   "discokey:4aa3957ed6b5615405353eb55222d4ee6c93bed655bfa1a535e442dee3714258",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54300", "10.65.0.27:54300", "172.17.0.1:54300"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:56:47.425991994Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1443164279246849,
+				"StableID":   "nLeSUkUcGC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0fa242e60f98a54dc6844129dea048f60363e879a5562c9a67d7dd28602d129",
+				"DiscoKey":   "discokey:8347107f62e31294c854f6eb417290a34a950d64ce25f45e01ed7bac92db4329",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57601", "10.65.0.27:57601", "172.17.0.1:57601"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:56:47.970584512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7035870875477749,
+				"StableID":   "npJN43QZww11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:acdb8c3d338587734517ed66044a2f529e576ca9b7b99e87968a349cc3d60427",
+				"DiscoKey":   "discokey:b874b5573a9caac7973532f270494fcba9982ce9708fa1e0b5dff49ea27bea28",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36355", "10.65.0.27:36355", "172.17.0.1:36355"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:56:48.543183442Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8184785213573848,
+				"StableID":   "nRquqrRuu621CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cf520e00b9a47a80feaa19d8125c5a918b1b739aaa73afa36431415f5d1e896f",
+				"KeyExpiry":  "2026-10-26T10:56:49Z",
+				"DiscoKey":   "discokey:a04235f49c036e5f140efbc9c5e6479d02bce85be8e0472e5e2d18925a12c851",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:60860", "10.65.0.27:60860", "172.17.0.1:60860"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:56:49.59014091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2655493809458214,
+				"StableID":   "ndvZdXKgjM11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:61cbd6709e1df7090184c07148c5949b8916c79a58a4ce681de120fbcc2c741f",
+				"KeyExpiry":  "2026-10-26T10:56:50Z",
+				"DiscoKey":   "discokey:873be5ce1e620411dd6500e83e8038545d5ebe6704d665d913016d5885f5181d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:35555", "10.65.0.27:35555", "172.17.0.1:35555"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:56:50.128077427Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7393802595010274,
+				"StableID":   "n3V9S5ffjz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9be3684356179842fec60d26289668dd4af8a146e8831bd172340f0a41f69703",
+				"KeyExpiry":  "2026-10-26T10:56:50Z",
+				"DiscoKey":   "discokey:932430a150bd4b07b926c870fe2d587768416cbbb0e869db58e123c163670e12",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35019", "10.65.0.27:35019", "172.17.0.1:35019"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:56:50.680700556Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3396467607152915": {
+				"ID":          3396467607152915,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7393802595010274,
+				"StableID":   "n3V9S5ffjz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9be3684356179842fec60d26289668dd4af8a146e8831bd172340f0a41f69703",
+				"KeyExpiry":  "2026-10-26T10:56:50Z",
+				"DiscoKey":   "discokey:932430a150bd4b07b926c870fe2d587768416cbbb0e869db58e123c163670e12",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35019", "10.65.0.27:35019", "172.17.0.1:35019"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:56:50.680700556Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9be3684356179842fec60d26289668dd4af8a146e8831bd172340f0a41f69703",
+			"MachineKey": "mkey:f8399100f4b73a9a413d80f24705d673b6bfe30f9335fea53fbe635eb1384078",
+			"Peers": [{
+				"ID":         7558377688744346,
+				"StableID":   "njTYuNmC2221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ab840d63b782ab25fafa203be7a104674a1bf2f34db8d9883dd532a65086400",
+				"DiscoKey":   "discokey:0727c1316d45af9a36830f2019d42efcc69b3bd1dc3469eb62504966925d3819",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34585", "10.65.0.27:34585", "172.17.0.1:34585"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:56:46.933886946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2296397784649359,
+				"StableID":   "nAtuabU3wJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e6749b97fcc8dd8ba31d125546f8ceada020871eff7e68f6df32f47b0bc997e",
+				"DiscoKey":   "discokey:4aa3957ed6b5615405353eb55222d4ee6c93bed655bfa1a535e442dee3714258",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54300", "10.65.0.27:54300", "172.17.0.1:54300"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:56:47.425991994Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1443164279246849,
+				"StableID":   "nLeSUkUcGC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0fa242e60f98a54dc6844129dea048f60363e879a5562c9a67d7dd28602d129",
+				"DiscoKey":   "discokey:8347107f62e31294c854f6eb417290a34a950d64ce25f45e01ed7bac92db4329",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57601", "10.65.0.27:57601", "172.17.0.1:57601"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:56:47.970584512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7035870875477749,
+				"StableID":   "npJN43QZww11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:acdb8c3d338587734517ed66044a2f529e576ca9b7b99e87968a349cc3d60427",
+				"DiscoKey":   "discokey:b874b5573a9caac7973532f270494fcba9982ce9708fa1e0b5dff49ea27bea28",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36355", "10.65.0.27:36355", "172.17.0.1:36355"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:56:48.543183442Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3396467607152915,
+				"StableID":   "ng7fnnSGXT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46fbe8911b754c0aa5a80df32ed93b708039b0eb4b64ae3631adade92a862f06",
+				"DiscoKey":   "discokey:7d014b9382943b99708fe3897b553d452653a81eb8a0ce2e2d10d90cc1d23d11",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:59808", "10.65.0.27:59808", "172.17.0.1:59808"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:56:49.062683271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8184785213573848,
+				"StableID":   "nRquqrRuu621CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cf520e00b9a47a80feaa19d8125c5a918b1b739aaa73afa36431415f5d1e896f",
+				"KeyExpiry":  "2026-10-26T10:56:49Z",
+				"DiscoKey":   "discokey:a04235f49c036e5f140efbc9c5e6479d02bce85be8e0472e5e2d18925a12c851",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:60860", "10.65.0.27:60860", "172.17.0.1:60860"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:56:49.59014091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2655493809458214,
+				"StableID":   "ndvZdXKgjM11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:61cbd6709e1df7090184c07148c5949b8916c79a58a4ce681de120fbcc2c741f",
+				"KeyExpiry":  "2026-10-26T10:56:50Z",
+				"DiscoKey":   "discokey:873be5ce1e620411dd6500e83e8038545d5ebe6704d665d913016d5885f5181d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:35555", "10.65.0.27:35555", "172.17.0.1:35555"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:56:50.128077427Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7558377688744346,
+				"StableID":   "njTYuNmC2221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       7558377688744346,
+				"Key":        "nodekey:7ab840d63b782ab25fafa203be7a104674a1bf2f34db8d9883dd532a65086400",
+				"DiscoKey":   "discokey:0727c1316d45af9a36830f2019d42efcc69b3bd1dc3469eb62504966925d3819",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34585", "10.65.0.27:34585", "172.17.0.1:34585"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:56:46.933886946Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7ab840d63b782ab25fafa203be7a104674a1bf2f34db8d9883dd532a65086400",
+			"MachineKey": "mkey:21d20d48d9150ab0633c8191c641a1f96340b795abb8fc57cf191cdcba045626",
+			"Peers": [{
+				"ID":         2296397784649359,
+				"StableID":   "nAtuabU3wJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e6749b97fcc8dd8ba31d125546f8ceada020871eff7e68f6df32f47b0bc997e",
+				"DiscoKey":   "discokey:4aa3957ed6b5615405353eb55222d4ee6c93bed655bfa1a535e442dee3714258",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54300", "10.65.0.27:54300", "172.17.0.1:54300"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:56:47.425991994Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1443164279246849,
+				"StableID":   "nLeSUkUcGC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0fa242e60f98a54dc6844129dea048f60363e879a5562c9a67d7dd28602d129",
+				"DiscoKey":   "discokey:8347107f62e31294c854f6eb417290a34a950d64ce25f45e01ed7bac92db4329",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57601", "10.65.0.27:57601", "172.17.0.1:57601"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:56:47.970584512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7035870875477749,
+				"StableID":   "npJN43QZww11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:acdb8c3d338587734517ed66044a2f529e576ca9b7b99e87968a349cc3d60427",
+				"DiscoKey":   "discokey:b874b5573a9caac7973532f270494fcba9982ce9708fa1e0b5dff49ea27bea28",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36355", "10.65.0.27:36355", "172.17.0.1:36355"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:56:48.543183442Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3396467607152915,
+				"StableID":   "ng7fnnSGXT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46fbe8911b754c0aa5a80df32ed93b708039b0eb4b64ae3631adade92a862f06",
+				"DiscoKey":   "discokey:7d014b9382943b99708fe3897b553d452653a81eb8a0ce2e2d10d90cc1d23d11",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:59808", "10.65.0.27:59808", "172.17.0.1:59808"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:56:49.062683271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8184785213573848,
+				"StableID":   "nRquqrRuu621CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cf520e00b9a47a80feaa19d8125c5a918b1b739aaa73afa36431415f5d1e896f",
+				"KeyExpiry":  "2026-10-26T10:56:49Z",
+				"DiscoKey":   "discokey:a04235f49c036e5f140efbc9c5e6479d02bce85be8e0472e5e2d18925a12c851",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:60860", "10.65.0.27:60860", "172.17.0.1:60860"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:56:49.59014091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2655493809458214,
+				"StableID":   "ndvZdXKgjM11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:61cbd6709e1df7090184c07148c5949b8916c79a58a4ce681de120fbcc2c741f",
+				"KeyExpiry":  "2026-10-26T10:56:50Z",
+				"DiscoKey":   "discokey:873be5ce1e620411dd6500e83e8038545d5ebe6704d665d913016d5885f5181d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:35555", "10.65.0.27:35555", "172.17.0.1:35555"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:56:50.128077427Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7393802595010274,
+				"StableID":   "n3V9S5ffjz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9be3684356179842fec60d26289668dd4af8a146e8831bd172340f0a41f69703",
+				"KeyExpiry":  "2026-10-26T10:56:50Z",
+				"DiscoKey":   "discokey:932430a150bd4b07b926c870fe2d587768416cbbb0e869db58e123c163670e12",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35019", "10.65.0.27:35019", "172.17.0.1:35019"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:56:50.680700556Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7558377688744346": {
+				"ID":          7558377688744346,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8184785213573848,
+				"StableID":   "nRquqrRuu621CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cf520e00b9a47a80feaa19d8125c5a918b1b739aaa73afa36431415f5d1e896f",
+				"KeyExpiry":  "2026-10-26T10:56:49Z",
+				"DiscoKey":   "discokey:a04235f49c036e5f140efbc9c5e6479d02bce85be8e0472e5e2d18925a12c851",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:60860", "10.65.0.27:60860", "172.17.0.1:60860"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:56:49.59014091Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cf520e00b9a47a80feaa19d8125c5a918b1b739aaa73afa36431415f5d1e896f",
+			"MachineKey": "mkey:8195fafe148d0c5859b1aa2183bce2d4fad4c77bbf4dba5a86c0e5c1b32fb205",
+			"Peers": [{
+				"ID":         7558377688744346,
+				"StableID":   "njTYuNmC2221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ab840d63b782ab25fafa203be7a104674a1bf2f34db8d9883dd532a65086400",
+				"DiscoKey":   "discokey:0727c1316d45af9a36830f2019d42efcc69b3bd1dc3469eb62504966925d3819",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34585", "10.65.0.27:34585", "172.17.0.1:34585"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:56:46.933886946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2296397784649359,
+				"StableID":   "nAtuabU3wJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e6749b97fcc8dd8ba31d125546f8ceada020871eff7e68f6df32f47b0bc997e",
+				"DiscoKey":   "discokey:4aa3957ed6b5615405353eb55222d4ee6c93bed655bfa1a535e442dee3714258",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54300", "10.65.0.27:54300", "172.17.0.1:54300"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:56:47.425991994Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1443164279246849,
+				"StableID":   "nLeSUkUcGC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0fa242e60f98a54dc6844129dea048f60363e879a5562c9a67d7dd28602d129",
+				"DiscoKey":   "discokey:8347107f62e31294c854f6eb417290a34a950d64ce25f45e01ed7bac92db4329",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57601", "10.65.0.27:57601", "172.17.0.1:57601"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:56:47.970584512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7035870875477749,
+				"StableID":   "npJN43QZww11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:acdb8c3d338587734517ed66044a2f529e576ca9b7b99e87968a349cc3d60427",
+				"DiscoKey":   "discokey:b874b5573a9caac7973532f270494fcba9982ce9708fa1e0b5dff49ea27bea28",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36355", "10.65.0.27:36355", "172.17.0.1:36355"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:56:48.543183442Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3396467607152915,
+				"StableID":   "ng7fnnSGXT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46fbe8911b754c0aa5a80df32ed93b708039b0eb4b64ae3631adade92a862f06",
+				"DiscoKey":   "discokey:7d014b9382943b99708fe3897b553d452653a81eb8a0ce2e2d10d90cc1d23d11",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:59808", "10.65.0.27:59808", "172.17.0.1:59808"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:56:49.062683271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2655493809458214,
+				"StableID":   "ndvZdXKgjM11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:61cbd6709e1df7090184c07148c5949b8916c79a58a4ce681de120fbcc2c741f",
+				"KeyExpiry":  "2026-10-26T10:56:50Z",
+				"DiscoKey":   "discokey:873be5ce1e620411dd6500e83e8038545d5ebe6704d665d913016d5885f5181d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:35555", "10.65.0.27:35555", "172.17.0.1:35555"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:56:50.128077427Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7393802595010274,
+				"StableID":   "n3V9S5ffjz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9be3684356179842fec60d26289668dd4af8a146e8831bd172340f0a41f69703",
+				"KeyExpiry":  "2026-10-26T10:56:50Z",
+				"DiscoKey":   "discokey:932430a150bd4b07b926c870fe2d587768416cbbb0e869db58e123c163670e12",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35019", "10.65.0.27:35019", "172.17.0.1:35019"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:56:50.680700556Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7035870875477749,
+				"StableID":   "npJN43QZww11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       7035870875477749,
+				"Key":        "nodekey:acdb8c3d338587734517ed66044a2f529e576ca9b7b99e87968a349cc3d60427",
+				"DiscoKey":   "discokey:b874b5573a9caac7973532f270494fcba9982ce9708fa1e0b5dff49ea27bea28",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36355", "10.65.0.27:36355", "172.17.0.1:36355"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:56:48.543183442Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:acdb8c3d338587734517ed66044a2f529e576ca9b7b99e87968a349cc3d60427",
+			"MachineKey": "mkey:4ea5a3d9107ff00ae4a64d6a2811fa6c8cbd3b3eb7d00df0a292615e566a9737",
+			"Peers": [{
+				"ID":         7558377688744346,
+				"StableID":   "njTYuNmC2221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ab840d63b782ab25fafa203be7a104674a1bf2f34db8d9883dd532a65086400",
+				"DiscoKey":   "discokey:0727c1316d45af9a36830f2019d42efcc69b3bd1dc3469eb62504966925d3819",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34585", "10.65.0.27:34585", "172.17.0.1:34585"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:56:46.933886946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2296397784649359,
+				"StableID":   "nAtuabU3wJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e6749b97fcc8dd8ba31d125546f8ceada020871eff7e68f6df32f47b0bc997e",
+				"DiscoKey":   "discokey:4aa3957ed6b5615405353eb55222d4ee6c93bed655bfa1a535e442dee3714258",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54300", "10.65.0.27:54300", "172.17.0.1:54300"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:56:47.425991994Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1443164279246849,
+				"StableID":   "nLeSUkUcGC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0fa242e60f98a54dc6844129dea048f60363e879a5562c9a67d7dd28602d129",
+				"DiscoKey":   "discokey:8347107f62e31294c854f6eb417290a34a950d64ce25f45e01ed7bac92db4329",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57601", "10.65.0.27:57601", "172.17.0.1:57601"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:56:47.970584512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3396467607152915,
+				"StableID":   "ng7fnnSGXT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46fbe8911b754c0aa5a80df32ed93b708039b0eb4b64ae3631adade92a862f06",
+				"DiscoKey":   "discokey:7d014b9382943b99708fe3897b553d452653a81eb8a0ce2e2d10d90cc1d23d11",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:59808", "10.65.0.27:59808", "172.17.0.1:59808"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:56:49.062683271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8184785213573848,
+				"StableID":   "nRquqrRuu621CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cf520e00b9a47a80feaa19d8125c5a918b1b739aaa73afa36431415f5d1e896f",
+				"KeyExpiry":  "2026-10-26T10:56:49Z",
+				"DiscoKey":   "discokey:a04235f49c036e5f140efbc9c5e6479d02bce85be8e0472e5e2d18925a12c851",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:60860", "10.65.0.27:60860", "172.17.0.1:60860"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:56:49.59014091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2655493809458214,
+				"StableID":   "ndvZdXKgjM11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:61cbd6709e1df7090184c07148c5949b8916c79a58a4ce681de120fbcc2c741f",
+				"KeyExpiry":  "2026-10-26T10:56:50Z",
+				"DiscoKey":   "discokey:873be5ce1e620411dd6500e83e8038545d5ebe6704d665d913016d5885f5181d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:35555", "10.65.0.27:35555", "172.17.0.1:35555"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:56:50.128077427Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7393802595010274,
+				"StableID":   "n3V9S5ffjz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9be3684356179842fec60d26289668dd4af8a146e8831bd172340f0a41f69703",
+				"KeyExpiry":  "2026-10-26T10:56:50Z",
+				"DiscoKey":   "discokey:932430a150bd4b07b926c870fe2d587768416cbbb0e869db58e123c163670e12",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35019", "10.65.0.27:35019", "172.17.0.1:35019"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:56:50.680700556Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7035870875477749": {
+				"ID":          7035870875477749,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2296397784649359,
+				"StableID":   "nAtuabU3wJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       2296397784649359,
+				"Key":        "nodekey:2e6749b97fcc8dd8ba31d125546f8ceada020871eff7e68f6df32f47b0bc997e",
+				"DiscoKey":   "discokey:4aa3957ed6b5615405353eb55222d4ee6c93bed655bfa1a535e442dee3714258",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54300", "10.65.0.27:54300", "172.17.0.1:54300"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:56:47.425991994Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2e6749b97fcc8dd8ba31d125546f8ceada020871eff7e68f6df32f47b0bc997e",
+			"MachineKey": "mkey:aa018180f061e81c7de311e1c86409b88283d592de721bbab3146c7d53d86b2a",
+			"Peers": [{
+				"ID":         7558377688744346,
+				"StableID":   "njTYuNmC2221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ab840d63b782ab25fafa203be7a104674a1bf2f34db8d9883dd532a65086400",
+				"DiscoKey":   "discokey:0727c1316d45af9a36830f2019d42efcc69b3bd1dc3469eb62504966925d3819",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34585", "10.65.0.27:34585", "172.17.0.1:34585"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:56:46.933886946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1443164279246849,
+				"StableID":   "nLeSUkUcGC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0fa242e60f98a54dc6844129dea048f60363e879a5562c9a67d7dd28602d129",
+				"DiscoKey":   "discokey:8347107f62e31294c854f6eb417290a34a950d64ce25f45e01ed7bac92db4329",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57601", "10.65.0.27:57601", "172.17.0.1:57601"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:56:47.970584512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7035870875477749,
+				"StableID":   "npJN43QZww11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:acdb8c3d338587734517ed66044a2f529e576ca9b7b99e87968a349cc3d60427",
+				"DiscoKey":   "discokey:b874b5573a9caac7973532f270494fcba9982ce9708fa1e0b5dff49ea27bea28",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36355", "10.65.0.27:36355", "172.17.0.1:36355"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:56:48.543183442Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3396467607152915,
+				"StableID":   "ng7fnnSGXT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46fbe8911b754c0aa5a80df32ed93b708039b0eb4b64ae3631adade92a862f06",
+				"DiscoKey":   "discokey:7d014b9382943b99708fe3897b553d452653a81eb8a0ce2e2d10d90cc1d23d11",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:59808", "10.65.0.27:59808", "172.17.0.1:59808"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:56:49.062683271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8184785213573848,
+				"StableID":   "nRquqrRuu621CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cf520e00b9a47a80feaa19d8125c5a918b1b739aaa73afa36431415f5d1e896f",
+				"KeyExpiry":  "2026-10-26T10:56:49Z",
+				"DiscoKey":   "discokey:a04235f49c036e5f140efbc9c5e6479d02bce85be8e0472e5e2d18925a12c851",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:60860", "10.65.0.27:60860", "172.17.0.1:60860"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:56:49.59014091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2655493809458214,
+				"StableID":   "ndvZdXKgjM11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:61cbd6709e1df7090184c07148c5949b8916c79a58a4ce681de120fbcc2c741f",
+				"KeyExpiry":  "2026-10-26T10:56:50Z",
+				"DiscoKey":   "discokey:873be5ce1e620411dd6500e83e8038545d5ebe6704d665d913016d5885f5181d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:35555", "10.65.0.27:35555", "172.17.0.1:35555"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:56:50.128077427Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7393802595010274,
+				"StableID":   "n3V9S5ffjz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9be3684356179842fec60d26289668dd4af8a146e8831bd172340f0a41f69703",
+				"KeyExpiry":  "2026-10-26T10:56:50Z",
+				"DiscoKey":   "discokey:932430a150bd4b07b926c870fe2d587768416cbbb0e869db58e123c163670e12",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35019", "10.65.0.27:35019", "172.17.0.1:35019"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:56:50.680700556Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2296397784649359": {
+				"ID":          2296397784649359,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2655493809458214,
+				"StableID":   "ndvZdXKgjM11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:61cbd6709e1df7090184c07148c5949b8916c79a58a4ce681de120fbcc2c741f",
+				"KeyExpiry":  "2026-10-26T10:56:50Z",
+				"DiscoKey":   "discokey:873be5ce1e620411dd6500e83e8038545d5ebe6704d665d913016d5885f5181d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:35555", "10.65.0.27:35555", "172.17.0.1:35555"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:56:50.128077427Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:61cbd6709e1df7090184c07148c5949b8916c79a58a4ce681de120fbcc2c741f",
+			"MachineKey": "mkey:384e0dd4b8b155baee5a13e7fc2adfb568acb0f05cd492522d927a22f762002b",
+			"Peers": [{
+				"ID":         7558377688744346,
+				"StableID":   "njTYuNmC2221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ab840d63b782ab25fafa203be7a104674a1bf2f34db8d9883dd532a65086400",
+				"DiscoKey":   "discokey:0727c1316d45af9a36830f2019d42efcc69b3bd1dc3469eb62504966925d3819",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34585", "10.65.0.27:34585", "172.17.0.1:34585"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:56:46.933886946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2296397784649359,
+				"StableID":   "nAtuabU3wJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e6749b97fcc8dd8ba31d125546f8ceada020871eff7e68f6df32f47b0bc997e",
+				"DiscoKey":   "discokey:4aa3957ed6b5615405353eb55222d4ee6c93bed655bfa1a535e442dee3714258",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54300", "10.65.0.27:54300", "172.17.0.1:54300"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:56:47.425991994Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1443164279246849,
+				"StableID":   "nLeSUkUcGC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0fa242e60f98a54dc6844129dea048f60363e879a5562c9a67d7dd28602d129",
+				"DiscoKey":   "discokey:8347107f62e31294c854f6eb417290a34a950d64ce25f45e01ed7bac92db4329",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57601", "10.65.0.27:57601", "172.17.0.1:57601"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:56:47.970584512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7035870875477749,
+				"StableID":   "npJN43QZww11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:acdb8c3d338587734517ed66044a2f529e576ca9b7b99e87968a349cc3d60427",
+				"DiscoKey":   "discokey:b874b5573a9caac7973532f270494fcba9982ce9708fa1e0b5dff49ea27bea28",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36355", "10.65.0.27:36355", "172.17.0.1:36355"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:56:48.543183442Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3396467607152915,
+				"StableID":   "ng7fnnSGXT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46fbe8911b754c0aa5a80df32ed93b708039b0eb4b64ae3631adade92a862f06",
+				"DiscoKey":   "discokey:7d014b9382943b99708fe3897b553d452653a81eb8a0ce2e2d10d90cc1d23d11",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:59808", "10.65.0.27:59808", "172.17.0.1:59808"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:56:49.062683271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8184785213573848,
+				"StableID":   "nRquqrRuu621CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cf520e00b9a47a80feaa19d8125c5a918b1b739aaa73afa36431415f5d1e896f",
+				"KeyExpiry":  "2026-10-26T10:56:49Z",
+				"DiscoKey":   "discokey:a04235f49c036e5f140efbc9c5e6479d02bce85be8e0472e5e2d18925a12c851",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:60860", "10.65.0.27:60860", "172.17.0.1:60860"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:56:49.59014091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7393802595010274,
+				"StableID":   "n3V9S5ffjz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9be3684356179842fec60d26289668dd4af8a146e8831bd172340f0a41f69703",
+				"KeyExpiry":  "2026-10-26T10:56:50Z",
+				"DiscoKey":   "discokey:932430a150bd4b07b926c870fe2d587768416cbbb0e869db58e123c163670e12",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35019", "10.65.0.27:35019", "172.17.0.1:35019"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:56:50.680700556Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1443164279246849,
+				"StableID":   "nLeSUkUcGC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1443164279246849,
+				"Key":        "nodekey:d0fa242e60f98a54dc6844129dea048f60363e879a5562c9a67d7dd28602d129",
+				"DiscoKey":   "discokey:8347107f62e31294c854f6eb417290a34a950d64ce25f45e01ed7bac92db4329",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:57601", "10.65.0.27:57601", "172.17.0.1:57601"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:56:47.970584512Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d0fa242e60f98a54dc6844129dea048f60363e879a5562c9a67d7dd28602d129",
+			"MachineKey": "mkey:34593e3c5b6eb6b3cbf028a1a009285179dbf913cb3017d5dde577bf3e010853",
+			"Peers": [{
+				"ID":         7558377688744346,
+				"StableID":   "njTYuNmC2221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ab840d63b782ab25fafa203be7a104674a1bf2f34db8d9883dd532a65086400",
+				"DiscoKey":   "discokey:0727c1316d45af9a36830f2019d42efcc69b3bd1dc3469eb62504966925d3819",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34585", "10.65.0.27:34585", "172.17.0.1:34585"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:56:46.933886946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2296397784649359,
+				"StableID":   "nAtuabU3wJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e6749b97fcc8dd8ba31d125546f8ceada020871eff7e68f6df32f47b0bc997e",
+				"DiscoKey":   "discokey:4aa3957ed6b5615405353eb55222d4ee6c93bed655bfa1a535e442dee3714258",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54300", "10.65.0.27:54300", "172.17.0.1:54300"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:56:47.425991994Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7035870875477749,
+				"StableID":   "npJN43QZww11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:acdb8c3d338587734517ed66044a2f529e576ca9b7b99e87968a349cc3d60427",
+				"DiscoKey":   "discokey:b874b5573a9caac7973532f270494fcba9982ce9708fa1e0b5dff49ea27bea28",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36355", "10.65.0.27:36355", "172.17.0.1:36355"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:56:48.543183442Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3396467607152915,
+				"StableID":   "ng7fnnSGXT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46fbe8911b754c0aa5a80df32ed93b708039b0eb4b64ae3631adade92a862f06",
+				"DiscoKey":   "discokey:7d014b9382943b99708fe3897b553d452653a81eb8a0ce2e2d10d90cc1d23d11",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:59808", "10.65.0.27:59808", "172.17.0.1:59808"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:56:49.062683271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8184785213573848,
+				"StableID":   "nRquqrRuu621CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cf520e00b9a47a80feaa19d8125c5a918b1b739aaa73afa36431415f5d1e896f",
+				"KeyExpiry":  "2026-10-26T10:56:49Z",
+				"DiscoKey":   "discokey:a04235f49c036e5f140efbc9c5e6479d02bce85be8e0472e5e2d18925a12c851",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:60860", "10.65.0.27:60860", "172.17.0.1:60860"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:56:49.59014091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2655493809458214,
+				"StableID":   "ndvZdXKgjM11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:61cbd6709e1df7090184c07148c5949b8916c79a58a4ce681de120fbcc2c741f",
+				"KeyExpiry":  "2026-10-26T10:56:50Z",
+				"DiscoKey":   "discokey:873be5ce1e620411dd6500e83e8038545d5ebe6704d665d913016d5885f5181d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:35555", "10.65.0.27:35555", "172.17.0.1:35555"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:56:50.128077427Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7393802595010274,
+				"StableID":   "n3V9S5ffjz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9be3684356179842fec60d26289668dd4af8a146e8831bd172340f0a41f69703",
+				"KeyExpiry":  "2026-10-26T10:56:50Z",
+				"DiscoKey":   "discokey:932430a150bd4b07b926c870fe2d587768416cbbb0e869db58e123c163670e12",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35019", "10.65.0.27:35019", "172.17.0.1:35019"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:56:50.680700556Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1443164279246849": {
+				"ID":          1443164279246849,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-port-shape-single.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-port-shape-single.hujson
@@ -1,0 +1,7229 @@
+// policytest-port-shape-single
+//
+// tests block port-shape: single dst port
+//
+// Nodes with filter rules: 1 of 8
+// Captured at:    2026-04-29T10:57:12Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-port-shape-single",
+	"description":    "tests block port-shape: single dst port",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:57:12.390714357Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                               \n  \n                                                                       \n                                              \n{\n\t\"id\":          \"policytest-port-shape-single\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block port-shape: single dst port\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": false},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"thor@example.org\"], \"dst\": [\"webserver:80\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"accept\": [\"webserver:80\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-port-shape-single.hujson",
+		"full_policy": {"acls": [
+			{"action": "accept", "dst": ["webserver:80"], "src": ["thor@example.org"]}
+		], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [{"accept": ["webserver:80"], "src": "thor@example.org"}]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {"packet_filter_rules": [{
+		"SrcIPs":   ["100.64.0.17", "fd7a:115c:a1e0::11"],
+		"DstPorts": [{"IP": "100.64.0.16", "Ports": {"First": 80, "Last": 80}}]
+	}], "packet_filter_matches": [{
+		"IPProto": [6, 17, 1, 58],
+		"Srcs":    ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+		"SrcCaps": null,
+		"Dsts":    [{"Net": "100.64.0.16/32", "Ports": {"First": 80, "Last": 80}}],
+		"Caps":    []
+	}], "netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         3287548964604881,
+			"StableID":   "nA7YKXLwfS11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       3287548964604881,
+			"Key":        "nodekey:ef90cc0977498cfe2b40e0b13303fa49d17518c12185af100c17fe6c71fc5060",
+			"DiscoKey":   "discokey:1b2acc3b2fced7365bb96e43d23f9faaf1ce0962bcf036adc237dbb52b762329",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints":  ["77.164.248.136:42172", "10.65.0.27:42172", "172.17.0.1:42172"],
+			"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:57:16.017683362Z",
+			"Tags":              ["tag:server"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:ef90cc0977498cfe2b40e0b13303fa49d17518c12185af100c17fe6c71fc5060",
+		"MachineKey": "mkey:315306e277d1bbcb255ea4a4761360f3bb1ddd31e54a270182531d65ab06746c",
+		"Peers": [{
+			"ID":         310851264785900,
+			"StableID":   "n9Rvo4YnR311CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:79f0de68ca30c39f6f9ebdbf3f3ff317134b353f8b49d2fdb8ec343057092304",
+			"KeyExpiry":  "2026-10-26T10:57:16Z",
+			"DiscoKey":   "discokey:93281df60303c5b410b59690837781b7d968a4dcd17f28b2864faab2f2a74238",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints":  ["77.164.248.136:55217", "10.65.0.27:55217", "172.17.0.1:55217"],
+			"HomeDERP":   14,
+			"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496}
+			]},
+			"Created":              "2026-04-29T10:57:16.569874918Z",
+			"Cap":                  131,
+			"Online":               true,
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		}],
+		"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter": [{
+			"IPProto": [6, 17, 1, 58],
+			"Srcs":    ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"SrcCaps": null,
+			"Dsts":    [{"Net": "100.64.0.16/32", "Ports": {"First": 80, "Last": 80}}],
+			"Caps":    []
+		}],
+		"PacketFilterRules": [{
+			"SrcIPs":   ["100.64.0.17", "fd7a:115c:a1e0::11"],
+			"DstPorts": [{"IP": "100.64.0.16", "Ports": {"First": 80, "Last": 80}}]
+		}],
+		"SSHPolicy":       {"rules": []},
+		"CollectServices": false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3287548964604881": {
+			"ID":          3287548964604881,
+			"LoginName":   "beedrill.tail78f774.ts.net",
+			"DisplayName": "beedrill"
+		}, "4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}}
+	}}, "bulbasaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2384040920855507,
+			"StableID":   "naxrQKijcK11CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:aa217cf1bbafd75bace1bf2a0e499f900dce04ce1a72688d6f138619788e3d7f",
+			"KeyExpiry":  "2026-10-26T10:57:17Z",
+			"DiscoKey":   "discokey:c283fe746ec03e59c6ad117c4ecfac5115ee94a5db190f8dc75edfe1e3a57428",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints":  ["77.164.248.136:55790", "10.65.0.27:55790", "172.17.0.1:55790"],
+			"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:57:17.64280469Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:aa217cf1bbafd75bace1bf2a0e499f900dce04ce1a72688d6f138619788e3d7f",
+		"MachineKey":        "mkey:4f54dfbe4880912aa2e11d7a7ae97fc364b4c2be9f514b83b20531959892321a",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}}
+	}}, "charmander": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7931241969427595,
+			"StableID":   "nW8Ra6H5w421CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       7931241969427595,
+			"Key":        "nodekey:ec61ff8ab01bea319da457eb54b0b60d3c3dcff9638732b89c7b8f7dff1b4153",
+			"DiscoKey":   "discokey:80b61c65e3d62aa30c0464e6414a6737b606864622962f0f60f178d902a23601",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"Endpoints":  ["77.164.248.136:49036", "10.65.0.27:49036", "172.17.0.1:49036"],
+			"Hostinfo": {
+				"Hostname":    "charmander",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T10:57:13.899448741Z",
+			"Tags":              ["tag:exit"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:ec61ff8ab01bea319da457eb54b0b60d3c3dcff9638732b89c7b8f7dff1b4153",
+		"MachineKey":        "mkey:b47f9c774e02ab10204747e1a51b1824775e795c3e94dd17af92d89e603f5a66",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"7931241969427595": {
+			"ID":          7931241969427595,
+			"LoginName":   "charmander.tail78f774.ts.net",
+			"DisplayName": "charmander"
+		}}
+	}}, "ivysaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         310851264785900,
+			"StableID":   "n9Rvo4YnR311CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:79f0de68ca30c39f6f9ebdbf3f3ff317134b353f8b49d2fdb8ec343057092304",
+			"KeyExpiry":  "2026-10-26T10:57:16Z",
+			"DiscoKey":   "discokey:93281df60303c5b410b59690837781b7d968a4dcd17f28b2864faab2f2a74238",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints":  ["77.164.248.136:55217", "10.65.0.27:55217", "172.17.0.1:55217"],
+			"Hostinfo": {"Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:57:16.569874918Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:79f0de68ca30c39f6f9ebdbf3f3ff317134b353f8b49d2fdb8ec343057092304",
+		"MachineKey": "mkey:106d615fcd6f77aab5fa5a4923e7ca3809aa958d8bc65311f97313778715fe55",
+		"Peers": [{
+			"ID":         3287548964604881,
+			"StableID":   "nA7YKXLwfS11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:ef90cc0977498cfe2b40e0b13303fa49d17518c12185af100c17fe6c71fc5060",
+			"DiscoKey":   "discokey:1b2acc3b2fced7365bb96e43d23f9faaf1ce0962bcf036adc237dbb52b762329",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints":  ["77.164.248.136:42172", "10.65.0.27:42172", "172.17.0.1:42172"],
+			"HomeDERP":   14,
+			"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358}
+			]},
+			"Created":              "2026-04-29T10:57:16.017683362Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:server"],
+			"Online":               true,
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}}
+	}}, "kakuna": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1596742964806427,
+			"StableID":   "nCTc1MjAUD11CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       1596742964806427,
+			"Key":        "nodekey:923e8e243d851940948b077a53b665087a4e1d887fffc33a40da57e51b673222",
+			"DiscoKey":   "discokey:0f5275c455add2826fd3412ae285464588ced9bf68ad03c9e4c7accd627a540b",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints":  ["77.164.248.136:51589", "10.65.0.27:51589", "172.17.0.1:51589"],
+			"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:57:15.496639805Z",
+			"Tags":              ["tag:prod"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:923e8e243d851940948b077a53b665087a4e1d887fffc33a40da57e51b673222",
+		"MachineKey":        "mkey:1249faee40a3b249b382f7eafe7b24870ae6c415b2ac493a563194831f99de18",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1596742964806427": {
+			"ID":          1596742964806427,
+			"LoginName":   "kakuna.tail78f774.ts.net",
+			"DisplayName": "kakuna"
+		}}
+	}}, "squirtle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1815424966013994,
+			"StableID":   "n9xicr8DBF11CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       1815424966013994,
+			"Key":        "nodekey:ef00c2965cfd7396e70d0748b2ac815046c8d10f3712d4446238810ab1357f53",
+			"DiscoKey":   "discokey:442ad59611c655507d20ca34872fa165273a513aec2c8aba20abf09de24c8418",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"Endpoints":  ["77.164.248.136:49883", "10.65.0.27:49883", "172.17.0.1:49883"],
+			"Hostinfo": {
+				"Hostname":    "squirtle",
+				"RoutableIPs": ["10.33.0.0/16"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T10:57:14.400596276Z",
+			"Tags":              ["tag:router"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:ef00c2965cfd7396e70d0748b2ac815046c8d10f3712d4446238810ab1357f53",
+		"MachineKey":        "mkey:024e9ec28c1fa20bbdc2afde5e85b6cbd6f6f8495ea29459a8ebb15307a44653",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1815424966013994": {
+			"ID":          1815424966013994,
+			"LoginName":   "squirtle.tail78f774.ts.net",
+			"DisplayName": "squirtle"
+		}}
+	}}, "venusaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7566590203113282,
+			"StableID":   "nDeLgeVv5221CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:4c51a37f360f319b7303213eaffcf1d6536cf7b7dd1c39361cf4654c6631d96c",
+			"KeyExpiry":  "2026-10-26T10:57:17Z",
+			"DiscoKey":   "discokey:32886ecd545e397e023425294b289fab76f488935b7ac919ccd0da5fbf658f21",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints":  ["77.164.248.136:54208", "10.65.0.27:54208", "172.17.0.1:54208"],
+			"Hostinfo": {"Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:57:17.092705223Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:4c51a37f360f319b7303213eaffcf1d6536cf7b7dd1c39361cf4654c6631d96c",
+		"MachineKey":        "mkey:eb7be9248da7e989fc41b884f54695dccd88277d06dbe615b66d0139eface41b",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}}
+	}}, "weedle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2440954824309878,
+			"StableID":   "njKhAAkW4L11CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       2440954824309878,
+			"Key":        "nodekey:a2c950cf55e805f164595dfb3a79daebaba9519c2fff4fe8de81bed767b9823c",
+			"DiscoKey":   "discokey:67a2b32b5bf6d920c487dcec37a961718c290eeb745019caa3e289912f93807f",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints":  ["77.164.248.136:40305", "10.65.0.27:40305", "172.17.0.1:40305"],
+			"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:57:14.938410413Z",
+			"Tags":              ["tag:client"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:a2c950cf55e805f164595dfb3a79daebaba9519c2fff4fe8de81bed767b9823c",
+		"MachineKey":        "mkey:738c5a49059b0e302edf1966e6178ad44975ab79b7e576902a37b01dc5acee68",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"2440954824309878": {
+			"ID":          2440954824309878,
+			"LoginName":   "weedle.tail78f774.ts.net",
+			"DisplayName": "weedle"
+		}}
+	}}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-port-shape-wildcard.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-port-shape-wildcard.hujson
@@ -1,0 +1,8839 @@
+// policytest-port-shape-wildcard
+//
+// tests block port-shape: dst port wildcard (*)
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:57:48Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-port-shape-wildcard",
+	"description":    "tests block port-shape: dst port wildcard (*)",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:57:48.449221379Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                 \n  \n                                                                     \n                                           \n{\n\t\"id\":          \"policytest-port-shape-wildcard\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block port-shape: dst port wildcard (*)\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": false},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"thor@example.org\"], \"dst\": [\"webserver:*\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"accept\": [\"webserver:*\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-port-shape-wildcard.hujson",
+		"full_policy": {"acls": [
+			{"action": "accept", "dst": ["webserver:*"], "src": ["thor@example.org"]}
+		], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [{"accept": ["webserver:*"], "src": "thor@example.org"}]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5341759814479084,
+				"StableID":   "n7StoPyHii11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       5341759814479084,
+				"Key":        "nodekey:e41975d1edf0bea543502ae8e8577225e081356903496be7cb83cd5bbb322654",
+				"DiscoKey":   "discokey:abd2e2b16eac1fcb4cc1073efdb0889d7eb60c20ae83fce14e73e1f6111c0224",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:56096", "10.65.0.27:56096", "172.17.0.1:56096"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:58:12.279078705Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e41975d1edf0bea543502ae8e8577225e081356903496be7cb83cd5bbb322654",
+			"MachineKey": "mkey:d94f29837e177e4a367b859928a58e75c91d59cbbc47178e24335fe28a8c136f",
+			"Peers": [{
+				"ID":         4589275789633880,
+				"StableID":   "n1h1JbVVqc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25c0b2412fa4eaf06ceb301cd3dfa99fe7d45dd2e8b590f007d64d87b57d1c1f",
+				"DiscoKey":   "discokey:5290603cf9df856d3f0f05295b86f45d1a9c8ac265876ad8fd61fcf3e7359954",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:58181", "10.65.0.27:58181", "172.17.0.1:58181"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:57:56.019189124Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8310794873167203,
+				"StableID":   "ntKnxLVyt721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b59abb2ffb5d06c2b9e320ac87d8d7285e4fab6ade6ef45ba866457f1c3a4153",
+				"DiscoKey":   "discokey:2f114a5c6a45de4a322e7bcb939e66d37656eda453deeeca9e16544f8a500e4f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:38060", "10.65.0.27:38060", "172.17.0.1:38060"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:57:57.424027999Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2332132382322990,
+				"StableID":   "noZbcTAEDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83b3ffb3ce90d4f6faeaf27a07f0ad63aa17d6ed1faeedc0f8c1161ad2e11837",
+				"DiscoKey":   "discokey:7b381f441100d01bb322fd6ce33ad3973238e693038036116a7a96a6198dc406",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:39041", "10.65.0.27:39041", "172.17.0.1:39041"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:58:02.208397239Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7377237862471417,
+				"StableID":   "nCJ4kgXAcz11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0896ce8a1833d51a7b2ce4e15cb3d1fd5b41163e4135722aaae68b19e44fe04a",
+				"DiscoKey":   "discokey:b971d47d118d18af1b30ee31a45685a7a1c4ca2392b9f7845a0af2169edf9d17",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:42122", "10.65.0.27:42122", "172.17.0.1:42122"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:58:09.700011041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5409461165872024,
+				"StableID":   "njt7QaNxEj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d9410feac4e9bbd9f91aa338356c336527675197c72a8cfd6b551a010daa625",
+				"KeyExpiry":  "2026-10-26T10:58:13Z",
+				"DiscoKey":   "discokey:a6742fc609412e2f9532999ebbc4d4426008664b0bc7dff0d51ebe053909b120",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38559", "10.65.0.27:38559", "172.17.0.1:38559"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:58:13.157598916Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4447032378360071,
+				"StableID":   "nt1U8zz4jb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dda9c9c92521623739af6070c51538fda70fe09e8bc2cea8ecf6088c5a8ef973",
+				"KeyExpiry":  "2026-10-26T10:58:14Z",
+				"DiscoKey":   "discokey:cd60d32beaec8a9d856ec5c068e0c1cb5b6989946d710f383d46186d9f7e7b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48009", "10.65.0.27:48009", "172.17.0.1:48009"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:58:14.549275052Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7091447953578408,
+				"StableID":   "nwJq89KjNx11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2b96995c41264d24905ef5e25108c802615e36340286f77215562a57ac01bf2f",
+				"KeyExpiry":  "2026-10-26T10:58:15Z",
+				"DiscoKey":   "discokey:54704cd8dfd1035c5b3baac5211c71b25fcb5200fac8747234c5b6a53ebbcd61",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:45857", "10.65.0.27:45857", "172.17.0.1:45857"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:58:15.204403484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5341759814479084": {
+				"ID":          5341759814479084,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7091447953578408,
+				"StableID":   "nwJq89KjNx11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2b96995c41264d24905ef5e25108c802615e36340286f77215562a57ac01bf2f",
+				"KeyExpiry":  "2026-10-26T10:58:15Z",
+				"DiscoKey":   "discokey:54704cd8dfd1035c5b3baac5211c71b25fcb5200fac8747234c5b6a53ebbcd61",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:45857", "10.65.0.27:45857", "172.17.0.1:45857"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:58:15.204403484Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2b96995c41264d24905ef5e25108c802615e36340286f77215562a57ac01bf2f",
+			"MachineKey": "mkey:cf77fdde145dcbbc949c9c28e8eac2b59707a36f5b11057455fd2e8302977c4d",
+			"Peers": [{
+				"ID":         4589275789633880,
+				"StableID":   "n1h1JbVVqc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25c0b2412fa4eaf06ceb301cd3dfa99fe7d45dd2e8b590f007d64d87b57d1c1f",
+				"DiscoKey":   "discokey:5290603cf9df856d3f0f05295b86f45d1a9c8ac265876ad8fd61fcf3e7359954",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:58181", "10.65.0.27:58181", "172.17.0.1:58181"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:57:56.019189124Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8310794873167203,
+				"StableID":   "ntKnxLVyt721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b59abb2ffb5d06c2b9e320ac87d8d7285e4fab6ade6ef45ba866457f1c3a4153",
+				"DiscoKey":   "discokey:2f114a5c6a45de4a322e7bcb939e66d37656eda453deeeca9e16544f8a500e4f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:38060", "10.65.0.27:38060", "172.17.0.1:38060"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:57:57.424027999Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2332132382322990,
+				"StableID":   "noZbcTAEDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83b3ffb3ce90d4f6faeaf27a07f0ad63aa17d6ed1faeedc0f8c1161ad2e11837",
+				"DiscoKey":   "discokey:7b381f441100d01bb322fd6ce33ad3973238e693038036116a7a96a6198dc406",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:39041", "10.65.0.27:39041", "172.17.0.1:39041"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:58:02.208397239Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7377237862471417,
+				"StableID":   "nCJ4kgXAcz11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0896ce8a1833d51a7b2ce4e15cb3d1fd5b41163e4135722aaae68b19e44fe04a",
+				"DiscoKey":   "discokey:b971d47d118d18af1b30ee31a45685a7a1c4ca2392b9f7845a0af2169edf9d17",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:42122", "10.65.0.27:42122", "172.17.0.1:42122"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:58:09.700011041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5341759814479084,
+				"StableID":   "n7StoPyHii11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e41975d1edf0bea543502ae8e8577225e081356903496be7cb83cd5bbb322654",
+				"DiscoKey":   "discokey:abd2e2b16eac1fcb4cc1073efdb0889d7eb60c20ae83fce14e73e1f6111c0224",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:56096", "10.65.0.27:56096", "172.17.0.1:56096"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:58:12.279078705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5409461165872024,
+				"StableID":   "njt7QaNxEj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d9410feac4e9bbd9f91aa338356c336527675197c72a8cfd6b551a010daa625",
+				"KeyExpiry":  "2026-10-26T10:58:13Z",
+				"DiscoKey":   "discokey:a6742fc609412e2f9532999ebbc4d4426008664b0bc7dff0d51ebe053909b120",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38559", "10.65.0.27:38559", "172.17.0.1:38559"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:58:13.157598916Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4447032378360071,
+				"StableID":   "nt1U8zz4jb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dda9c9c92521623739af6070c51538fda70fe09e8bc2cea8ecf6088c5a8ef973",
+				"KeyExpiry":  "2026-10-26T10:58:14Z",
+				"DiscoKey":   "discokey:cd60d32beaec8a9d856ec5c068e0c1cb5b6989946d710f383d46186d9f7e7b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48009", "10.65.0.27:48009", "172.17.0.1:48009"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:58:14.549275052Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4589275789633880,
+				"StableID":   "n1h1JbVVqc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       4589275789633880,
+				"Key":        "nodekey:25c0b2412fa4eaf06ceb301cd3dfa99fe7d45dd2e8b590f007d64d87b57d1c1f",
+				"DiscoKey":   "discokey:5290603cf9df856d3f0f05295b86f45d1a9c8ac265876ad8fd61fcf3e7359954",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:58181", "10.65.0.27:58181", "172.17.0.1:58181"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:57:56.019189124Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:25c0b2412fa4eaf06ceb301cd3dfa99fe7d45dd2e8b590f007d64d87b57d1c1f",
+			"MachineKey": "mkey:ad98075021cbce0417db5284c2ad55c6df0bdf09752341423cd56e05d4b2875b",
+			"Peers": [{
+				"ID":         8310794873167203,
+				"StableID":   "ntKnxLVyt721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b59abb2ffb5d06c2b9e320ac87d8d7285e4fab6ade6ef45ba866457f1c3a4153",
+				"DiscoKey":   "discokey:2f114a5c6a45de4a322e7bcb939e66d37656eda453deeeca9e16544f8a500e4f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:38060", "10.65.0.27:38060", "172.17.0.1:38060"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:57:57.424027999Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2332132382322990,
+				"StableID":   "noZbcTAEDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83b3ffb3ce90d4f6faeaf27a07f0ad63aa17d6ed1faeedc0f8c1161ad2e11837",
+				"DiscoKey":   "discokey:7b381f441100d01bb322fd6ce33ad3973238e693038036116a7a96a6198dc406",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:39041", "10.65.0.27:39041", "172.17.0.1:39041"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:58:02.208397239Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7377237862471417,
+				"StableID":   "nCJ4kgXAcz11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0896ce8a1833d51a7b2ce4e15cb3d1fd5b41163e4135722aaae68b19e44fe04a",
+				"DiscoKey":   "discokey:b971d47d118d18af1b30ee31a45685a7a1c4ca2392b9f7845a0af2169edf9d17",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:42122", "10.65.0.27:42122", "172.17.0.1:42122"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:58:09.700011041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5341759814479084,
+				"StableID":   "n7StoPyHii11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e41975d1edf0bea543502ae8e8577225e081356903496be7cb83cd5bbb322654",
+				"DiscoKey":   "discokey:abd2e2b16eac1fcb4cc1073efdb0889d7eb60c20ae83fce14e73e1f6111c0224",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:56096", "10.65.0.27:56096", "172.17.0.1:56096"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:58:12.279078705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5409461165872024,
+				"StableID":   "njt7QaNxEj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d9410feac4e9bbd9f91aa338356c336527675197c72a8cfd6b551a010daa625",
+				"KeyExpiry":  "2026-10-26T10:58:13Z",
+				"DiscoKey":   "discokey:a6742fc609412e2f9532999ebbc4d4426008664b0bc7dff0d51ebe053909b120",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38559", "10.65.0.27:38559", "172.17.0.1:38559"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:58:13.157598916Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4447032378360071,
+				"StableID":   "nt1U8zz4jb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dda9c9c92521623739af6070c51538fda70fe09e8bc2cea8ecf6088c5a8ef973",
+				"KeyExpiry":  "2026-10-26T10:58:14Z",
+				"DiscoKey":   "discokey:cd60d32beaec8a9d856ec5c068e0c1cb5b6989946d710f383d46186d9f7e7b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48009", "10.65.0.27:48009", "172.17.0.1:48009"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:58:14.549275052Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7091447953578408,
+				"StableID":   "nwJq89KjNx11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2b96995c41264d24905ef5e25108c802615e36340286f77215562a57ac01bf2f",
+				"KeyExpiry":  "2026-10-26T10:58:15Z",
+				"DiscoKey":   "discokey:54704cd8dfd1035c5b3baac5211c71b25fcb5200fac8747234c5b6a53ebbcd61",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:45857", "10.65.0.27:45857", "172.17.0.1:45857"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:58:15.204403484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4589275789633880": {
+				"ID":          4589275789633880,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5409461165872024,
+				"StableID":   "njt7QaNxEj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d9410feac4e9bbd9f91aa338356c336527675197c72a8cfd6b551a010daa625",
+				"KeyExpiry":  "2026-10-26T10:58:13Z",
+				"DiscoKey":   "discokey:a6742fc609412e2f9532999ebbc4d4426008664b0bc7dff0d51ebe053909b120",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38559", "10.65.0.27:38559", "172.17.0.1:38559"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:58:13.157598916Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9d9410feac4e9bbd9f91aa338356c336527675197c72a8cfd6b551a010daa625",
+			"MachineKey": "mkey:cc239f8568c749fa5de24dffb33fc39d657957e80bebe555adc92b1c92fb3224",
+			"Peers": [{
+				"ID":         4589275789633880,
+				"StableID":   "n1h1JbVVqc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25c0b2412fa4eaf06ceb301cd3dfa99fe7d45dd2e8b590f007d64d87b57d1c1f",
+				"DiscoKey":   "discokey:5290603cf9df856d3f0f05295b86f45d1a9c8ac265876ad8fd61fcf3e7359954",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:58181", "10.65.0.27:58181", "172.17.0.1:58181"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:57:56.019189124Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8310794873167203,
+				"StableID":   "ntKnxLVyt721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b59abb2ffb5d06c2b9e320ac87d8d7285e4fab6ade6ef45ba866457f1c3a4153",
+				"DiscoKey":   "discokey:2f114a5c6a45de4a322e7bcb939e66d37656eda453deeeca9e16544f8a500e4f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:38060", "10.65.0.27:38060", "172.17.0.1:38060"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:57:57.424027999Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2332132382322990,
+				"StableID":   "noZbcTAEDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83b3ffb3ce90d4f6faeaf27a07f0ad63aa17d6ed1faeedc0f8c1161ad2e11837",
+				"DiscoKey":   "discokey:7b381f441100d01bb322fd6ce33ad3973238e693038036116a7a96a6198dc406",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:39041", "10.65.0.27:39041", "172.17.0.1:39041"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:58:02.208397239Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7377237862471417,
+				"StableID":   "nCJ4kgXAcz11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0896ce8a1833d51a7b2ce4e15cb3d1fd5b41163e4135722aaae68b19e44fe04a",
+				"DiscoKey":   "discokey:b971d47d118d18af1b30ee31a45685a7a1c4ca2392b9f7845a0af2169edf9d17",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:42122", "10.65.0.27:42122", "172.17.0.1:42122"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:58:09.700011041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5341759814479084,
+				"StableID":   "n7StoPyHii11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e41975d1edf0bea543502ae8e8577225e081356903496be7cb83cd5bbb322654",
+				"DiscoKey":   "discokey:abd2e2b16eac1fcb4cc1073efdb0889d7eb60c20ae83fce14e73e1f6111c0224",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:56096", "10.65.0.27:56096", "172.17.0.1:56096"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:58:12.279078705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4447032378360071,
+				"StableID":   "nt1U8zz4jb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dda9c9c92521623739af6070c51538fda70fe09e8bc2cea8ecf6088c5a8ef973",
+				"KeyExpiry":  "2026-10-26T10:58:14Z",
+				"DiscoKey":   "discokey:cd60d32beaec8a9d856ec5c068e0c1cb5b6989946d710f383d46186d9f7e7b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48009", "10.65.0.27:48009", "172.17.0.1:48009"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:58:14.549275052Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7091447953578408,
+				"StableID":   "nwJq89KjNx11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2b96995c41264d24905ef5e25108c802615e36340286f77215562a57ac01bf2f",
+				"KeyExpiry":  "2026-10-26T10:58:15Z",
+				"DiscoKey":   "discokey:54704cd8dfd1035c5b3baac5211c71b25fcb5200fac8747234c5b6a53ebbcd61",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:45857", "10.65.0.27:45857", "172.17.0.1:45857"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:58:15.204403484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7377237862471417,
+				"StableID":   "nCJ4kgXAcz11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       7377237862471417,
+				"Key":        "nodekey:0896ce8a1833d51a7b2ce4e15cb3d1fd5b41163e4135722aaae68b19e44fe04a",
+				"DiscoKey":   "discokey:b971d47d118d18af1b30ee31a45685a7a1c4ca2392b9f7845a0af2169edf9d17",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:42122", "10.65.0.27:42122", "172.17.0.1:42122"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:58:09.700011041Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0896ce8a1833d51a7b2ce4e15cb3d1fd5b41163e4135722aaae68b19e44fe04a",
+			"MachineKey": "mkey:ff1c9dc0bb6c03e5b6b130e68a9b92c1356e5478fd6fc843444282b223c6ee42",
+			"Peers": [{
+				"ID":         4589275789633880,
+				"StableID":   "n1h1JbVVqc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25c0b2412fa4eaf06ceb301cd3dfa99fe7d45dd2e8b590f007d64d87b57d1c1f",
+				"DiscoKey":   "discokey:5290603cf9df856d3f0f05295b86f45d1a9c8ac265876ad8fd61fcf3e7359954",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:58181", "10.65.0.27:58181", "172.17.0.1:58181"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:57:56.019189124Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8310794873167203,
+				"StableID":   "ntKnxLVyt721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b59abb2ffb5d06c2b9e320ac87d8d7285e4fab6ade6ef45ba866457f1c3a4153",
+				"DiscoKey":   "discokey:2f114a5c6a45de4a322e7bcb939e66d37656eda453deeeca9e16544f8a500e4f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:38060", "10.65.0.27:38060", "172.17.0.1:38060"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:57:57.424027999Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2332132382322990,
+				"StableID":   "noZbcTAEDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83b3ffb3ce90d4f6faeaf27a07f0ad63aa17d6ed1faeedc0f8c1161ad2e11837",
+				"DiscoKey":   "discokey:7b381f441100d01bb322fd6ce33ad3973238e693038036116a7a96a6198dc406",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:39041", "10.65.0.27:39041", "172.17.0.1:39041"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:58:02.208397239Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5341759814479084,
+				"StableID":   "n7StoPyHii11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e41975d1edf0bea543502ae8e8577225e081356903496be7cb83cd5bbb322654",
+				"DiscoKey":   "discokey:abd2e2b16eac1fcb4cc1073efdb0889d7eb60c20ae83fce14e73e1f6111c0224",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:56096", "10.65.0.27:56096", "172.17.0.1:56096"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:58:12.279078705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5409461165872024,
+				"StableID":   "njt7QaNxEj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d9410feac4e9bbd9f91aa338356c336527675197c72a8cfd6b551a010daa625",
+				"KeyExpiry":  "2026-10-26T10:58:13Z",
+				"DiscoKey":   "discokey:a6742fc609412e2f9532999ebbc4d4426008664b0bc7dff0d51ebe053909b120",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38559", "10.65.0.27:38559", "172.17.0.1:38559"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:58:13.157598916Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4447032378360071,
+				"StableID":   "nt1U8zz4jb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dda9c9c92521623739af6070c51538fda70fe09e8bc2cea8ecf6088c5a8ef973",
+				"KeyExpiry":  "2026-10-26T10:58:14Z",
+				"DiscoKey":   "discokey:cd60d32beaec8a9d856ec5c068e0c1cb5b6989946d710f383d46186d9f7e7b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48009", "10.65.0.27:48009", "172.17.0.1:48009"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:58:14.549275052Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7091447953578408,
+				"StableID":   "nwJq89KjNx11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2b96995c41264d24905ef5e25108c802615e36340286f77215562a57ac01bf2f",
+				"KeyExpiry":  "2026-10-26T10:58:15Z",
+				"DiscoKey":   "discokey:54704cd8dfd1035c5b3baac5211c71b25fcb5200fac8747234c5b6a53ebbcd61",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:45857", "10.65.0.27:45857", "172.17.0.1:45857"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:58:15.204403484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7377237862471417": {
+				"ID":          7377237862471417,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8310794873167203,
+				"StableID":   "ntKnxLVyt721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       8310794873167203,
+				"Key":        "nodekey:b59abb2ffb5d06c2b9e320ac87d8d7285e4fab6ade6ef45ba866457f1c3a4153",
+				"DiscoKey":   "discokey:2f114a5c6a45de4a322e7bcb939e66d37656eda453deeeca9e16544f8a500e4f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:38060", "10.65.0.27:38060", "172.17.0.1:38060"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:57:57.424027999Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b59abb2ffb5d06c2b9e320ac87d8d7285e4fab6ade6ef45ba866457f1c3a4153",
+			"MachineKey": "mkey:99919161295c627d777009032ba11b53b1425c0f9be574103238a95bf1ab7451",
+			"Peers": [{
+				"ID":         4589275789633880,
+				"StableID":   "n1h1JbVVqc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25c0b2412fa4eaf06ceb301cd3dfa99fe7d45dd2e8b590f007d64d87b57d1c1f",
+				"DiscoKey":   "discokey:5290603cf9df856d3f0f05295b86f45d1a9c8ac265876ad8fd61fcf3e7359954",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:58181", "10.65.0.27:58181", "172.17.0.1:58181"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:57:56.019189124Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2332132382322990,
+				"StableID":   "noZbcTAEDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83b3ffb3ce90d4f6faeaf27a07f0ad63aa17d6ed1faeedc0f8c1161ad2e11837",
+				"DiscoKey":   "discokey:7b381f441100d01bb322fd6ce33ad3973238e693038036116a7a96a6198dc406",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:39041", "10.65.0.27:39041", "172.17.0.1:39041"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:58:02.208397239Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7377237862471417,
+				"StableID":   "nCJ4kgXAcz11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0896ce8a1833d51a7b2ce4e15cb3d1fd5b41163e4135722aaae68b19e44fe04a",
+				"DiscoKey":   "discokey:b971d47d118d18af1b30ee31a45685a7a1c4ca2392b9f7845a0af2169edf9d17",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:42122", "10.65.0.27:42122", "172.17.0.1:42122"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:58:09.700011041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5341759814479084,
+				"StableID":   "n7StoPyHii11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e41975d1edf0bea543502ae8e8577225e081356903496be7cb83cd5bbb322654",
+				"DiscoKey":   "discokey:abd2e2b16eac1fcb4cc1073efdb0889d7eb60c20ae83fce14e73e1f6111c0224",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:56096", "10.65.0.27:56096", "172.17.0.1:56096"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:58:12.279078705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5409461165872024,
+				"StableID":   "njt7QaNxEj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d9410feac4e9bbd9f91aa338356c336527675197c72a8cfd6b551a010daa625",
+				"KeyExpiry":  "2026-10-26T10:58:13Z",
+				"DiscoKey":   "discokey:a6742fc609412e2f9532999ebbc4d4426008664b0bc7dff0d51ebe053909b120",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38559", "10.65.0.27:38559", "172.17.0.1:38559"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:58:13.157598916Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4447032378360071,
+				"StableID":   "nt1U8zz4jb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dda9c9c92521623739af6070c51538fda70fe09e8bc2cea8ecf6088c5a8ef973",
+				"KeyExpiry":  "2026-10-26T10:58:14Z",
+				"DiscoKey":   "discokey:cd60d32beaec8a9d856ec5c068e0c1cb5b6989946d710f383d46186d9f7e7b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48009", "10.65.0.27:48009", "172.17.0.1:48009"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:58:14.549275052Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7091447953578408,
+				"StableID":   "nwJq89KjNx11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2b96995c41264d24905ef5e25108c802615e36340286f77215562a57ac01bf2f",
+				"KeyExpiry":  "2026-10-26T10:58:15Z",
+				"DiscoKey":   "discokey:54704cd8dfd1035c5b3baac5211c71b25fcb5200fac8747234c5b6a53ebbcd61",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:45857", "10.65.0.27:45857", "172.17.0.1:45857"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:58:15.204403484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8310794873167203": {
+				"ID":          8310794873167203,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4447032378360071,
+				"StableID":   "nt1U8zz4jb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dda9c9c92521623739af6070c51538fda70fe09e8bc2cea8ecf6088c5a8ef973",
+				"KeyExpiry":  "2026-10-26T10:58:14Z",
+				"DiscoKey":   "discokey:cd60d32beaec8a9d856ec5c068e0c1cb5b6989946d710f383d46186d9f7e7b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48009", "10.65.0.27:48009", "172.17.0.1:48009"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:58:14.549275052Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dda9c9c92521623739af6070c51538fda70fe09e8bc2cea8ecf6088c5a8ef973",
+			"MachineKey": "mkey:0aae994113257cd44d56704736ed7ff42c42539739761b6f0c8485dc8e51a434",
+			"Peers": [{
+				"ID":         4589275789633880,
+				"StableID":   "n1h1JbVVqc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25c0b2412fa4eaf06ceb301cd3dfa99fe7d45dd2e8b590f007d64d87b57d1c1f",
+				"DiscoKey":   "discokey:5290603cf9df856d3f0f05295b86f45d1a9c8ac265876ad8fd61fcf3e7359954",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:58181", "10.65.0.27:58181", "172.17.0.1:58181"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:57:56.019189124Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8310794873167203,
+				"StableID":   "ntKnxLVyt721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b59abb2ffb5d06c2b9e320ac87d8d7285e4fab6ade6ef45ba866457f1c3a4153",
+				"DiscoKey":   "discokey:2f114a5c6a45de4a322e7bcb939e66d37656eda453deeeca9e16544f8a500e4f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:38060", "10.65.0.27:38060", "172.17.0.1:38060"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:57:57.424027999Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2332132382322990,
+				"StableID":   "noZbcTAEDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83b3ffb3ce90d4f6faeaf27a07f0ad63aa17d6ed1faeedc0f8c1161ad2e11837",
+				"DiscoKey":   "discokey:7b381f441100d01bb322fd6ce33ad3973238e693038036116a7a96a6198dc406",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:39041", "10.65.0.27:39041", "172.17.0.1:39041"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:58:02.208397239Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7377237862471417,
+				"StableID":   "nCJ4kgXAcz11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0896ce8a1833d51a7b2ce4e15cb3d1fd5b41163e4135722aaae68b19e44fe04a",
+				"DiscoKey":   "discokey:b971d47d118d18af1b30ee31a45685a7a1c4ca2392b9f7845a0af2169edf9d17",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:42122", "10.65.0.27:42122", "172.17.0.1:42122"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:58:09.700011041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5341759814479084,
+				"StableID":   "n7StoPyHii11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e41975d1edf0bea543502ae8e8577225e081356903496be7cb83cd5bbb322654",
+				"DiscoKey":   "discokey:abd2e2b16eac1fcb4cc1073efdb0889d7eb60c20ae83fce14e73e1f6111c0224",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:56096", "10.65.0.27:56096", "172.17.0.1:56096"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:58:12.279078705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5409461165872024,
+				"StableID":   "njt7QaNxEj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d9410feac4e9bbd9f91aa338356c336527675197c72a8cfd6b551a010daa625",
+				"KeyExpiry":  "2026-10-26T10:58:13Z",
+				"DiscoKey":   "discokey:a6742fc609412e2f9532999ebbc4d4426008664b0bc7dff0d51ebe053909b120",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38559", "10.65.0.27:38559", "172.17.0.1:38559"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:58:13.157598916Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7091447953578408,
+				"StableID":   "nwJq89KjNx11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2b96995c41264d24905ef5e25108c802615e36340286f77215562a57ac01bf2f",
+				"KeyExpiry":  "2026-10-26T10:58:15Z",
+				"DiscoKey":   "discokey:54704cd8dfd1035c5b3baac5211c71b25fcb5200fac8747234c5b6a53ebbcd61",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:45857", "10.65.0.27:45857", "172.17.0.1:45857"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:58:15.204403484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2332132382322990,
+				"StableID":   "noZbcTAEDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       2332132382322990,
+				"Key":        "nodekey:83b3ffb3ce90d4f6faeaf27a07f0ad63aa17d6ed1faeedc0f8c1161ad2e11837",
+				"DiscoKey":   "discokey:7b381f441100d01bb322fd6ce33ad3973238e693038036116a7a96a6198dc406",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:39041", "10.65.0.27:39041", "172.17.0.1:39041"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:58:02.208397239Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:83b3ffb3ce90d4f6faeaf27a07f0ad63aa17d6ed1faeedc0f8c1161ad2e11837",
+			"MachineKey": "mkey:d840b166466eadc3b8f5c12576eb1572dd8b69fec440b998ccfe02499a7cec15",
+			"Peers": [{
+				"ID":         4589275789633880,
+				"StableID":   "n1h1JbVVqc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25c0b2412fa4eaf06ceb301cd3dfa99fe7d45dd2e8b590f007d64d87b57d1c1f",
+				"DiscoKey":   "discokey:5290603cf9df856d3f0f05295b86f45d1a9c8ac265876ad8fd61fcf3e7359954",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:58181", "10.65.0.27:58181", "172.17.0.1:58181"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:57:56.019189124Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8310794873167203,
+				"StableID":   "ntKnxLVyt721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b59abb2ffb5d06c2b9e320ac87d8d7285e4fab6ade6ef45ba866457f1c3a4153",
+				"DiscoKey":   "discokey:2f114a5c6a45de4a322e7bcb939e66d37656eda453deeeca9e16544f8a500e4f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:38060", "10.65.0.27:38060", "172.17.0.1:38060"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:57:57.424027999Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7377237862471417,
+				"StableID":   "nCJ4kgXAcz11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0896ce8a1833d51a7b2ce4e15cb3d1fd5b41163e4135722aaae68b19e44fe04a",
+				"DiscoKey":   "discokey:b971d47d118d18af1b30ee31a45685a7a1c4ca2392b9f7845a0af2169edf9d17",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:42122", "10.65.0.27:42122", "172.17.0.1:42122"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:58:09.700011041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5341759814479084,
+				"StableID":   "n7StoPyHii11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e41975d1edf0bea543502ae8e8577225e081356903496be7cb83cd5bbb322654",
+				"DiscoKey":   "discokey:abd2e2b16eac1fcb4cc1073efdb0889d7eb60c20ae83fce14e73e1f6111c0224",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:56096", "10.65.0.27:56096", "172.17.0.1:56096"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:58:12.279078705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5409461165872024,
+				"StableID":   "njt7QaNxEj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d9410feac4e9bbd9f91aa338356c336527675197c72a8cfd6b551a010daa625",
+				"KeyExpiry":  "2026-10-26T10:58:13Z",
+				"DiscoKey":   "discokey:a6742fc609412e2f9532999ebbc4d4426008664b0bc7dff0d51ebe053909b120",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38559", "10.65.0.27:38559", "172.17.0.1:38559"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:58:13.157598916Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4447032378360071,
+				"StableID":   "nt1U8zz4jb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dda9c9c92521623739af6070c51538fda70fe09e8bc2cea8ecf6088c5a8ef973",
+				"KeyExpiry":  "2026-10-26T10:58:14Z",
+				"DiscoKey":   "discokey:cd60d32beaec8a9d856ec5c068e0c1cb5b6989946d710f383d46186d9f7e7b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48009", "10.65.0.27:48009", "172.17.0.1:48009"],
+				"HomeDERP":   4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:58:14.549275052Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7091447953578408,
+				"StableID":   "nwJq89KjNx11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2b96995c41264d24905ef5e25108c802615e36340286f77215562a57ac01bf2f",
+				"KeyExpiry":  "2026-10-26T10:58:15Z",
+				"DiscoKey":   "discokey:54704cd8dfd1035c5b3baac5211c71b25fcb5200fac8747234c5b6a53ebbcd61",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:45857", "10.65.0.27:45857", "172.17.0.1:45857"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:58:15.204403484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2332132382322990": {
+				"ID":          2332132382322990,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-proto-empty.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-proto-empty.hujson
@@ -1,0 +1,7229 @@
+// policytest-proto-empty
+//
+// tests block proto: empty proto, default match
+//
+// Nodes with filter rules: 1 of 8
+// Captured at:    2026-04-29T10:58:37Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-proto-empty",
+	"description":    "tests block proto: empty proto, default match",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:58:37.130123052Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                         \n  \n                                                                      \n                                  \n{\n\t\"id\":          \"policytest-proto-empty\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block proto: empty proto, default match\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": false},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"thor@example.org\"], \"dst\": [\"webserver:80\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"accept\": [\"webserver:80\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-proto-empty.hujson",
+		"full_policy": {"acls": [
+			{"action": "accept", "dst": ["webserver:80"], "src": ["thor@example.org"]}
+		], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [{"accept": ["webserver:80"], "src": "thor@example.org"}]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {"packet_filter_rules": [{
+		"SrcIPs":   ["100.64.0.17", "fd7a:115c:a1e0::11"],
+		"DstPorts": [{"IP": "100.64.0.16", "Ports": {"First": 80, "Last": 80}}]
+	}], "packet_filter_matches": [{
+		"IPProto": [6, 17, 1, 58],
+		"Srcs":    ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+		"SrcCaps": null,
+		"Dsts":    [{"Net": "100.64.0.16/32", "Ports": {"First": 80, "Last": 80}}],
+		"Caps":    []
+	}], "netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1615880366042883,
+			"StableID":   "nC1FdMSqcD11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       1615880366042883,
+			"Key":        "nodekey:b44c23a12f08117d2bec5ef21b4f9cc4e41b55f729d1b4e54f4bb342ed49ae47",
+			"DiscoKey":   "discokey:87eff0a1d346508276e60beca19c29ec131b582c8c4ca840d5c04780b96c3e16",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints":  ["77.164.248.136:35875", "10.65.0.27:35875", "172.17.0.1:35875"],
+			"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:58:54.315649441Z",
+			"Tags":              ["tag:server"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:b44c23a12f08117d2bec5ef21b4f9cc4e41b55f729d1b4e54f4bb342ed49ae47",
+		"MachineKey": "mkey:6b3f51ee55b841f627442613f6873486189d96562251c80a1b6f2e2bbb387c28",
+		"Peers": [{
+			"ID":         1919568208956029,
+			"StableID":   "nAXdNWoNzF11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:aaa2f454761ce67b2d2efd94ce28e221838fbcbabb00a0099486ea698ede3036",
+			"KeyExpiry":  "2026-10-26T10:58:55Z",
+			"DiscoKey":   "discokey:e5d5d33efabb97914d6c76c44712df80eefc6c8419668eb0a2f72734b1a54356",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints":  ["77.164.248.136:52582", "10.65.0.27:52582", "172.17.0.1:52582"],
+			"HomeDERP":   14,
+			"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496}
+			]},
+			"Created":              "2026-04-29T10:58:55.972835561Z",
+			"Cap":                  131,
+			"Online":               true,
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		}],
+		"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter": [{
+			"IPProto": [6, 17, 1, 58],
+			"Srcs":    ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"SrcCaps": null,
+			"Dsts":    [{"Net": "100.64.0.16/32", "Ports": {"First": 80, "Last": 80}}],
+			"Caps":    []
+		}],
+		"PacketFilterRules": [{
+			"SrcIPs":   ["100.64.0.17", "fd7a:115c:a1e0::11"],
+			"DstPorts": [{"IP": "100.64.0.16", "Ports": {"First": 80, "Last": 80}}]
+		}],
+		"SSHPolicy":       {"rules": []},
+		"CollectServices": false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1615880366042883": {
+			"ID":          1615880366042883,
+			"LoginName":   "beedrill.tail78f774.ts.net",
+			"DisplayName": "beedrill"
+		}, "4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}}
+	}}, "bulbasaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1376624045428443,
+			"StableID":   "nANHsbaUkB11CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:bc4863898767dd5ae9e8873933b545afa6d7b245cc4e70c153e4c8b6565fb325",
+			"KeyExpiry":  "2026-10-26T10:58:59Z",
+			"DiscoKey":   "discokey:8f9c46162a4617045044d916f447c6400b5047309314191a31814e7f74dd9d29",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints":  ["77.164.248.136:46138", "10.65.0.27:46138", "172.17.0.1:46138"],
+			"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:58:59.550350737Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:bc4863898767dd5ae9e8873933b545afa6d7b245cc4e70c153e4c8b6565fb325",
+		"MachineKey":        "mkey:334181c57d4d305f2c771ecaaac26d4d782d6fce7feb7c5127d9e4c22376a300",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}}
+	}}, "charmander": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8042555643492444,
+			"StableID":   "nfS6nLJVo521CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       8042555643492444,
+			"Key":        "nodekey:77589bc4e09b4a32dc2e28b441ae0d73f57ffc105c58d76d7c70efdc62ee8144",
+			"DiscoKey":   "discokey:ad0a1c50d7a6075cf2e2724c757a85488db3da4c3b864e2a04933126956cf407",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"Endpoints":  ["77.164.248.136:53702", "10.65.0.27:53702", "172.17.0.1:53702"],
+			"Hostinfo": {
+				"Hostname":    "charmander",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T10:58:44.999496681Z",
+			"Tags":              ["tag:exit"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:77589bc4e09b4a32dc2e28b441ae0d73f57ffc105c58d76d7c70efdc62ee8144",
+		"MachineKey":        "mkey:a51d6dba35cc1667104c3903c69a4d95f9457d52b7342abe4ec464806072253f",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"8042555643492444": {
+			"ID":          8042555643492444,
+			"LoginName":   "charmander.tail78f774.ts.net",
+			"DisplayName": "charmander"
+		}}
+	}}, "ivysaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1919568208956029,
+			"StableID":   "nAXdNWoNzF11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:aaa2f454761ce67b2d2efd94ce28e221838fbcbabb00a0099486ea698ede3036",
+			"KeyExpiry":  "2026-10-26T10:58:55Z",
+			"DiscoKey":   "discokey:e5d5d33efabb97914d6c76c44712df80eefc6c8419668eb0a2f72734b1a54356",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints":  ["77.164.248.136:52582", "10.65.0.27:52582", "172.17.0.1:52582"],
+			"Hostinfo": {"Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:58:55.972835561Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:aaa2f454761ce67b2d2efd94ce28e221838fbcbabb00a0099486ea698ede3036",
+		"MachineKey": "mkey:94ae8f9deb8b9a099a88b025c14f864fc2eb80ff13d16c3ad973f1145f5e8500",
+		"Peers": [{
+			"ID":         1615880366042883,
+			"StableID":   "nC1FdMSqcD11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:b44c23a12f08117d2bec5ef21b4f9cc4e41b55f729d1b4e54f4bb342ed49ae47",
+			"DiscoKey":   "discokey:87eff0a1d346508276e60beca19c29ec131b582c8c4ca840d5c04780b96c3e16",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints":  ["77.164.248.136:35875", "10.65.0.27:35875", "172.17.0.1:35875"],
+			"HomeDERP":   14,
+			"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358}
+			]},
+			"Created":              "2026-04-29T10:58:54.315649441Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:server"],
+			"Online":               true,
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}}
+	}}, "kakuna": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4818751848926094,
+			"StableID":   "nFRFrWSRde11CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       4818751848926094,
+			"Key":        "nodekey:da294c4e270db9230f0f2e89d3c1458590b435a0d6c18903dfe6879561b5e476",
+			"DiscoKey":   "discokey:22fa31298d8c06525d8e85a1d26342e97542414a7bb51a9cdea216a2f0a5ea54",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints":  ["77.164.248.136:47542", "10.65.0.27:47542", "172.17.0.1:47542"],
+			"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:58:52.285863706Z",
+			"Tags":              ["tag:prod"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:da294c4e270db9230f0f2e89d3c1458590b435a0d6c18903dfe6879561b5e476",
+		"MachineKey":        "mkey:fc1e788517926c88b156e1527de1f7edc271142b3bcb04d9d091596bb2f72624",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4818751848926094": {
+			"ID":          4818751848926094,
+			"LoginName":   "kakuna.tail78f774.ts.net",
+			"DisplayName": "kakuna"
+		}}
+	}}, "squirtle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         6117656058354078,
+			"StableID":   "nhGyw9Thmp11CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       6117656058354078,
+			"Key":        "nodekey:524dfbed89debfd5581eac3229abfa7c3fe8f012ac113abfb075a266e7173933",
+			"DiscoKey":   "discokey:803668a4377d908e4673ba5993b442d678366e517c032f775f3638d1f01a8f20",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"Endpoints":  ["77.164.248.136:51024", "10.65.0.27:51024", "172.17.0.1:51024"],
+			"Hostinfo": {
+				"Hostname":    "squirtle",
+				"RoutableIPs": ["10.33.0.0/16"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T10:58:45.706871368Z",
+			"Tags":              ["tag:router"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:524dfbed89debfd5581eac3229abfa7c3fe8f012ac113abfb075a266e7173933",
+		"MachineKey":        "mkey:2ee982ed00b6aea5e99d4aef7e22d6c56bff77b87de5b9d8cf1f4af08e943f15",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"6117656058354078": {
+			"ID":          6117656058354078,
+			"LoginName":   "squirtle.tail78f774.ts.net",
+			"DisplayName": "squirtle"
+		}}
+	}}, "venusaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2942775615498961,
+			"StableID":   "n42e55jnyP11CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:75bf277a7ff34528224c96eea86eac142dd07e0cbe60078d1a74c7d0469b716b",
+			"KeyExpiry":  "2026-10-26T10:58:58Z",
+			"DiscoKey":   "discokey:b1f68b175f8b68ac2f8e916eb5e35a4d487d558dca6294155efe274de757155d",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints":  ["77.164.248.136:44651", "10.65.0.27:44651", "172.17.0.1:44651"],
+			"Hostinfo": {"Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:58:58.659485963Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:75bf277a7ff34528224c96eea86eac142dd07e0cbe60078d1a74c7d0469b716b",
+		"MachineKey":        "mkey:4a8cf7ddec63f0bb840f847c601f404ea80d4584750839f75675642ecba03521",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}}
+	}}, "weedle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         552639753866689,
+			"StableID":   "nCg9djuHK511CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       552639753866689,
+			"Key":        "nodekey:a4000c4d55f0e42ab7350895b2ff85cb01b3c2e58153a6b1bf001cbd7b4fab66",
+			"DiscoKey":   "discokey:12c7300abf8809ab447c4cefeee6353a0924db80d2aab3af7a4e1aae222b051e",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints":  ["77.164.248.136:48419", "10.65.0.27:48419", "172.17.0.1:48419"],
+			"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T10:58:46.464528613Z",
+			"Tags":              ["tag:client"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:a4000c4d55f0e42ab7350895b2ff85cb01b3c2e58153a6b1bf001cbd7b4fab66",
+		"MachineKey":        "mkey:9bbe8eda96d5c1e24f84c4a1f4f8bb56982ff9c28b2d52df31fce665dd09f47d",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"552639753866689": {
+			"ID":          552639753866689,
+			"LoginName":   "weedle.tail78f774.ts.net",
+			"DisplayName": "weedle"
+		}}
+	}}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-proto-icmp.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-proto-icmp.hujson
@@ -1,0 +1,8848 @@
+// policytest-proto-icmp
+//
+// tests block proto: icmp string
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T10:59:30Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-proto-icmp",
+	"description":    "tests block proto: icmp string",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:59:30.68860619Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                        \n  \n                                                                     \n                                     \n{\n\t\"id\":          \"policytest-proto-icmp\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block proto: icmp string\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": false},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"proto\": \"icmp\", \"src\": [\"thor@example.org\"], \"dst\": [\"webserver:*\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"proto\": \"icmp\", \"accept\": [\"webserver:*\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-proto-icmp.hujson",
+		"full_policy": {
+			"acls": [{
+				"action": "accept",
+				"dst":    ["webserver:*"],
+				"proto":  "icmp",
+				"src":    ["thor@example.org"]
+			}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["webserver:*"], "proto": "icmp", "src": "thor@example.org"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2476962605389605,
+				"StableID":   "nA5kUEcpLL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       2476962605389605,
+				"Key":        "nodekey:b327ce95d8b07fc2cf8c131fedd06bf4295cd1de21365128168a92e8b2e31d00",
+				"DiscoKey":   "discokey:e427a92e32c5ede0426f101403419d3ee78fcb0f3bb8ca184dd4c04360fc8954",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39814", "10.65.0.27:39814", "172.17.0.1:39814"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:59:34.526845375Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b327ce95d8b07fc2cf8c131fedd06bf4295cd1de21365128168a92e8b2e31d00",
+			"MachineKey": "mkey:0c3d43a271bf1f4759481d92786a06a383db93d744bee4ea3002409e442de201",
+			"Peers": [{
+				"ID":         7055977848701259,
+				"StableID":   "nJEsRFaf6x11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0af622a9c5d428cf9118bcce874971bd7dd5686314f94553309a63f50a5876c",
+				"DiscoKey":   "discokey:5095a74de00d87f3088d4d77d694bb32775801cac74217945dc06beeb493f833",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52841", "10.65.0.27:52841", "172.17.0.1:52841"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:59:32.211580543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         364219773479333,
+				"StableID":   "n44tAHSxq311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33670f52af2f00664ac3bf39cae0c616f380dce41307ae1424d817d433077e2f",
+				"DiscoKey":   "discokey:8d2a589070f8b029b6944ad507b74b886035820d633f7dc29404e3a88e964b48",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:51724", "10.65.0.27:51724", "172.17.0.1:51724"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:59:32.913190841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4030579850338725,
+				"StableID":   "nrTXJtVTUY11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fec87b4fb2ef5f1ee7c76c8282f046a8ca5b372495c2a804c12f884a42397833",
+				"DiscoKey":   "discokey:d69564f30ce6c48090c90bf87ba9881732dca4d0996f306993400bfa7f7aa543",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40973", "10.65.0.27:40973", "172.17.0.1:40973"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:59:33.446105567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7656639024268320,
+				"StableID":   "ndDUeavhn221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:91aff902309a1f47714b2451b3d6dbcd048c135cf9d4c42ab68e08c22c906775",
+				"DiscoKey":   "discokey:342b0e59d198bb48ee599219009391fd73fe8c8aaf546298d18a2d4d646e8b2b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:51649", "10.65.0.27:51649", "172.17.0.1:51649"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:59:33.978276574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7730336753989430,
+				"StableID":   "nZx1fcq5N321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f847b1a0221843a367f821ee3493af596653976f0727fd49cbda66fe1ac6d361",
+				"KeyExpiry":  "2026-10-26T10:59:35Z",
+				"DiscoKey":   "discokey:c2340ad64b4705d27b73372a68a18525d852892b119f69e85850050e7cf98d01",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34983", "10.65.0.27:34983", "172.17.0.1:34983"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:59:35.044737654Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6395681337503055,
+				"StableID":   "nizApohcwr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b6a28b73f192eb7ccf6b6b9a53620506647300d2a065880679a2bb83c9d10525",
+				"KeyExpiry":  "2026-10-26T10:59:35Z",
+				"DiscoKey":   "discokey:3ffd0abe9f5ffd4ef3a76a2c4c50943c3aa8e7bd9eeac06bce8a447b82400611",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58814", "10.65.0.27:58814", "172.17.0.1:58814"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:59:35.574627044Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1647497012794049,
+				"StableID":   "nEh4SGx9sD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:430774f5c474a48f3d09b702d3c392e3c9d5c0e77b17fb765f84b2cb8766f02b",
+				"KeyExpiry":  "2026-10-26T10:59:36Z",
+				"DiscoKey":   "discokey:b4134bce3b9c5a3a08163a41f044730660371336c900c338c12fc084a6c3ea50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43783", "10.65.0.27:43783", "172.17.0.1:43783"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:59:36.124078193Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2476962605389605": {
+				"ID":          2476962605389605,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1647497012794049,
+				"StableID":   "nEh4SGx9sD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:430774f5c474a48f3d09b702d3c392e3c9d5c0e77b17fb765f84b2cb8766f02b",
+				"KeyExpiry":  "2026-10-26T10:59:36Z",
+				"DiscoKey":   "discokey:b4134bce3b9c5a3a08163a41f044730660371336c900c338c12fc084a6c3ea50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43783", "10.65.0.27:43783", "172.17.0.1:43783"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:59:36.124078193Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:430774f5c474a48f3d09b702d3c392e3c9d5c0e77b17fb765f84b2cb8766f02b",
+			"MachineKey": "mkey:efae8d3c9fc8f00e4d99661774bf1f8ac5640520bf95983e6aba636bbba9ce5a",
+			"Peers": [{
+				"ID":         7055977848701259,
+				"StableID":   "nJEsRFaf6x11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0af622a9c5d428cf9118bcce874971bd7dd5686314f94553309a63f50a5876c",
+				"DiscoKey":   "discokey:5095a74de00d87f3088d4d77d694bb32775801cac74217945dc06beeb493f833",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52841", "10.65.0.27:52841", "172.17.0.1:52841"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:59:32.211580543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         364219773479333,
+				"StableID":   "n44tAHSxq311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33670f52af2f00664ac3bf39cae0c616f380dce41307ae1424d817d433077e2f",
+				"DiscoKey":   "discokey:8d2a589070f8b029b6944ad507b74b886035820d633f7dc29404e3a88e964b48",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:51724", "10.65.0.27:51724", "172.17.0.1:51724"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:59:32.913190841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4030579850338725,
+				"StableID":   "nrTXJtVTUY11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fec87b4fb2ef5f1ee7c76c8282f046a8ca5b372495c2a804c12f884a42397833",
+				"DiscoKey":   "discokey:d69564f30ce6c48090c90bf87ba9881732dca4d0996f306993400bfa7f7aa543",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40973", "10.65.0.27:40973", "172.17.0.1:40973"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:59:33.446105567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7656639024268320,
+				"StableID":   "ndDUeavhn221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:91aff902309a1f47714b2451b3d6dbcd048c135cf9d4c42ab68e08c22c906775",
+				"DiscoKey":   "discokey:342b0e59d198bb48ee599219009391fd73fe8c8aaf546298d18a2d4d646e8b2b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:51649", "10.65.0.27:51649", "172.17.0.1:51649"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:59:33.978276574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2476962605389605,
+				"StableID":   "nA5kUEcpLL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b327ce95d8b07fc2cf8c131fedd06bf4295cd1de21365128168a92e8b2e31d00",
+				"DiscoKey":   "discokey:e427a92e32c5ede0426f101403419d3ee78fcb0f3bb8ca184dd4c04360fc8954",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39814", "10.65.0.27:39814", "172.17.0.1:39814"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:59:34.526845375Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7730336753989430,
+				"StableID":   "nZx1fcq5N321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f847b1a0221843a367f821ee3493af596653976f0727fd49cbda66fe1ac6d361",
+				"KeyExpiry":  "2026-10-26T10:59:35Z",
+				"DiscoKey":   "discokey:c2340ad64b4705d27b73372a68a18525d852892b119f69e85850050e7cf98d01",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34983", "10.65.0.27:34983", "172.17.0.1:34983"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:59:35.044737654Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6395681337503055,
+				"StableID":   "nizApohcwr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b6a28b73f192eb7ccf6b6b9a53620506647300d2a065880679a2bb83c9d10525",
+				"KeyExpiry":  "2026-10-26T10:59:35Z",
+				"DiscoKey":   "discokey:3ffd0abe9f5ffd4ef3a76a2c4c50943c3aa8e7bd9eeac06bce8a447b82400611",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58814", "10.65.0.27:58814", "172.17.0.1:58814"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:59:35.574627044Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7055977848701259,
+				"StableID":   "nJEsRFaf6x11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       7055977848701259,
+				"Key":        "nodekey:c0af622a9c5d428cf9118bcce874971bd7dd5686314f94553309a63f50a5876c",
+				"DiscoKey":   "discokey:5095a74de00d87f3088d4d77d694bb32775801cac74217945dc06beeb493f833",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52841", "10.65.0.27:52841", "172.17.0.1:52841"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:59:32.211580543Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c0af622a9c5d428cf9118bcce874971bd7dd5686314f94553309a63f50a5876c",
+			"MachineKey": "mkey:400cb02abee657919b3615eb356aff7946c0a9a929851ac4caf4f5dc1611916e",
+			"Peers": [{
+				"ID":         364219773479333,
+				"StableID":   "n44tAHSxq311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33670f52af2f00664ac3bf39cae0c616f380dce41307ae1424d817d433077e2f",
+				"DiscoKey":   "discokey:8d2a589070f8b029b6944ad507b74b886035820d633f7dc29404e3a88e964b48",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:51724", "10.65.0.27:51724", "172.17.0.1:51724"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:59:32.913190841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4030579850338725,
+				"StableID":   "nrTXJtVTUY11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fec87b4fb2ef5f1ee7c76c8282f046a8ca5b372495c2a804c12f884a42397833",
+				"DiscoKey":   "discokey:d69564f30ce6c48090c90bf87ba9881732dca4d0996f306993400bfa7f7aa543",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40973", "10.65.0.27:40973", "172.17.0.1:40973"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:59:33.446105567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7656639024268320,
+				"StableID":   "ndDUeavhn221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:91aff902309a1f47714b2451b3d6dbcd048c135cf9d4c42ab68e08c22c906775",
+				"DiscoKey":   "discokey:342b0e59d198bb48ee599219009391fd73fe8c8aaf546298d18a2d4d646e8b2b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:51649", "10.65.0.27:51649", "172.17.0.1:51649"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:59:33.978276574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2476962605389605,
+				"StableID":   "nA5kUEcpLL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b327ce95d8b07fc2cf8c131fedd06bf4295cd1de21365128168a92e8b2e31d00",
+				"DiscoKey":   "discokey:e427a92e32c5ede0426f101403419d3ee78fcb0f3bb8ca184dd4c04360fc8954",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39814", "10.65.0.27:39814", "172.17.0.1:39814"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:59:34.526845375Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7730336753989430,
+				"StableID":   "nZx1fcq5N321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f847b1a0221843a367f821ee3493af596653976f0727fd49cbda66fe1ac6d361",
+				"KeyExpiry":  "2026-10-26T10:59:35Z",
+				"DiscoKey":   "discokey:c2340ad64b4705d27b73372a68a18525d852892b119f69e85850050e7cf98d01",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34983", "10.65.0.27:34983", "172.17.0.1:34983"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:59:35.044737654Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6395681337503055,
+				"StableID":   "nizApohcwr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b6a28b73f192eb7ccf6b6b9a53620506647300d2a065880679a2bb83c9d10525",
+				"KeyExpiry":  "2026-10-26T10:59:35Z",
+				"DiscoKey":   "discokey:3ffd0abe9f5ffd4ef3a76a2c4c50943c3aa8e7bd9eeac06bce8a447b82400611",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58814", "10.65.0.27:58814", "172.17.0.1:58814"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:59:35.574627044Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1647497012794049,
+				"StableID":   "nEh4SGx9sD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:430774f5c474a48f3d09b702d3c392e3c9d5c0e77b17fb765f84b2cb8766f02b",
+				"KeyExpiry":  "2026-10-26T10:59:36Z",
+				"DiscoKey":   "discokey:b4134bce3b9c5a3a08163a41f044730660371336c900c338c12fc084a6c3ea50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43783", "10.65.0.27:43783", "172.17.0.1:43783"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:59:36.124078193Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7055977848701259": {
+				"ID":          7055977848701259,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7730336753989430,
+				"StableID":   "nZx1fcq5N321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f847b1a0221843a367f821ee3493af596653976f0727fd49cbda66fe1ac6d361",
+				"KeyExpiry":  "2026-10-26T10:59:35Z",
+				"DiscoKey":   "discokey:c2340ad64b4705d27b73372a68a18525d852892b119f69e85850050e7cf98d01",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34983", "10.65.0.27:34983", "172.17.0.1:34983"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:59:35.044737654Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f847b1a0221843a367f821ee3493af596653976f0727fd49cbda66fe1ac6d361",
+			"MachineKey": "mkey:26e4946bf582f9f8af2a17da0bc4dc0535737663b157c66a1f9de956e934c522",
+			"Peers": [{
+				"ID":         7055977848701259,
+				"StableID":   "nJEsRFaf6x11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0af622a9c5d428cf9118bcce874971bd7dd5686314f94553309a63f50a5876c",
+				"DiscoKey":   "discokey:5095a74de00d87f3088d4d77d694bb32775801cac74217945dc06beeb493f833",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52841", "10.65.0.27:52841", "172.17.0.1:52841"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:59:32.211580543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         364219773479333,
+				"StableID":   "n44tAHSxq311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33670f52af2f00664ac3bf39cae0c616f380dce41307ae1424d817d433077e2f",
+				"DiscoKey":   "discokey:8d2a589070f8b029b6944ad507b74b886035820d633f7dc29404e3a88e964b48",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:51724", "10.65.0.27:51724", "172.17.0.1:51724"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:59:32.913190841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4030579850338725,
+				"StableID":   "nrTXJtVTUY11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fec87b4fb2ef5f1ee7c76c8282f046a8ca5b372495c2a804c12f884a42397833",
+				"DiscoKey":   "discokey:d69564f30ce6c48090c90bf87ba9881732dca4d0996f306993400bfa7f7aa543",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40973", "10.65.0.27:40973", "172.17.0.1:40973"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:59:33.446105567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7656639024268320,
+				"StableID":   "ndDUeavhn221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:91aff902309a1f47714b2451b3d6dbcd048c135cf9d4c42ab68e08c22c906775",
+				"DiscoKey":   "discokey:342b0e59d198bb48ee599219009391fd73fe8c8aaf546298d18a2d4d646e8b2b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:51649", "10.65.0.27:51649", "172.17.0.1:51649"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:59:33.978276574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2476962605389605,
+				"StableID":   "nA5kUEcpLL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b327ce95d8b07fc2cf8c131fedd06bf4295cd1de21365128168a92e8b2e31d00",
+				"DiscoKey":   "discokey:e427a92e32c5ede0426f101403419d3ee78fcb0f3bb8ca184dd4c04360fc8954",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39814", "10.65.0.27:39814", "172.17.0.1:39814"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:59:34.526845375Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6395681337503055,
+				"StableID":   "nizApohcwr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b6a28b73f192eb7ccf6b6b9a53620506647300d2a065880679a2bb83c9d10525",
+				"KeyExpiry":  "2026-10-26T10:59:35Z",
+				"DiscoKey":   "discokey:3ffd0abe9f5ffd4ef3a76a2c4c50943c3aa8e7bd9eeac06bce8a447b82400611",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58814", "10.65.0.27:58814", "172.17.0.1:58814"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:59:35.574627044Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1647497012794049,
+				"StableID":   "nEh4SGx9sD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:430774f5c474a48f3d09b702d3c392e3c9d5c0e77b17fb765f84b2cb8766f02b",
+				"KeyExpiry":  "2026-10-26T10:59:36Z",
+				"DiscoKey":   "discokey:b4134bce3b9c5a3a08163a41f044730660371336c900c338c12fc084a6c3ea50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43783", "10.65.0.27:43783", "172.17.0.1:43783"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:59:36.124078193Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7656639024268320,
+				"StableID":   "ndDUeavhn221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       7656639024268320,
+				"Key":        "nodekey:91aff902309a1f47714b2451b3d6dbcd048c135cf9d4c42ab68e08c22c906775",
+				"DiscoKey":   "discokey:342b0e59d198bb48ee599219009391fd73fe8c8aaf546298d18a2d4d646e8b2b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:51649", "10.65.0.27:51649", "172.17.0.1:51649"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:59:33.978276574Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:91aff902309a1f47714b2451b3d6dbcd048c135cf9d4c42ab68e08c22c906775",
+			"MachineKey": "mkey:6f48c6311ed6a1c2469680fb14f0278432dacf9968562fb894f0b449391d6115",
+			"Peers": [{
+				"ID":         7055977848701259,
+				"StableID":   "nJEsRFaf6x11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0af622a9c5d428cf9118bcce874971bd7dd5686314f94553309a63f50a5876c",
+				"DiscoKey":   "discokey:5095a74de00d87f3088d4d77d694bb32775801cac74217945dc06beeb493f833",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52841", "10.65.0.27:52841", "172.17.0.1:52841"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:59:32.211580543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         364219773479333,
+				"StableID":   "n44tAHSxq311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33670f52af2f00664ac3bf39cae0c616f380dce41307ae1424d817d433077e2f",
+				"DiscoKey":   "discokey:8d2a589070f8b029b6944ad507b74b886035820d633f7dc29404e3a88e964b48",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:51724", "10.65.0.27:51724", "172.17.0.1:51724"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:59:32.913190841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4030579850338725,
+				"StableID":   "nrTXJtVTUY11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fec87b4fb2ef5f1ee7c76c8282f046a8ca5b372495c2a804c12f884a42397833",
+				"DiscoKey":   "discokey:d69564f30ce6c48090c90bf87ba9881732dca4d0996f306993400bfa7f7aa543",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40973", "10.65.0.27:40973", "172.17.0.1:40973"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:59:33.446105567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2476962605389605,
+				"StableID":   "nA5kUEcpLL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b327ce95d8b07fc2cf8c131fedd06bf4295cd1de21365128168a92e8b2e31d00",
+				"DiscoKey":   "discokey:e427a92e32c5ede0426f101403419d3ee78fcb0f3bb8ca184dd4c04360fc8954",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39814", "10.65.0.27:39814", "172.17.0.1:39814"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:59:34.526845375Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7730336753989430,
+				"StableID":   "nZx1fcq5N321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f847b1a0221843a367f821ee3493af596653976f0727fd49cbda66fe1ac6d361",
+				"KeyExpiry":  "2026-10-26T10:59:35Z",
+				"DiscoKey":   "discokey:c2340ad64b4705d27b73372a68a18525d852892b119f69e85850050e7cf98d01",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34983", "10.65.0.27:34983", "172.17.0.1:34983"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:59:35.044737654Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6395681337503055,
+				"StableID":   "nizApohcwr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b6a28b73f192eb7ccf6b6b9a53620506647300d2a065880679a2bb83c9d10525",
+				"KeyExpiry":  "2026-10-26T10:59:35Z",
+				"DiscoKey":   "discokey:3ffd0abe9f5ffd4ef3a76a2c4c50943c3aa8e7bd9eeac06bce8a447b82400611",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58814", "10.65.0.27:58814", "172.17.0.1:58814"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:59:35.574627044Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1647497012794049,
+				"StableID":   "nEh4SGx9sD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:430774f5c474a48f3d09b702d3c392e3c9d5c0e77b17fb765f84b2cb8766f02b",
+				"KeyExpiry":  "2026-10-26T10:59:36Z",
+				"DiscoKey":   "discokey:b4134bce3b9c5a3a08163a41f044730660371336c900c338c12fc084a6c3ea50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43783", "10.65.0.27:43783", "172.17.0.1:43783"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:59:36.124078193Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7656639024268320": {
+				"ID":          7656639024268320,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         364219773479333,
+				"StableID":   "n44tAHSxq311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       364219773479333,
+				"Key":        "nodekey:33670f52af2f00664ac3bf39cae0c616f380dce41307ae1424d817d433077e2f",
+				"DiscoKey":   "discokey:8d2a589070f8b029b6944ad507b74b886035820d633f7dc29404e3a88e964b48",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:51724", "10.65.0.27:51724", "172.17.0.1:51724"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T10:59:32.913190841Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:33670f52af2f00664ac3bf39cae0c616f380dce41307ae1424d817d433077e2f",
+			"MachineKey": "mkey:61cc6b10c43a9a7c9ba7b2a81cf08d87b82ff761f4646a680fd1c034c15b8c24",
+			"Peers": [{
+				"ID":         7055977848701259,
+				"StableID":   "nJEsRFaf6x11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0af622a9c5d428cf9118bcce874971bd7dd5686314f94553309a63f50a5876c",
+				"DiscoKey":   "discokey:5095a74de00d87f3088d4d77d694bb32775801cac74217945dc06beeb493f833",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52841", "10.65.0.27:52841", "172.17.0.1:52841"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:59:32.211580543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4030579850338725,
+				"StableID":   "nrTXJtVTUY11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fec87b4fb2ef5f1ee7c76c8282f046a8ca5b372495c2a804c12f884a42397833",
+				"DiscoKey":   "discokey:d69564f30ce6c48090c90bf87ba9881732dca4d0996f306993400bfa7f7aa543",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40973", "10.65.0.27:40973", "172.17.0.1:40973"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:59:33.446105567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7656639024268320,
+				"StableID":   "ndDUeavhn221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:91aff902309a1f47714b2451b3d6dbcd048c135cf9d4c42ab68e08c22c906775",
+				"DiscoKey":   "discokey:342b0e59d198bb48ee599219009391fd73fe8c8aaf546298d18a2d4d646e8b2b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:51649", "10.65.0.27:51649", "172.17.0.1:51649"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:59:33.978276574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2476962605389605,
+				"StableID":   "nA5kUEcpLL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b327ce95d8b07fc2cf8c131fedd06bf4295cd1de21365128168a92e8b2e31d00",
+				"DiscoKey":   "discokey:e427a92e32c5ede0426f101403419d3ee78fcb0f3bb8ca184dd4c04360fc8954",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39814", "10.65.0.27:39814", "172.17.0.1:39814"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:59:34.526845375Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7730336753989430,
+				"StableID":   "nZx1fcq5N321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f847b1a0221843a367f821ee3493af596653976f0727fd49cbda66fe1ac6d361",
+				"KeyExpiry":  "2026-10-26T10:59:35Z",
+				"DiscoKey":   "discokey:c2340ad64b4705d27b73372a68a18525d852892b119f69e85850050e7cf98d01",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34983", "10.65.0.27:34983", "172.17.0.1:34983"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:59:35.044737654Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6395681337503055,
+				"StableID":   "nizApohcwr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b6a28b73f192eb7ccf6b6b9a53620506647300d2a065880679a2bb83c9d10525",
+				"KeyExpiry":  "2026-10-26T10:59:35Z",
+				"DiscoKey":   "discokey:3ffd0abe9f5ffd4ef3a76a2c4c50943c3aa8e7bd9eeac06bce8a447b82400611",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58814", "10.65.0.27:58814", "172.17.0.1:58814"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:59:35.574627044Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1647497012794049,
+				"StableID":   "nEh4SGx9sD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:430774f5c474a48f3d09b702d3c392e3c9d5c0e77b17fb765f84b2cb8766f02b",
+				"KeyExpiry":  "2026-10-26T10:59:36Z",
+				"DiscoKey":   "discokey:b4134bce3b9c5a3a08163a41f044730660371336c900c338c12fc084a6c3ea50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43783", "10.65.0.27:43783", "172.17.0.1:43783"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:59:36.124078193Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "364219773479333": {
+				"ID":          364219773479333,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6395681337503055,
+				"StableID":   "nizApohcwr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b6a28b73f192eb7ccf6b6b9a53620506647300d2a065880679a2bb83c9d10525",
+				"KeyExpiry":  "2026-10-26T10:59:35Z",
+				"DiscoKey":   "discokey:3ffd0abe9f5ffd4ef3a76a2c4c50943c3aa8e7bd9eeac06bce8a447b82400611",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58814", "10.65.0.27:58814", "172.17.0.1:58814"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:59:35.574627044Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b6a28b73f192eb7ccf6b6b9a53620506647300d2a065880679a2bb83c9d10525",
+			"MachineKey": "mkey:fee8d34441fd4e9e58f4c84c45cf28a955c2f4e716f82695e60de7ad754dd503",
+			"Peers": [{
+				"ID":         7055977848701259,
+				"StableID":   "nJEsRFaf6x11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0af622a9c5d428cf9118bcce874971bd7dd5686314f94553309a63f50a5876c",
+				"DiscoKey":   "discokey:5095a74de00d87f3088d4d77d694bb32775801cac74217945dc06beeb493f833",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52841", "10.65.0.27:52841", "172.17.0.1:52841"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:59:32.211580543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         364219773479333,
+				"StableID":   "n44tAHSxq311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33670f52af2f00664ac3bf39cae0c616f380dce41307ae1424d817d433077e2f",
+				"DiscoKey":   "discokey:8d2a589070f8b029b6944ad507b74b886035820d633f7dc29404e3a88e964b48",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:51724", "10.65.0.27:51724", "172.17.0.1:51724"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:59:32.913190841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4030579850338725,
+				"StableID":   "nrTXJtVTUY11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fec87b4fb2ef5f1ee7c76c8282f046a8ca5b372495c2a804c12f884a42397833",
+				"DiscoKey":   "discokey:d69564f30ce6c48090c90bf87ba9881732dca4d0996f306993400bfa7f7aa543",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40973", "10.65.0.27:40973", "172.17.0.1:40973"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T10:59:33.446105567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7656639024268320,
+				"StableID":   "ndDUeavhn221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:91aff902309a1f47714b2451b3d6dbcd048c135cf9d4c42ab68e08c22c906775",
+				"DiscoKey":   "discokey:342b0e59d198bb48ee599219009391fd73fe8c8aaf546298d18a2d4d646e8b2b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:51649", "10.65.0.27:51649", "172.17.0.1:51649"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:59:33.978276574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2476962605389605,
+				"StableID":   "nA5kUEcpLL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b327ce95d8b07fc2cf8c131fedd06bf4295cd1de21365128168a92e8b2e31d00",
+				"DiscoKey":   "discokey:e427a92e32c5ede0426f101403419d3ee78fcb0f3bb8ca184dd4c04360fc8954",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39814", "10.65.0.27:39814", "172.17.0.1:39814"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:59:34.526845375Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7730336753989430,
+				"StableID":   "nZx1fcq5N321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f847b1a0221843a367f821ee3493af596653976f0727fd49cbda66fe1ac6d361",
+				"KeyExpiry":  "2026-10-26T10:59:35Z",
+				"DiscoKey":   "discokey:c2340ad64b4705d27b73372a68a18525d852892b119f69e85850050e7cf98d01",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34983", "10.65.0.27:34983", "172.17.0.1:34983"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:59:35.044737654Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1647497012794049,
+				"StableID":   "nEh4SGx9sD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:430774f5c474a48f3d09b702d3c392e3c9d5c0e77b17fb765f84b2cb8766f02b",
+				"KeyExpiry":  "2026-10-26T10:59:36Z",
+				"DiscoKey":   "discokey:b4134bce3b9c5a3a08163a41f044730660371336c900c338c12fc084a6c3ea50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43783", "10.65.0.27:43783", "172.17.0.1:43783"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:59:36.124078193Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4030579850338725,
+				"StableID":   "nrTXJtVTUY11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       4030579850338725,
+				"Key":        "nodekey:fec87b4fb2ef5f1ee7c76c8282f046a8ca5b372495c2a804c12f884a42397833",
+				"DiscoKey":   "discokey:d69564f30ce6c48090c90bf87ba9881732dca4d0996f306993400bfa7f7aa543",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40973", "10.65.0.27:40973", "172.17.0.1:40973"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T10:59:33.446105567Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fec87b4fb2ef5f1ee7c76c8282f046a8ca5b372495c2a804c12f884a42397833",
+			"MachineKey": "mkey:f16251f49f1601a62cd5f9c20b5139d9b7f8f263cdc25a36e1258b5d5a54a317",
+			"Peers": [{
+				"ID":         7055977848701259,
+				"StableID":   "nJEsRFaf6x11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0af622a9c5d428cf9118bcce874971bd7dd5686314f94553309a63f50a5876c",
+				"DiscoKey":   "discokey:5095a74de00d87f3088d4d77d694bb32775801cac74217945dc06beeb493f833",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52841", "10.65.0.27:52841", "172.17.0.1:52841"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T10:59:32.211580543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         364219773479333,
+				"StableID":   "n44tAHSxq311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33670f52af2f00664ac3bf39cae0c616f380dce41307ae1424d817d433077e2f",
+				"DiscoKey":   "discokey:8d2a589070f8b029b6944ad507b74b886035820d633f7dc29404e3a88e964b48",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:51724", "10.65.0.27:51724", "172.17.0.1:51724"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T10:59:32.913190841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7656639024268320,
+				"StableID":   "ndDUeavhn221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:91aff902309a1f47714b2451b3d6dbcd048c135cf9d4c42ab68e08c22c906775",
+				"DiscoKey":   "discokey:342b0e59d198bb48ee599219009391fd73fe8c8aaf546298d18a2d4d646e8b2b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:51649", "10.65.0.27:51649", "172.17.0.1:51649"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T10:59:33.978276574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2476962605389605,
+				"StableID":   "nA5kUEcpLL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b327ce95d8b07fc2cf8c131fedd06bf4295cd1de21365128168a92e8b2e31d00",
+				"DiscoKey":   "discokey:e427a92e32c5ede0426f101403419d3ee78fcb0f3bb8ca184dd4c04360fc8954",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:39814", "10.65.0.27:39814", "172.17.0.1:39814"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T10:59:34.526845375Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7730336753989430,
+				"StableID":   "nZx1fcq5N321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f847b1a0221843a367f821ee3493af596653976f0727fd49cbda66fe1ac6d361",
+				"KeyExpiry":  "2026-10-26T10:59:35Z",
+				"DiscoKey":   "discokey:c2340ad64b4705d27b73372a68a18525d852892b119f69e85850050e7cf98d01",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34983", "10.65.0.27:34983", "172.17.0.1:34983"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T10:59:35.044737654Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6395681337503055,
+				"StableID":   "nizApohcwr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b6a28b73f192eb7ccf6b6b9a53620506647300d2a065880679a2bb83c9d10525",
+				"KeyExpiry":  "2026-10-26T10:59:35Z",
+				"DiscoKey":   "discokey:3ffd0abe9f5ffd4ef3a76a2c4c50943c3aa8e7bd9eeac06bce8a447b82400611",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58814", "10.65.0.27:58814", "172.17.0.1:58814"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T10:59:35.574627044Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1647497012794049,
+				"StableID":   "nEh4SGx9sD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:430774f5c474a48f3d09b702d3c392e3c9d5c0e77b17fb765f84b2cb8766f02b",
+				"KeyExpiry":  "2026-10-26T10:59:36Z",
+				"DiscoKey":   "discokey:b4134bce3b9c5a3a08163a41f044730660371336c900c338c12fc084a6c3ea50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43783", "10.65.0.27:43783", "172.17.0.1:43783"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T10:59:36.124078193Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4030579850338725": {
+				"ID":          4030579850338725,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-proto-numeric.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-proto-numeric.hujson
@@ -1,0 +1,7240 @@
+// policytest-proto-numeric
+//
+// tests block proto: numeric (6, tcp)
+//
+// Nodes with filter rules: 1 of 8
+// Captured at:    2026-04-29T10:59:57Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-proto-numeric",
+	"description":    "tests block proto: numeric (6, tcp)",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T10:59:57.824610704Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                           \n  \n                                                                 \n                                                         \n{\n\t\"id\":          \"policytest-proto-numeric\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block proto: numeric (6, tcp)\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": false},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"proto\": \"6\", \"src\": [\"thor@example.org\"], \"dst\": [\"webserver:443\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"proto\": \"6\", \"accept\": [\"webserver:443\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-proto-numeric.hujson",
+		"full_policy": {
+			"acls": [{
+				"action": "accept",
+				"dst":    ["webserver:443"],
+				"proto":  "6",
+				"src":    ["thor@example.org"]
+			}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["webserver:443"], "proto": "6", "src": "thor@example.org"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {"packet_filter_rules": [{
+		"SrcIPs":   ["100.64.0.17", "fd7a:115c:a1e0::11"],
+		"DstPorts": [{"IP": "100.64.0.16", "Ports": {"First": 443, "Last": 443}}],
+		"IPProto":  [6]
+	}], "packet_filter_matches": [{
+		"IPProto": [6],
+		"Srcs":    ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+		"SrcCaps": null,
+		"Dsts":    [{"Net": "100.64.0.16/32", "Ports": {"First": 443, "Last": 443}}],
+		"Caps":    []
+	}], "netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7290888300001329,
+			"StableID":   "n6XdboG4wy11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       7290888300001329,
+			"Key":        "nodekey:694377ec3d76b4f8d172e9d29b9ce3036a4cb0fdca8dd06322f2e95bbc98960f",
+			"DiscoKey":   "discokey:a7e77c089ac51f11a97b3250fe8121dc9df7a0b057c0345f6f3355e7fb02cb51",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints":  ["77.164.248.136:43841", "10.65.0.27:43841", "172.17.0.1:43841"],
+			"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T11:00:01.474866534Z",
+			"Tags":              ["tag:server"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:694377ec3d76b4f8d172e9d29b9ce3036a4cb0fdca8dd06322f2e95bbc98960f",
+		"MachineKey": "mkey:300b06037a29d81c10178d1896d81ebff319c7bd765eed033d3fe2dfa9a0cb70",
+		"Peers": [{
+			"ID":         5962598326973990,
+			"StableID":   "n3DNC9MUZo11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:8a31f503f22126490ff25bd2f19bbf1709a8fb768fd563a99cf62c2c20b88a11",
+			"KeyExpiry":  "2026-10-26T11:00:02Z",
+			"DiscoKey":   "discokey:cbb194f276e4de9330c0617ae95af5c52e7c68e26e9c8830809b427664f06470",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints":  ["77.164.248.136:46265", "10.65.0.27:46265", "172.17.0.1:46265"],
+			"HomeDERP":   14,
+			"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496}
+			]},
+			"Created":              "2026-04-29T11:00:02.024553616Z",
+			"Cap":                  131,
+			"Online":               true,
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		}],
+		"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter": [{
+			"IPProto": [6],
+			"Srcs":    ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"SrcCaps": null,
+			"Dsts":    [{"Net": "100.64.0.16/32", "Ports": {"First": 443, "Last": 443}}],
+			"Caps":    []
+		}],
+		"PacketFilterRules": [{
+			"SrcIPs":   ["100.64.0.17", "fd7a:115c:a1e0::11"],
+			"DstPorts": [{"IP": "100.64.0.16", "Ports": {"First": 443, "Last": 443}}],
+			"IPProto":  [6]
+		}],
+		"SSHPolicy":       {"rules": []},
+		"CollectServices": false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}, "7290888300001329": {
+			"ID":          7290888300001329,
+			"LoginName":   "beedrill.tail78f774.ts.net",
+			"DisplayName": "beedrill"
+		}}
+	}}, "bulbasaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         535880388798761,
+			"StableID":   "nWVUvofhB511CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:c683046ee3a2a29a85e25c9d54f329beda192c4c29e603f6e01cf1acda55f031",
+			"KeyExpiry":  "2026-10-26T11:00:03Z",
+			"DiscoKey":   "discokey:78d6bb7f8b22264f9d1cedf34bbe5b7c4f5bdac9c951b034a31f50538dc1355a",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints":  ["77.164.248.136:53694", "10.65.0.27:53694", "172.17.0.1:53694"],
+			"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T11:00:03.090137125Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:c683046ee3a2a29a85e25c9d54f329beda192c4c29e603f6e01cf1acda55f031",
+		"MachineKey":        "mkey:070f083c3b58c73937f7b4921e53a471a4a05b3b73cd935fda483c606cc55c63",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}}
+	}}, "charmander": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8996236908026179,
+			"StableID":   "n62zPYtQFD21CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       8996236908026179,
+			"Key":        "nodekey:3acf5985e487ef09b08bd9615e3689327cb16c1dd2cfa0d7cd7e6d4099faf10b",
+			"DiscoKey":   "discokey:33e0ea8007d13f2a9310232e182a5e0b8975653adacd593995034e3f99e8ba48",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"Endpoints":  ["77.164.248.136:50076", "10.65.0.27:50076", "172.17.0.1:50076"],
+			"Hostinfo": {
+				"Hostname":    "charmander",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T10:59:59.31915484Z",
+			"Tags":              ["tag:exit"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:3acf5985e487ef09b08bd9615e3689327cb16c1dd2cfa0d7cd7e6d4099faf10b",
+		"MachineKey":        "mkey:47982af270cbcee713d32e98135c121ca6a84a6b7a240ef769b65e34ce198d71",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"8996236908026179": {
+			"ID":          8996236908026179,
+			"LoginName":   "charmander.tail78f774.ts.net",
+			"DisplayName": "charmander"
+		}}
+	}}, "ivysaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5962598326973990,
+			"StableID":   "n3DNC9MUZo11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:8a31f503f22126490ff25bd2f19bbf1709a8fb768fd563a99cf62c2c20b88a11",
+			"KeyExpiry":  "2026-10-26T11:00:02Z",
+			"DiscoKey":   "discokey:cbb194f276e4de9330c0617ae95af5c52e7c68e26e9c8830809b427664f06470",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints":  ["77.164.248.136:46265", "10.65.0.27:46265", "172.17.0.1:46265"],
+			"Hostinfo": {"Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T11:00:02.024553616Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:8a31f503f22126490ff25bd2f19bbf1709a8fb768fd563a99cf62c2c20b88a11",
+		"MachineKey": "mkey:116f6d4efc45610ccc7f34cbe46b0722a24af276a6c26ba2a1c755da4a11827f",
+		"Peers": [{
+			"ID":         7290888300001329,
+			"StableID":   "n6XdboG4wy11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:694377ec3d76b4f8d172e9d29b9ce3036a4cb0fdca8dd06322f2e95bbc98960f",
+			"DiscoKey":   "discokey:a7e77c089ac51f11a97b3250fe8121dc9df7a0b057c0345f6f3355e7fb02cb51",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints":  ["77.164.248.136:43841", "10.65.0.27:43841", "172.17.0.1:43841"],
+			"HomeDERP":   14,
+			"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358}
+			]},
+			"Created":              "2026-04-29T11:00:01.474866534Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:server"],
+			"Online":               true,
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}}
+	}}, "kakuna": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1617954197732500,
+			"StableID":   "nh7j2yumdD11CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       1617954197732500,
+			"Key":        "nodekey:0c9eda97cb5b585efffa2e8863fe6359dcd08dcce9488386a7df4a476068a229",
+			"DiscoKey":   "discokey:05bec266239c653a21eb15beca25081d6ccfcd7c6e5606f85b743a98b5b0d402",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints":  ["77.164.248.136:39504", "10.65.0.27:39504", "172.17.0.1:39504"],
+			"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T11:00:00.94060284Z",
+			"Tags":              ["tag:prod"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:0c9eda97cb5b585efffa2e8863fe6359dcd08dcce9488386a7df4a476068a229",
+		"MachineKey":        "mkey:e0200a3eec75acbe1a0e918dbd3c08eb52d70146d511af1ea546ece916b18c3e",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1617954197732500": {
+			"ID":          1617954197732500,
+			"LoginName":   "kakuna.tail78f774.ts.net",
+			"DisplayName": "kakuna"
+		}}
+	}}, "squirtle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2054848102496218,
+			"StableID":   "ndJcKmNe3H11CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       2054848102496218,
+			"Key":        "nodekey:a9fa8146e47e078a9be9ce9d702421583b2f4f9a58a539ce618fa15be1ad6d03",
+			"DiscoKey":   "discokey:003805fecf8cac4136fed4b1c61f4c32796ca722603f170a9aae728be856083e",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"Endpoints":  ["77.164.248.136:38074", "10.65.0.27:38074", "172.17.0.1:38074"],
+			"Hostinfo": {
+				"Hostname":    "squirtle",
+				"RoutableIPs": ["10.33.0.0/16"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T10:59:59.878579692Z",
+			"Tags":              ["tag:router"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:a9fa8146e47e078a9be9ce9d702421583b2f4f9a58a539ce618fa15be1ad6d03",
+		"MachineKey":        "mkey:afd558598fd2bf60e6adf9ac0b0c223789b7bfadfd1972a56c8816f936abff4a",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"2054848102496218": {
+			"ID":          2054848102496218,
+			"LoginName":   "squirtle.tail78f774.ts.net",
+			"DisplayName": "squirtle"
+		}}
+	}}, "venusaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7502957209188051,
+			"StableID":   "nStYurx6b121CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:adf7ece2f89a2706d970e422fc6ea136537e8ac8979f4f1cc93faced23b09355",
+			"KeyExpiry":  "2026-10-26T11:00:02Z",
+			"DiscoKey":   "discokey:a07e0dd25e4112ce8126b87b0e79694633fede7f6471e8ae9b62bd6969e53354",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints":  ["77.164.248.136:58208", "10.65.0.27:58208", "172.17.0.1:58208"],
+			"Hostinfo": {"Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T11:00:02.554688905Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:adf7ece2f89a2706d970e422fc6ea136537e8ac8979f4f1cc93faced23b09355",
+		"MachineKey":        "mkey:08dc8919f2bfd1d55d108e20ec9e783a76714599b47f0eccc970a09fbe829c4f",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}}
+	}}, "weedle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7394740273635722,
+			"StableID":   "nbbCtgH6kz11CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       7394740273635722,
+			"Key":        "nodekey:5512583a861ab806685254ae2e3786b0e655d884ff42654dea25307417e7756a",
+			"DiscoKey":   "discokey:e7632c5712d2b9bedda1105e66441265568d490bc9913d469a51402d2b9af718",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints":  ["77.164.248.136:34046", "10.65.0.27:34046", "172.17.0.1:34046"],
+			"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T11:00:00.40966322Z",
+			"Tags":              ["tag:client"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:5512583a861ab806685254ae2e3786b0e655d884ff42654dea25307417e7756a",
+		"MachineKey":        "mkey:974021bed6765ef2e0a5206dc4ae8c103b68d9aa1daa9818a0b801daf619f172",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"7394740273635722": {
+			"ID":          7394740273635722,
+			"LoginName":   "weedle.tail78f774.ts.net",
+			"DisplayName": "weedle"
+		}}
+	}}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-proto-tcp.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-proto-tcp.hujson
@@ -1,0 +1,7240 @@
+// policytest-proto-tcp
+//
+// tests block proto: tcp string
+//
+// Nodes with filter rules: 1 of 8
+// Captured at:    2026-04-29T11:00:33Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-proto-tcp",
+	"description":    "tests block proto: tcp string",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T11:00:33.922021971Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                       \n  \n                                                                    \n                                     \n{\n\t\"id\":          \"policytest-proto-tcp\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block proto: tcp string\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": false},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"proto\": \"tcp\", \"src\": [\"thor@example.org\"], \"dst\": [\"webserver:80\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"proto\": \"tcp\", \"accept\": [\"webserver:80\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-proto-tcp.hujson",
+		"full_policy": {
+			"acls": [{
+				"action": "accept",
+				"dst":    ["webserver:80"],
+				"proto":  "tcp",
+				"src":    ["thor@example.org"]
+			}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["webserver:80"], "proto": "tcp", "src": "thor@example.org"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {"packet_filter_rules": [{
+		"SrcIPs":   ["100.64.0.17", "fd7a:115c:a1e0::11"],
+		"DstPorts": [{"IP": "100.64.0.16", "Ports": {"First": 80, "Last": 80}}],
+		"IPProto":  [6]
+	}], "packet_filter_matches": [{
+		"IPProto": [6],
+		"Srcs":    ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+		"SrcCaps": null,
+		"Dsts":    [{"Net": "100.64.0.16/32", "Ports": {"First": 80, "Last": 80}}],
+		"Caps":    []
+	}], "netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8063979410118327,
+			"StableID":   "npVyfm4Cy521CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       8063979410118327,
+			"Key":        "nodekey:bfaed4f28a28b9d689f9c4a37490727c1913d0cfefa66d2d7cad02ccf046e637",
+			"DiscoKey":   "discokey:94944bb1cce44fc5d77e6a370f4be2e0014d034f8d0b26efb7569c90ec747251",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints":  ["77.164.248.136:38922", "10.65.0.27:38922", "172.17.0.1:38922"],
+			"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T11:00:37.704979559Z",
+			"Tags":              ["tag:server"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:bfaed4f28a28b9d689f9c4a37490727c1913d0cfefa66d2d7cad02ccf046e637",
+		"MachineKey": "mkey:d821b6d04522b8f3ebf1fbf79d2d84ee5c5e52d5d7e80500744799045778a468",
+		"Peers": [{
+			"ID":         5673391469623014,
+			"StableID":   "n5N9ZfNVJm11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:682782aabd22e3600f17b35664a28d1c1b458d18087fbe7f45a6b3894de0926c",
+			"KeyExpiry":  "2026-10-26T11:00:38Z",
+			"DiscoKey":   "discokey:600d3ba3265b3270c752e1df5ed1e43fa73905b71bf40c536013ce583c46fa7f",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints":  ["77.164.248.136:35812", "10.65.0.27:35812", "172.17.0.1:35812"],
+			"HomeDERP":   4,
+			"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496}
+			]},
+			"Created":              "2026-04-29T11:00:38.225649074Z",
+			"Cap":                  131,
+			"Online":               true,
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		}],
+		"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter": [{
+			"IPProto": [6],
+			"Srcs":    ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"SrcCaps": null,
+			"Dsts":    [{"Net": "100.64.0.16/32", "Ports": {"First": 80, "Last": 80}}],
+			"Caps":    []
+		}],
+		"PacketFilterRules": [{
+			"SrcIPs":   ["100.64.0.17", "fd7a:115c:a1e0::11"],
+			"DstPorts": [{"IP": "100.64.0.16", "Ports": {"First": 80, "Last": 80}}],
+			"IPProto":  [6]
+		}],
+		"SSHPolicy":       {"rules": []},
+		"CollectServices": false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}, "8063979410118327": {
+			"ID":          8063979410118327,
+			"LoginName":   "beedrill.tail78f774.ts.net",
+			"DisplayName": "beedrill"
+		}}
+	}}, "bulbasaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         132295364662922,
+			"StableID":   "nqzMM9Bv2211CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:71902b8f2d35308d37df364eceac1de9665e01176023be1276f0cb770532c30c",
+			"KeyExpiry":  "2026-10-26T11:00:39Z",
+			"DiscoKey":   "discokey:339e7baab84069e8a8b66ad1e164faedc9d6cdaec51daddacd41fe291bde035a",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints":  ["77.164.248.136:57043", "10.65.0.27:57043", "172.17.0.1:57043"],
+			"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T11:00:39.302306599Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:71902b8f2d35308d37df364eceac1de9665e01176023be1276f0cb770532c30c",
+		"MachineKey":        "mkey:e4d1a69eff715efc2f72a8abda0e6841ecacdb800f1fc0e5ee5856b916d7ef1c",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}}
+	}}, "charmander": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         3489487337814494,
+			"StableID":   "n54ar5vPFU11CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       3489487337814494,
+			"Key":        "nodekey:4b1c1b8059796a51172bbd13f5acac45c4a7ff4b15deb93187529d1c5474bf08",
+			"DiscoKey":   "discokey:d37b898526bac351ae27a4e906938a69bb1b4c07c944a13ad66f4f0d889abf1d",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"Endpoints":  ["77.164.248.136:46286", "10.65.0.27:46286", "172.17.0.1:46286"],
+			"Hostinfo": {
+				"Hostname":    "charmander",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T11:00:35.448125608Z",
+			"Tags":              ["tag:exit"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:4b1c1b8059796a51172bbd13f5acac45c4a7ff4b15deb93187529d1c5474bf08",
+		"MachineKey":        "mkey:16e33fc88e26466660a0deca80c8b17653e714a9df2355360651aa5309d59f1f",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3489487337814494": {
+			"ID":          3489487337814494,
+			"LoginName":   "charmander.tail78f774.ts.net",
+			"DisplayName": "charmander"
+		}}
+	}}, "ivysaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5673391469623014,
+			"StableID":   "n5N9ZfNVJm11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:682782aabd22e3600f17b35664a28d1c1b458d18087fbe7f45a6b3894de0926c",
+			"KeyExpiry":  "2026-10-26T11:00:38Z",
+			"DiscoKey":   "discokey:600d3ba3265b3270c752e1df5ed1e43fa73905b71bf40c536013ce583c46fa7f",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints":  ["77.164.248.136:35812", "10.65.0.27:35812", "172.17.0.1:35812"],
+			"Hostinfo": {"Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T11:00:38.225649074Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:682782aabd22e3600f17b35664a28d1c1b458d18087fbe7f45a6b3894de0926c",
+		"MachineKey": "mkey:f2e3390c34d91711cd005c2eae508d4ab59a8a94a7ec1a818b969798e3430019",
+		"Peers": [{
+			"ID":         8063979410118327,
+			"StableID":   "npVyfm4Cy521CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:bfaed4f28a28b9d689f9c4a37490727c1913d0cfefa66d2d7cad02ccf046e637",
+			"DiscoKey":   "discokey:94944bb1cce44fc5d77e6a370f4be2e0014d034f8d0b26efb7569c90ec747251",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints":  ["77.164.248.136:38922", "10.65.0.27:38922", "172.17.0.1:38922"],
+			"HomeDERP":   14,
+			"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358}
+			]},
+			"Created":              "2026-04-29T11:00:37.704979559Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:server"],
+			"Online":               true,
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}}
+	}}, "kakuna": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         3130389165470466,
+			"StableID":   "n7dE3t1mSR11CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       3130389165470466,
+			"Key":        "nodekey:f809deba8eb99c220859bcb87e9dce81e8c6de3a61dc20b295288d03d71d1b33",
+			"DiscoKey":   "discokey:e21e8a1adec6e0103b349f7cfc7e4724f183b07ba0c4e7e4e9f8e09a30221302",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints":  ["77.164.248.136:37658", "10.65.0.27:37658", "172.17.0.1:37658"],
+			"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T11:00:37.154324428Z",
+			"Tags":              ["tag:prod"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:f809deba8eb99c220859bcb87e9dce81e8c6de3a61dc20b295288d03d71d1b33",
+		"MachineKey":        "mkey:2a94dcf553292f81ac00bf5d43bee674fd97f087111dd0e3d7b217f41628d833",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3130389165470466": {
+			"ID":          3130389165470466,
+			"LoginName":   "kakuna.tail78f774.ts.net",
+			"DisplayName": "kakuna"
+		}}
+	}}, "squirtle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4759476535558124,
+			"StableID":   "nX2NPvNaAe11CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       4759476535558124,
+			"Key":        "nodekey:bf8375f150b1cb771cedc618ea1ea24c6f8b62797b53df291649d30479f54956",
+			"DiscoKey":   "discokey:ac463c8e02fd9a85ac3bc862147b8c9d36560dfa32c06aed3a3bc25f93d5d071",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"Endpoints":  ["77.164.248.136:55883", "10.65.0.27:55883", "172.17.0.1:55883"],
+			"Hostinfo": {
+				"Hostname":    "squirtle",
+				"RoutableIPs": ["10.33.0.0/16"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T11:00:36.10740461Z",
+			"Tags":              ["tag:router"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:bf8375f150b1cb771cedc618ea1ea24c6f8b62797b53df291649d30479f54956",
+		"MachineKey":        "mkey:ce815d0b389e5becd8021b2f1e9d984ad0a4c935d00f5695d19c1aed4cfbc515",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4759476535558124": {
+			"ID":          4759476535558124,
+			"LoginName":   "squirtle.tail78f774.ts.net",
+			"DisplayName": "squirtle"
+		}}
+	}}, "venusaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1795480882746926,
+			"StableID":   "nX5qGpEB2F11CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:e7f0d362f0cc5772d446344111e40d69cbbe5b1778d4791b1ba2610cceeb1a0c",
+			"KeyExpiry":  "2026-10-26T11:00:38Z",
+			"DiscoKey":   "discokey:7a9cfd16e64d63f32ef1bb892acfcaa148cd9020d18100618a779140b062bb04",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints":  ["77.164.248.136:35612", "10.65.0.27:35612", "172.17.0.1:35612"],
+			"Hostinfo": {"Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T11:00:38.782359927Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:e7f0d362f0cc5772d446344111e40d69cbbe5b1778d4791b1ba2610cceeb1a0c",
+		"MachineKey":        "mkey:e52a9c171d7786ab91f7241c8d67afc927326c2070ebf175030f9e2d7be77c22",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}}
+	}}, "weedle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8325839489271198,
+			"StableID":   "nPVoAkgn1821CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       8325839489271198,
+			"Key":        "nodekey:4df34d0c44153a583502613d846df8ac52a6db598a703e21e08c26ac0f80b043",
+			"DiscoKey":   "discokey:0d7cf74909bb5515965f8f5c113572272a9fc6e3c1ec38b835a994bbc30fbf76",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints":  ["77.164.248.136:58838", "10.65.0.27:58838", "172.17.0.1:58838"],
+			"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T11:00:36.616330465Z",
+			"Tags":              ["tag:client"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:4df34d0c44153a583502613d846df8ac52a6db598a703e21e08c26ac0f80b043",
+		"MachineKey":        "mkey:23ce4fb0e36eb28535ab93e1c0fa436a7ce2ce7b15e2b0563c0f0b2001e7815e",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"8325839489271198": {
+			"ID":          8325839489271198,
+			"LoginName":   "weedle.tail78f774.ts.net",
+			"DisplayName": "weedle"
+		}}
+	}}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-proto-udp.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-proto-udp.hujson
@@ -1,0 +1,7235 @@
+// policytest-proto-udp
+//
+// tests block proto: udp string
+//
+// Nodes with filter rules: 1 of 8
+// Captured at:    2026-04-29T11:01:10Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-proto-udp",
+	"description":    "tests block proto: udp string",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T11:01:10.099497045Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                       \n  \n                                                                    \n                                     \n{\n\t\"id\":          \"policytest-proto-udp\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block proto: udp string\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": false},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"proto\": \"udp\", \"src\": [\"thor@example.org\"], \"dst\": [\"webserver:53\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"thor@example.org\", \"proto\": \"udp\", \"accept\": [\"webserver:53\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-proto-udp.hujson",
+		"full_policy": {
+			"acls": [{
+				"action": "accept",
+				"dst":    ["webserver:53"],
+				"proto":  "udp",
+				"src":    ["thor@example.org"]
+			}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["webserver:53"], "proto": "udp", "src": "thor@example.org"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {"packet_filter_rules": [{
+		"SrcIPs":   ["100.64.0.17", "fd7a:115c:a1e0::11"],
+		"DstPorts": [{"IP": "100.64.0.16", "Ports": {"First": 53, "Last": 53}}],
+		"IPProto":  [17]
+	}], "packet_filter_matches": [{
+		"IPProto": [17],
+		"Srcs":    ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+		"SrcCaps": null,
+		"Dsts":    [{"Net": "100.64.0.16/32", "Ports": {"First": 53, "Last": 53}}],
+		"Caps":    []
+	}], "netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4926656812102411,
+			"StableID":   "nvGdwNvHUf11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       4926656812102411,
+			"Key":        "nodekey:fcd6cfc9924a5afa3448b0cf3833dea08908d174036e702823e147efd0f6737e",
+			"DiscoKey":   "discokey:ca40ddba5648405db52c442ab3e50294db01552f6f6467cf1c4e726307589163",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints":  ["77.164.248.136:50785", "10.65.0.27:50785", "172.17.0.1:50785"],
+			"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T11:02:51.909167277Z",
+			"Tags":              ["tag:server"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:fcd6cfc9924a5afa3448b0cf3833dea08908d174036e702823e147efd0f6737e",
+		"MachineKey": "mkey:8648ca178d39ac17b9c83a6bcdf4c28480ee4cd1e463ec409a39432060b5c854",
+		"Peers": [{
+			"ID":         4187862592901810,
+			"StableID":   "nK13gq3hhZ11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:d88342e4605438cb51ab12c08965e29050d85b9845e061d0735b51859ac3a20b",
+			"KeyExpiry":  "2026-10-26T11:02:52Z",
+			"DiscoKey":   "discokey:a86f2317b674c142cdfcc1fc157f919a27c6e8345240a75ca332424814d7236e",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints":  ["77.164.248.136:33207", "10.65.0.27:33207", "172.17.0.1:33207"],
+			"HomeDERP":   14,
+			"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496}
+			]},
+			"Created":              "2026-04-29T11:02:52.948369289Z",
+			"Cap":                  131,
+			"Online":               true,
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		}],
+		"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter": [{
+			"IPProto": [17],
+			"Srcs":    ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"SrcCaps": null,
+			"Dsts":    [{"Net": "100.64.0.16/32", "Ports": {"First": 53, "Last": 53}}],
+			"Caps":    []
+		}],
+		"PacketFilterRules": [{
+			"SrcIPs":   ["100.64.0.17", "fd7a:115c:a1e0::11"],
+			"DstPorts": [{"IP": "100.64.0.16", "Ports": {"First": 53, "Last": 53}}],
+			"IPProto":  [17]
+		}],
+		"SSHPolicy":       {"rules": []},
+		"CollectServices": false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}, "4926656812102411": {
+			"ID":          4926656812102411,
+			"LoginName":   "beedrill.tail78f774.ts.net",
+			"DisplayName": "beedrill"
+		}}
+	}}, "bulbasaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         667773029550336,
+			"StableID":   "nTLXwNGSD611CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:bcbf774f900f93f8a2dd7be04c34dadeb51aebec1256ff772cae97b1ace69106",
+			"KeyExpiry":  "2026-10-26T11:03:23Z",
+			"DiscoKey":   "discokey:1af37bb65da072cfc27607f1d555660326871214907f3ebc1142f0034e383367",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints":  ["77.164.248.136:35682", "10.65.0.27:35682", "172.17.0.1:35682"],
+			"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T11:03:23.610330947Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:bcbf774f900f93f8a2dd7be04c34dadeb51aebec1256ff772cae97b1ace69106",
+		"MachineKey":        "mkey:99145908c5a567023172eadd5adfc16e6094f6f371df531a724e6a2fd08b0770",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}}
+	}}, "charmander": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5529422504910176,
+			"StableID":   "nPeB95ZHBk11CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       5529422504910176,
+			"Key":        "nodekey:8d978ec3f9019a087f6ac175106bdfe1317fa8cfdff017c72a0c7b118cf34f7a",
+			"DiscoKey":   "discokey:3769c2d8415d111312487b0d6c9ef46aeaf81d7cc947beb342c698256f1f9506",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"Endpoints":  ["77.164.248.136:58533", "10.65.0.27:58533", "172.17.0.1:58533"],
+			"Hostinfo": {
+				"Hostname":    "charmander",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-04-29T11:02:10.514192986Z",
+			"Tags":              ["tag:exit"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:8d978ec3f9019a087f6ac175106bdfe1317fa8cfdff017c72a0c7b118cf34f7a",
+		"MachineKey":        "mkey:e878ca28d1f5dd5524333bcc591fe1fd68a550ac1bd6701a89b8733be168dc5a",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"5529422504910176": {
+			"ID":          5529422504910176,
+			"LoginName":   "charmander.tail78f774.ts.net",
+			"DisplayName": "charmander"
+		}}
+	}}, "ivysaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4187862592901810,
+			"StableID":   "nK13gq3hhZ11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:d88342e4605438cb51ab12c08965e29050d85b9845e061d0735b51859ac3a20b",
+			"KeyExpiry":  "2026-10-26T11:02:52Z",
+			"DiscoKey":   "discokey:a86f2317b674c142cdfcc1fc157f919a27c6e8345240a75ca332424814d7236e",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints":  ["77.164.248.136:33207", "10.65.0.27:33207", "172.17.0.1:33207"],
+			"Hostinfo": {"Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T11:02:52.948369289Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:d88342e4605438cb51ab12c08965e29050d85b9845e061d0735b51859ac3a20b",
+		"MachineKey": "mkey:b7cfb842586a7b1d0b8337265ea41308c46438a53816c3049aa5e62c97482331",
+		"Peers": [{
+			"ID":         4926656812102411,
+			"StableID":   "nvGdwNvHUf11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:fcd6cfc9924a5afa3448b0cf3833dea08908d174036e702823e147efd0f6737e",
+			"DiscoKey":   "discokey:ca40ddba5648405db52c442ab3e50294db01552f6f6467cf1c4e726307589163",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints":  ["77.164.248.136:50785", "10.65.0.27:50785", "172.17.0.1:50785"],
+			"HomeDERP":   14,
+			"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358}
+			]},
+			"Created":              "2026-04-29T11:02:51.909167277Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:server"],
+			"Online":               true,
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}}
+	}}, "kakuna": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8620600142057182,
+			"StableID":   "nPqKhmYHKA21CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       8620600142057182,
+			"Key":        "nodekey:24f8cf558b7d6abdb3965d5dd1d85b40199cdc352dbe95403bd83585c1dbe658",
+			"DiscoKey":   "discokey:c4ad5a7b13ebc68754f2dd82a5a70e90aa1749cf1aa7887ab15738836c575f69",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints":  ["77.164.248.136:44364", "10.65.0.27:44364", "172.17.0.1:44364"],
+			"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T11:02:51.092873248Z",
+			"Tags":              ["tag:prod"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:24f8cf558b7d6abdb3965d5dd1d85b40199cdc352dbe95403bd83585c1dbe658",
+		"MachineKey":        "mkey:f9dba73886503b8787d845e6f4eaaef3c72f9d3a68086f8fe13db06151393f44",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"8620600142057182": {
+			"ID":          8620600142057182,
+			"LoginName":   "kakuna.tail78f774.ts.net",
+			"DisplayName": "kakuna"
+		}}
+	}}, "squirtle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1382988616523345,
+			"StableID":   "n2ZmDRmMoB11CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       1382988616523345,
+			"Key":        "nodekey:a1814a7dfa9a86f0a22b4e3ce99ebd4009c55eee262a621bc1748b6f6580f026",
+			"DiscoKey":   "discokey:b691921d2121140f9bfff4c01acd19a95a0d0c7734ed2a2275b692af8357e94e",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"Endpoints":  ["77.164.248.136:54908", "10.65.0.27:54908", "172.17.0.1:54908"],
+			"Hostinfo": {"Hostname": "squirtle", "RequestTags": ["tag:router"], "Services": [
+				{"Proto": "peerapi4", "Port": 43119},
+				{"Proto": "peerapi6", "Port": 43119},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T11:02:45.389306833Z",
+			"Tags":              ["tag:router"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:a1814a7dfa9a86f0a22b4e3ce99ebd4009c55eee262a621bc1748b6f6580f026",
+		"MachineKey":        "mkey:cfd47000d9b6448e3eb53553c80b282a41ec3d999b7b513108f317e38c0c3160",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1382988616523345": {
+			"ID":          1382988616523345,
+			"LoginName":   "squirtle.tail78f774.ts.net",
+			"DisplayName": "squirtle"
+		}}
+	}}, "venusaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4625449564474171,
+			"StableID":   "nUKUuZis7d11CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:405cb52ff4e4d4e001f7ba6bfd7ba1f3f96afdaf7565b01472924a438f9a7e2f",
+			"KeyExpiry":  "2026-10-26T11:02:53Z",
+			"DiscoKey":   "discokey:615ac7c21fcb7f5abe1082b68208345a27f38a17b537e440fa4aeee788a7b316",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints":  ["77.164.248.136:48986", "10.65.0.27:48986", "172.17.0.1:48986"],
+			"Hostinfo": {"Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T11:02:53.971243788Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:405cb52ff4e4d4e001f7ba6bfd7ba1f3f96afdaf7565b01472924a438f9a7e2f",
+		"MachineKey":        "mkey:b4d6bcdbbfaa4bc2f0e89926feeeaf3b5a602f7ca1bdd8825324bdc0c7135b3d",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}}
+	}}, "weedle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5366747279859466,
+			"StableID":   "nPoPZLMcui11CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       5366747279859466,
+			"Key":        "nodekey:2ea0576fd7ca72b1c4e2ac62173ae41842ecc039130977b6024ebe4278440267",
+			"DiscoKey":   "discokey:c3355d286dbac6401552de9d8acbe735a0ed30eb001658e81ddc2d738fb61e1b",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints":  ["77.164.248.136:55147", "10.65.0.27:55147", "172.17.0.1:55147"],
+			"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-04-29T11:02:49.958605709Z",
+			"Tags":              ["tag:client"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:2ea0576fd7ca72b1c4e2ac62173ae41842ecc039130977b6024ebe4278440267",
+		"MachineKey":        "mkey:0d1ec43500610337cb3958149bec28b0d2ab5eeb8bb803ad2ba6bdd7b90f2d55",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"5366747279859466": {
+			"ID":          5366747279859466,
+			"LoginName":   "weedle.tail78f774.ts.net",
+			"DisplayName": "weedle"
+		}}
+	}}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-src-unknown-autogroup.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-src-unknown-autogroup.hujson
@@ -1,0 +1,8833 @@
+// policytest-src-unknown-autogroup
+//
+// tests block src-unknown: autogroup not recognised
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T11:03:58Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-src-unknown-autogroup",
+	"description":    "tests block src-unknown: autogroup not recognised",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T11:03:58.995708223Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                   \n  \n                                                              \n                                                                  \n{\n\t\"id\":          \"policytest-src-unknown-autogroup\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block src-unknown: autogroup not recognised\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"autogroup:member\"], \"dst\": [\"tag:server:22\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"autogroup:bogus\", \"accept\": [\"tag:server:22\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-src-unknown-autogroup.hujson",
+		"full_policy": {"acls": [{
+			"action": "accept",
+			"dst":    ["tag:server:22"],
+			"src":    ["autogroup:member"]
+		}], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [{"accept": ["tag:server:22"], "src": "autogroup:bogus"}]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7498057557474070,
+				"StableID":   "n7doTwFtY121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       7498057557474070,
+				"Key":        "nodekey:a5d809ddccf086e131dcbafb3fd4b7a9367831e91475174a878697e2cff22c0f",
+				"DiscoKey":   "discokey:13c2bfb58ff07b2e8d10559eb8670f1d4f5d5a735d7dc418be8a1a2677812f66",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:44356", "10.65.0.27:44356", "172.17.0.1:44356"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:04:10.862092809Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a5d809ddccf086e131dcbafb3fd4b7a9367831e91475174a878697e2cff22c0f",
+			"MachineKey": "mkey:a60d00aabb860f67abe79d5f0a964cedab6155bac030bba5ca86c4da12762733",
+			"Peers": [{
+				"ID":         5376805908726319,
+				"StableID":   "nnYY9HaAzi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:76f9474562f4658ffc5e8ad21b78ba3796d60904d0adfd631c2f5b1abb455b34",
+				"DiscoKey":   "discokey:e65d5fcac9df6c7312735d248e13e8719189b0da42a0458c3eb902598cf62466",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52792", "10.65.0.27:52792", "172.17.0.1:52792"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:04:04.58321976Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4910964930980881,
+				"StableID":   "nnmC9qiBMf11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e84a4b403e3325a9b4550a3a16c9ced31ffe103d25f770bbcb98515c4ba49b10",
+				"DiscoKey":   "discokey:00d1f66dcef758889caadb58d05cd140c6c6539bec80fda66b910d8c3c21064c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:59612", "10.65.0.27:59612", "172.17.0.1:59612"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:04:08.441157225Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8421166338741840,
+				"StableID":   "nsYfR5mxk821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3bffeaf2cabbd809d0f175b7b27b75d8305bfacec6a75974dc46792fb822eb1a",
+				"DiscoKey":   "discokey:7f42ebbb72f2b00b80ad872151d62649291c32d29918e776051affa13883a52a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40393", "10.65.0.27:40393", "172.17.0.1:40393"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:04:09.158247931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3430796928470184,
+				"StableID":   "nR9hMdDpnT11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92cd8ae02c6bd2b4c6c062ea8522ca1d4e90cace0a8177262f930ccbcd4f090b",
+				"DiscoKey":   "discokey:6111494bd4c9b1502c0394eb07fda1543275a3cfa2e533179fc689ddef29d131",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53045", "10.65.0.27:53045", "172.17.0.1:53045"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:04:09.923306506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6742874095336473,
+				"StableID":   "nNqCvNsreu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:41d2f5581d7ff6d5915f67445c1699432f85ccbe7cc075a35b8b395245c17859",
+				"KeyExpiry":  "2026-10-26T11:04:11Z",
+				"DiscoKey":   "discokey:709caeda2484f8c26e3140b97a7557a5c02626642d82cf2a0e98465764ac7a70",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51241", "10.65.0.27:51241", "172.17.0.1:51241"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:04:11.753153042Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2615209784445423,
+				"StableID":   "ngybHL8SRM11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b246183ea5787e9398c8a3d75a9cf8e90fb851ac455c3900bcec66d048c34862",
+				"KeyExpiry":  "2026-10-26T11:04:12Z",
+				"DiscoKey":   "discokey:6e15200730292649685592719e8648eb5748ddc0be29eb63ecf7a2872cfe153a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:44098", "10.65.0.27:44098", "172.17.0.1:44098"],
+				"HomeDERP":   26,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:04:12.459006325Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7665299691612213,
+				"StableID":   "nQSQAeRdr221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c603ced6b2231684bd8e5fe1382a2b2b71a53259645433a8dae88a585b4541a",
+				"KeyExpiry":  "2026-10-26T11:04:13Z",
+				"DiscoKey":   "discokey:4c3d21b348891ef309a0c8ca96563f38089b5d85ab926ad3349ad56ce8f2ed15",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:04:13.269848535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7498057557474070": {
+				"ID":          7498057557474070,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7665299691612213,
+				"StableID":   "nQSQAeRdr221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c603ced6b2231684bd8e5fe1382a2b2b71a53259645433a8dae88a585b4541a",
+				"KeyExpiry":  "2026-10-26T11:04:13Z",
+				"DiscoKey":   "discokey:4c3d21b348891ef309a0c8ca96563f38089b5d85ab926ad3349ad56ce8f2ed15",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:04:13.269848535Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1c603ced6b2231684bd8e5fe1382a2b2b71a53259645433a8dae88a585b4541a",
+			"MachineKey": "mkey:a088a063cc83c7c241a2b886ce9300d4084d95e1b0d92f3e421eadab7c787d6c",
+			"Peers": [{
+				"ID":         5376805908726319,
+				"StableID":   "nnYY9HaAzi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:76f9474562f4658ffc5e8ad21b78ba3796d60904d0adfd631c2f5b1abb455b34",
+				"DiscoKey":   "discokey:e65d5fcac9df6c7312735d248e13e8719189b0da42a0458c3eb902598cf62466",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52792", "10.65.0.27:52792", "172.17.0.1:52792"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:04:04.58321976Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4910964930980881,
+				"StableID":   "nnmC9qiBMf11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e84a4b403e3325a9b4550a3a16c9ced31ffe103d25f770bbcb98515c4ba49b10",
+				"DiscoKey":   "discokey:00d1f66dcef758889caadb58d05cd140c6c6539bec80fda66b910d8c3c21064c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:59612", "10.65.0.27:59612", "172.17.0.1:59612"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:04:08.441157225Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8421166338741840,
+				"StableID":   "nsYfR5mxk821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3bffeaf2cabbd809d0f175b7b27b75d8305bfacec6a75974dc46792fb822eb1a",
+				"DiscoKey":   "discokey:7f42ebbb72f2b00b80ad872151d62649291c32d29918e776051affa13883a52a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40393", "10.65.0.27:40393", "172.17.0.1:40393"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:04:09.158247931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3430796928470184,
+				"StableID":   "nR9hMdDpnT11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92cd8ae02c6bd2b4c6c062ea8522ca1d4e90cace0a8177262f930ccbcd4f090b",
+				"DiscoKey":   "discokey:6111494bd4c9b1502c0394eb07fda1543275a3cfa2e533179fc689ddef29d131",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53045", "10.65.0.27:53045", "172.17.0.1:53045"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:04:09.923306506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7498057557474070,
+				"StableID":   "n7doTwFtY121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a5d809ddccf086e131dcbafb3fd4b7a9367831e91475174a878697e2cff22c0f",
+				"DiscoKey":   "discokey:13c2bfb58ff07b2e8d10559eb8670f1d4f5d5a735d7dc418be8a1a2677812f66",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:44356", "10.65.0.27:44356", "172.17.0.1:44356"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:04:10.862092809Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6742874095336473,
+				"StableID":   "nNqCvNsreu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:41d2f5581d7ff6d5915f67445c1699432f85ccbe7cc075a35b8b395245c17859",
+				"KeyExpiry":  "2026-10-26T11:04:11Z",
+				"DiscoKey":   "discokey:709caeda2484f8c26e3140b97a7557a5c02626642d82cf2a0e98465764ac7a70",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51241", "10.65.0.27:51241", "172.17.0.1:51241"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:04:11.753153042Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2615209784445423,
+				"StableID":   "ngybHL8SRM11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b246183ea5787e9398c8a3d75a9cf8e90fb851ac455c3900bcec66d048c34862",
+				"KeyExpiry":  "2026-10-26T11:04:12Z",
+				"DiscoKey":   "discokey:6e15200730292649685592719e8648eb5748ddc0be29eb63ecf7a2872cfe153a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:44098", "10.65.0.27:44098", "172.17.0.1:44098"],
+				"HomeDERP":   26,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:04:12.459006325Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5376805908726319,
+				"StableID":   "nnYY9HaAzi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       5376805908726319,
+				"Key":        "nodekey:76f9474562f4658ffc5e8ad21b78ba3796d60904d0adfd631c2f5b1abb455b34",
+				"DiscoKey":   "discokey:e65d5fcac9df6c7312735d248e13e8719189b0da42a0458c3eb902598cf62466",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52792", "10.65.0.27:52792", "172.17.0.1:52792"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T11:04:04.58321976Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:76f9474562f4658ffc5e8ad21b78ba3796d60904d0adfd631c2f5b1abb455b34",
+			"MachineKey": "mkey:6073c7fc857b2e82fb085bc3306c2b8eba8b5adab8ec6f3478991c3c1a9ea05f",
+			"Peers": [{
+				"ID":         4910964930980881,
+				"StableID":   "nnmC9qiBMf11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e84a4b403e3325a9b4550a3a16c9ced31ffe103d25f770bbcb98515c4ba49b10",
+				"DiscoKey":   "discokey:00d1f66dcef758889caadb58d05cd140c6c6539bec80fda66b910d8c3c21064c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:59612", "10.65.0.27:59612", "172.17.0.1:59612"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:04:08.441157225Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8421166338741840,
+				"StableID":   "nsYfR5mxk821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3bffeaf2cabbd809d0f175b7b27b75d8305bfacec6a75974dc46792fb822eb1a",
+				"DiscoKey":   "discokey:7f42ebbb72f2b00b80ad872151d62649291c32d29918e776051affa13883a52a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40393", "10.65.0.27:40393", "172.17.0.1:40393"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:04:09.158247931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3430796928470184,
+				"StableID":   "nR9hMdDpnT11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92cd8ae02c6bd2b4c6c062ea8522ca1d4e90cace0a8177262f930ccbcd4f090b",
+				"DiscoKey":   "discokey:6111494bd4c9b1502c0394eb07fda1543275a3cfa2e533179fc689ddef29d131",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53045", "10.65.0.27:53045", "172.17.0.1:53045"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:04:09.923306506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7498057557474070,
+				"StableID":   "n7doTwFtY121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a5d809ddccf086e131dcbafb3fd4b7a9367831e91475174a878697e2cff22c0f",
+				"DiscoKey":   "discokey:13c2bfb58ff07b2e8d10559eb8670f1d4f5d5a735d7dc418be8a1a2677812f66",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:44356", "10.65.0.27:44356", "172.17.0.1:44356"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:04:10.862092809Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6742874095336473,
+				"StableID":   "nNqCvNsreu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:41d2f5581d7ff6d5915f67445c1699432f85ccbe7cc075a35b8b395245c17859",
+				"KeyExpiry":  "2026-10-26T11:04:11Z",
+				"DiscoKey":   "discokey:709caeda2484f8c26e3140b97a7557a5c02626642d82cf2a0e98465764ac7a70",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51241", "10.65.0.27:51241", "172.17.0.1:51241"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:04:11.753153042Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2615209784445423,
+				"StableID":   "ngybHL8SRM11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b246183ea5787e9398c8a3d75a9cf8e90fb851ac455c3900bcec66d048c34862",
+				"KeyExpiry":  "2026-10-26T11:04:12Z",
+				"DiscoKey":   "discokey:6e15200730292649685592719e8648eb5748ddc0be29eb63ecf7a2872cfe153a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:44098", "10.65.0.27:44098", "172.17.0.1:44098"],
+				"HomeDERP":   26,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:04:12.459006325Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7665299691612213,
+				"StableID":   "nQSQAeRdr221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c603ced6b2231684bd8e5fe1382a2b2b71a53259645433a8dae88a585b4541a",
+				"KeyExpiry":  "2026-10-26T11:04:13Z",
+				"DiscoKey":   "discokey:4c3d21b348891ef309a0c8ca96563f38089b5d85ab926ad3349ad56ce8f2ed15",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:04:13.269848535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5376805908726319": {
+				"ID":          5376805908726319,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6742874095336473,
+				"StableID":   "nNqCvNsreu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:41d2f5581d7ff6d5915f67445c1699432f85ccbe7cc075a35b8b395245c17859",
+				"KeyExpiry":  "2026-10-26T11:04:11Z",
+				"DiscoKey":   "discokey:709caeda2484f8c26e3140b97a7557a5c02626642d82cf2a0e98465764ac7a70",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51241", "10.65.0.27:51241", "172.17.0.1:51241"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:04:11.753153042Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:41d2f5581d7ff6d5915f67445c1699432f85ccbe7cc075a35b8b395245c17859",
+			"MachineKey": "mkey:64ad526424d66c507bdf1fa538a1cbae22fdedca583fb01481ab1ce7597c7459",
+			"Peers": [{
+				"ID":         5376805908726319,
+				"StableID":   "nnYY9HaAzi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:76f9474562f4658ffc5e8ad21b78ba3796d60904d0adfd631c2f5b1abb455b34",
+				"DiscoKey":   "discokey:e65d5fcac9df6c7312735d248e13e8719189b0da42a0458c3eb902598cf62466",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52792", "10.65.0.27:52792", "172.17.0.1:52792"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:04:04.58321976Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4910964930980881,
+				"StableID":   "nnmC9qiBMf11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e84a4b403e3325a9b4550a3a16c9ced31ffe103d25f770bbcb98515c4ba49b10",
+				"DiscoKey":   "discokey:00d1f66dcef758889caadb58d05cd140c6c6539bec80fda66b910d8c3c21064c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:59612", "10.65.0.27:59612", "172.17.0.1:59612"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:04:08.441157225Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8421166338741840,
+				"StableID":   "nsYfR5mxk821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3bffeaf2cabbd809d0f175b7b27b75d8305bfacec6a75974dc46792fb822eb1a",
+				"DiscoKey":   "discokey:7f42ebbb72f2b00b80ad872151d62649291c32d29918e776051affa13883a52a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40393", "10.65.0.27:40393", "172.17.0.1:40393"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:04:09.158247931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3430796928470184,
+				"StableID":   "nR9hMdDpnT11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92cd8ae02c6bd2b4c6c062ea8522ca1d4e90cace0a8177262f930ccbcd4f090b",
+				"DiscoKey":   "discokey:6111494bd4c9b1502c0394eb07fda1543275a3cfa2e533179fc689ddef29d131",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53045", "10.65.0.27:53045", "172.17.0.1:53045"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:04:09.923306506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7498057557474070,
+				"StableID":   "n7doTwFtY121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a5d809ddccf086e131dcbafb3fd4b7a9367831e91475174a878697e2cff22c0f",
+				"DiscoKey":   "discokey:13c2bfb58ff07b2e8d10559eb8670f1d4f5d5a735d7dc418be8a1a2677812f66",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:44356", "10.65.0.27:44356", "172.17.0.1:44356"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:04:10.862092809Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2615209784445423,
+				"StableID":   "ngybHL8SRM11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b246183ea5787e9398c8a3d75a9cf8e90fb851ac455c3900bcec66d048c34862",
+				"KeyExpiry":  "2026-10-26T11:04:12Z",
+				"DiscoKey":   "discokey:6e15200730292649685592719e8648eb5748ddc0be29eb63ecf7a2872cfe153a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:44098", "10.65.0.27:44098", "172.17.0.1:44098"],
+				"HomeDERP":   26,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:04:12.459006325Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7665299691612213,
+				"StableID":   "nQSQAeRdr221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c603ced6b2231684bd8e5fe1382a2b2b71a53259645433a8dae88a585b4541a",
+				"KeyExpiry":  "2026-10-26T11:04:13Z",
+				"DiscoKey":   "discokey:4c3d21b348891ef309a0c8ca96563f38089b5d85ab926ad3349ad56ce8f2ed15",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:04:13.269848535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3430796928470184,
+				"StableID":   "nR9hMdDpnT11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       3430796928470184,
+				"Key":        "nodekey:92cd8ae02c6bd2b4c6c062ea8522ca1d4e90cace0a8177262f930ccbcd4f090b",
+				"DiscoKey":   "discokey:6111494bd4c9b1502c0394eb07fda1543275a3cfa2e533179fc689ddef29d131",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53045", "10.65.0.27:53045", "172.17.0.1:53045"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:04:09.923306506Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:92cd8ae02c6bd2b4c6c062ea8522ca1d4e90cace0a8177262f930ccbcd4f090b",
+			"MachineKey": "mkey:88b8bb8e4a5867766fa2df1d4e99dd015402117ebb6f8f79305fcf0fb6208d4f",
+			"Peers": [{
+				"ID":         5376805908726319,
+				"StableID":   "nnYY9HaAzi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:76f9474562f4658ffc5e8ad21b78ba3796d60904d0adfd631c2f5b1abb455b34",
+				"DiscoKey":   "discokey:e65d5fcac9df6c7312735d248e13e8719189b0da42a0458c3eb902598cf62466",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52792", "10.65.0.27:52792", "172.17.0.1:52792"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:04:04.58321976Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4910964930980881,
+				"StableID":   "nnmC9qiBMf11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e84a4b403e3325a9b4550a3a16c9ced31ffe103d25f770bbcb98515c4ba49b10",
+				"DiscoKey":   "discokey:00d1f66dcef758889caadb58d05cd140c6c6539bec80fda66b910d8c3c21064c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:59612", "10.65.0.27:59612", "172.17.0.1:59612"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:04:08.441157225Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8421166338741840,
+				"StableID":   "nsYfR5mxk821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3bffeaf2cabbd809d0f175b7b27b75d8305bfacec6a75974dc46792fb822eb1a",
+				"DiscoKey":   "discokey:7f42ebbb72f2b00b80ad872151d62649291c32d29918e776051affa13883a52a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40393", "10.65.0.27:40393", "172.17.0.1:40393"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:04:09.158247931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7498057557474070,
+				"StableID":   "n7doTwFtY121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a5d809ddccf086e131dcbafb3fd4b7a9367831e91475174a878697e2cff22c0f",
+				"DiscoKey":   "discokey:13c2bfb58ff07b2e8d10559eb8670f1d4f5d5a735d7dc418be8a1a2677812f66",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:44356", "10.65.0.27:44356", "172.17.0.1:44356"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:04:10.862092809Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6742874095336473,
+				"StableID":   "nNqCvNsreu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:41d2f5581d7ff6d5915f67445c1699432f85ccbe7cc075a35b8b395245c17859",
+				"KeyExpiry":  "2026-10-26T11:04:11Z",
+				"DiscoKey":   "discokey:709caeda2484f8c26e3140b97a7557a5c02626642d82cf2a0e98465764ac7a70",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51241", "10.65.0.27:51241", "172.17.0.1:51241"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:04:11.753153042Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2615209784445423,
+				"StableID":   "ngybHL8SRM11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b246183ea5787e9398c8a3d75a9cf8e90fb851ac455c3900bcec66d048c34862",
+				"KeyExpiry":  "2026-10-26T11:04:12Z",
+				"DiscoKey":   "discokey:6e15200730292649685592719e8648eb5748ddc0be29eb63ecf7a2872cfe153a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:44098", "10.65.0.27:44098", "172.17.0.1:44098"],
+				"HomeDERP":   26,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:04:12.459006325Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7665299691612213,
+				"StableID":   "nQSQAeRdr221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c603ced6b2231684bd8e5fe1382a2b2b71a53259645433a8dae88a585b4541a",
+				"KeyExpiry":  "2026-10-26T11:04:13Z",
+				"DiscoKey":   "discokey:4c3d21b348891ef309a0c8ca96563f38089b5d85ab926ad3349ad56ce8f2ed15",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:04:13.269848535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3430796928470184": {
+				"ID":          3430796928470184,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4910964930980881,
+				"StableID":   "nnmC9qiBMf11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       4910964930980881,
+				"Key":        "nodekey:e84a4b403e3325a9b4550a3a16c9ced31ffe103d25f770bbcb98515c4ba49b10",
+				"DiscoKey":   "discokey:00d1f66dcef758889caadb58d05cd140c6c6539bec80fda66b910d8c3c21064c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:59612", "10.65.0.27:59612", "172.17.0.1:59612"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T11:04:08.441157225Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e84a4b403e3325a9b4550a3a16c9ced31ffe103d25f770bbcb98515c4ba49b10",
+			"MachineKey": "mkey:bc7f3261b28ecb91466b63d42da9e7186cb3de1a8813c4ad63a668ee6d1d8255",
+			"Peers": [{
+				"ID":         5376805908726319,
+				"StableID":   "nnYY9HaAzi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:76f9474562f4658ffc5e8ad21b78ba3796d60904d0adfd631c2f5b1abb455b34",
+				"DiscoKey":   "discokey:e65d5fcac9df6c7312735d248e13e8719189b0da42a0458c3eb902598cf62466",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52792", "10.65.0.27:52792", "172.17.0.1:52792"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:04:04.58321976Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8421166338741840,
+				"StableID":   "nsYfR5mxk821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3bffeaf2cabbd809d0f175b7b27b75d8305bfacec6a75974dc46792fb822eb1a",
+				"DiscoKey":   "discokey:7f42ebbb72f2b00b80ad872151d62649291c32d29918e776051affa13883a52a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40393", "10.65.0.27:40393", "172.17.0.1:40393"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:04:09.158247931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3430796928470184,
+				"StableID":   "nR9hMdDpnT11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92cd8ae02c6bd2b4c6c062ea8522ca1d4e90cace0a8177262f930ccbcd4f090b",
+				"DiscoKey":   "discokey:6111494bd4c9b1502c0394eb07fda1543275a3cfa2e533179fc689ddef29d131",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53045", "10.65.0.27:53045", "172.17.0.1:53045"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:04:09.923306506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7498057557474070,
+				"StableID":   "n7doTwFtY121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a5d809ddccf086e131dcbafb3fd4b7a9367831e91475174a878697e2cff22c0f",
+				"DiscoKey":   "discokey:13c2bfb58ff07b2e8d10559eb8670f1d4f5d5a735d7dc418be8a1a2677812f66",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:44356", "10.65.0.27:44356", "172.17.0.1:44356"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:04:10.862092809Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6742874095336473,
+				"StableID":   "nNqCvNsreu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:41d2f5581d7ff6d5915f67445c1699432f85ccbe7cc075a35b8b395245c17859",
+				"KeyExpiry":  "2026-10-26T11:04:11Z",
+				"DiscoKey":   "discokey:709caeda2484f8c26e3140b97a7557a5c02626642d82cf2a0e98465764ac7a70",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51241", "10.65.0.27:51241", "172.17.0.1:51241"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:04:11.753153042Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2615209784445423,
+				"StableID":   "ngybHL8SRM11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b246183ea5787e9398c8a3d75a9cf8e90fb851ac455c3900bcec66d048c34862",
+				"KeyExpiry":  "2026-10-26T11:04:12Z",
+				"DiscoKey":   "discokey:6e15200730292649685592719e8648eb5748ddc0be29eb63ecf7a2872cfe153a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:44098", "10.65.0.27:44098", "172.17.0.1:44098"],
+				"HomeDERP":   26,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:04:12.459006325Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7665299691612213,
+				"StableID":   "nQSQAeRdr221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c603ced6b2231684bd8e5fe1382a2b2b71a53259645433a8dae88a585b4541a",
+				"KeyExpiry":  "2026-10-26T11:04:13Z",
+				"DiscoKey":   "discokey:4c3d21b348891ef309a0c8ca96563f38089b5d85ab926ad3349ad56ce8f2ed15",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:04:13.269848535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4910964930980881": {
+				"ID":          4910964930980881,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2615209784445423,
+				"StableID":   "ngybHL8SRM11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b246183ea5787e9398c8a3d75a9cf8e90fb851ac455c3900bcec66d048c34862",
+				"KeyExpiry":  "2026-10-26T11:04:12Z",
+				"DiscoKey":   "discokey:6e15200730292649685592719e8648eb5748ddc0be29eb63ecf7a2872cfe153a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:44098", "10.65.0.27:44098", "172.17.0.1:44098"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:04:12.459006325Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b246183ea5787e9398c8a3d75a9cf8e90fb851ac455c3900bcec66d048c34862",
+			"MachineKey": "mkey:ecd4516c4321788ade2a017f90af51ed8b61e03910945e667fec920f3b86ac3f",
+			"Peers": [{
+				"ID":         5376805908726319,
+				"StableID":   "nnYY9HaAzi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:76f9474562f4658ffc5e8ad21b78ba3796d60904d0adfd631c2f5b1abb455b34",
+				"DiscoKey":   "discokey:e65d5fcac9df6c7312735d248e13e8719189b0da42a0458c3eb902598cf62466",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52792", "10.65.0.27:52792", "172.17.0.1:52792"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:04:04.58321976Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4910964930980881,
+				"StableID":   "nnmC9qiBMf11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e84a4b403e3325a9b4550a3a16c9ced31ffe103d25f770bbcb98515c4ba49b10",
+				"DiscoKey":   "discokey:00d1f66dcef758889caadb58d05cd140c6c6539bec80fda66b910d8c3c21064c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:59612", "10.65.0.27:59612", "172.17.0.1:59612"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:04:08.441157225Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8421166338741840,
+				"StableID":   "nsYfR5mxk821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3bffeaf2cabbd809d0f175b7b27b75d8305bfacec6a75974dc46792fb822eb1a",
+				"DiscoKey":   "discokey:7f42ebbb72f2b00b80ad872151d62649291c32d29918e776051affa13883a52a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40393", "10.65.0.27:40393", "172.17.0.1:40393"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:04:09.158247931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3430796928470184,
+				"StableID":   "nR9hMdDpnT11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92cd8ae02c6bd2b4c6c062ea8522ca1d4e90cace0a8177262f930ccbcd4f090b",
+				"DiscoKey":   "discokey:6111494bd4c9b1502c0394eb07fda1543275a3cfa2e533179fc689ddef29d131",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53045", "10.65.0.27:53045", "172.17.0.1:53045"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:04:09.923306506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7498057557474070,
+				"StableID":   "n7doTwFtY121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a5d809ddccf086e131dcbafb3fd4b7a9367831e91475174a878697e2cff22c0f",
+				"DiscoKey":   "discokey:13c2bfb58ff07b2e8d10559eb8670f1d4f5d5a735d7dc418be8a1a2677812f66",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:44356", "10.65.0.27:44356", "172.17.0.1:44356"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:04:10.862092809Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6742874095336473,
+				"StableID":   "nNqCvNsreu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:41d2f5581d7ff6d5915f67445c1699432f85ccbe7cc075a35b8b395245c17859",
+				"KeyExpiry":  "2026-10-26T11:04:11Z",
+				"DiscoKey":   "discokey:709caeda2484f8c26e3140b97a7557a5c02626642d82cf2a0e98465764ac7a70",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51241", "10.65.0.27:51241", "172.17.0.1:51241"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:04:11.753153042Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7665299691612213,
+				"StableID":   "nQSQAeRdr221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c603ced6b2231684bd8e5fe1382a2b2b71a53259645433a8dae88a585b4541a",
+				"KeyExpiry":  "2026-10-26T11:04:13Z",
+				"DiscoKey":   "discokey:4c3d21b348891ef309a0c8ca96563f38089b5d85ab926ad3349ad56ce8f2ed15",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:04:13.269848535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8421166338741840,
+				"StableID":   "nsYfR5mxk821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       8421166338741840,
+				"Key":        "nodekey:3bffeaf2cabbd809d0f175b7b27b75d8305bfacec6a75974dc46792fb822eb1a",
+				"DiscoKey":   "discokey:7f42ebbb72f2b00b80ad872151d62649291c32d29918e776051affa13883a52a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40393", "10.65.0.27:40393", "172.17.0.1:40393"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:04:09.158247931Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3bffeaf2cabbd809d0f175b7b27b75d8305bfacec6a75974dc46792fb822eb1a",
+			"MachineKey": "mkey:28f005e106978b3734acdb630666ab8e5988b45f9038a02d21eaab010d75551b",
+			"Peers": [{
+				"ID":         5376805908726319,
+				"StableID":   "nnYY9HaAzi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:76f9474562f4658ffc5e8ad21b78ba3796d60904d0adfd631c2f5b1abb455b34",
+				"DiscoKey":   "discokey:e65d5fcac9df6c7312735d248e13e8719189b0da42a0458c3eb902598cf62466",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52792", "10.65.0.27:52792", "172.17.0.1:52792"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:04:04.58321976Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4910964930980881,
+				"StableID":   "nnmC9qiBMf11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e84a4b403e3325a9b4550a3a16c9ced31ffe103d25f770bbcb98515c4ba49b10",
+				"DiscoKey":   "discokey:00d1f66dcef758889caadb58d05cd140c6c6539bec80fda66b910d8c3c21064c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:59612", "10.65.0.27:59612", "172.17.0.1:59612"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:04:08.441157225Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3430796928470184,
+				"StableID":   "nR9hMdDpnT11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92cd8ae02c6bd2b4c6c062ea8522ca1d4e90cace0a8177262f930ccbcd4f090b",
+				"DiscoKey":   "discokey:6111494bd4c9b1502c0394eb07fda1543275a3cfa2e533179fc689ddef29d131",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:53045", "10.65.0.27:53045", "172.17.0.1:53045"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:04:09.923306506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7498057557474070,
+				"StableID":   "n7doTwFtY121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a5d809ddccf086e131dcbafb3fd4b7a9367831e91475174a878697e2cff22c0f",
+				"DiscoKey":   "discokey:13c2bfb58ff07b2e8d10559eb8670f1d4f5d5a735d7dc418be8a1a2677812f66",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:44356", "10.65.0.27:44356", "172.17.0.1:44356"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:04:10.862092809Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6742874095336473,
+				"StableID":   "nNqCvNsreu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:41d2f5581d7ff6d5915f67445c1699432f85ccbe7cc075a35b8b395245c17859",
+				"KeyExpiry":  "2026-10-26T11:04:11Z",
+				"DiscoKey":   "discokey:709caeda2484f8c26e3140b97a7557a5c02626642d82cf2a0e98465764ac7a70",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51241", "10.65.0.27:51241", "172.17.0.1:51241"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:04:11.753153042Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2615209784445423,
+				"StableID":   "ngybHL8SRM11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b246183ea5787e9398c8a3d75a9cf8e90fb851ac455c3900bcec66d048c34862",
+				"KeyExpiry":  "2026-10-26T11:04:12Z",
+				"DiscoKey":   "discokey:6e15200730292649685592719e8648eb5748ddc0be29eb63ecf7a2872cfe153a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:44098", "10.65.0.27:44098", "172.17.0.1:44098"],
+				"HomeDERP":   26,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:04:12.459006325Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7665299691612213,
+				"StableID":   "nQSQAeRdr221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c603ced6b2231684bd8e5fe1382a2b2b71a53259645433a8dae88a585b4541a",
+				"KeyExpiry":  "2026-10-26T11:04:13Z",
+				"DiscoKey":   "discokey:4c3d21b348891ef309a0c8ca96563f38089b5d85ab926ad3349ad56ce8f2ed15",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:04:13.269848535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8421166338741840": {
+				"ID":          8421166338741840,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-src-unknown-group.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-src-unknown-group.hujson
@@ -1,0 +1,8841 @@
+// policytest-src-unknown-group
+//
+// tests block src-unknown: group not declared in policy.groups
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T11:04:41Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-src-unknown-group",
+	"description":    "tests block src-unknown: group not declared in policy.groups",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T11:04:41.854569897Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                               \n  \n                                                                      \n                                                           \n{\n\t\"id\":          \"policytest-src-unknown-group\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block src-unknown: group not declared in policy.groups\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"group:developers\"], \"dst\": [\"tag:server:22\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"group:phantom\", \"accept\": [\"tag:server:22\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-src-unknown-group.hujson",
+		"full_policy": {"acls": [{
+			"action": "accept",
+			"dst":    ["tag:server:22"],
+			"src":    ["group:developers"]
+		}], "groups": {
+			"group:admins":     ["odin@example.com"],
+			"group:developers": ["thor@example.org", "odin@example.com"],
+			"group:empty":      [],
+			"group:monitors":   ["freya@example.com"]
+		}, "hosts": {
+			"internal":  "10.0.0.0/8",
+			"prodbox":   "100.103.8.15",
+			"subnet24":  "192.168.1.0/24",
+			"webserver": "100.64.0.16"
+		}, "tagOwners": {
+			"tag:client":    ["odin@example.com"],
+			"tag:exit":      ["odin@example.com"],
+			"tag:pidgey":    ["odin@example.com"],
+			"tag:pidgeotto": ["odin@example.com"],
+			"tag:group-a":   ["odin@example.com"],
+			"tag:group-b":   ["odin@example.com"],
+			"tag:ha":        ["odin@example.com"],
+			"tag:prod":      ["odin@example.com"],
+			"tag:router":    ["odin@example.com"],
+			"tag:spearow":   ["odin@example.com"],
+			"tag:fearow":    ["odin@example.com"],
+			"tag:server":    ["odin@example.com"]
+		}, "tests": [{"accept": ["tag:server:22"], "src": "group:phantom"}]}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1221129267526804,
+				"StableID":   "nBv1piz3YA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1221129267526804,
+				"Key":        "nodekey:685f33afe836b188360c6e801838f138488cc20836f3244f22aeb1dd1523e350",
+				"DiscoKey":   "discokey:7a6ded82b73a599603b3c6c93f7c530289727d311b8635e8ed2a4e38a8d24421",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53150", "10.65.0.27:53150", "172.17.0.1:53150"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:04:52.942034381Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:685f33afe836b188360c6e801838f138488cc20836f3244f22aeb1dd1523e350",
+			"MachineKey": "mkey:6ca157c8526902f1b7371366a700e5d6772fb6422d866066a4e2d9a637d58671",
+			"Peers": [{
+				"ID":         8442035953973021,
+				"StableID":   "ncJorDyQv821CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f0ba21103efde24cbcbf8124cdfc509700f725e8fcce8bd4b6632ec996431c",
+				"DiscoKey":   "discokey:748d96ad50544f6767a184613f2c8f2fc9aa8953e723e5cab5dbba913572513b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:36510", "10.65.0.27:36510", "172.17.0.1:36510"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:04:44.303497882Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5563687250688700,
+				"StableID":   "nTnhPXdoSk11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2bfbf73d6ac68572e8efbdc282e1eeece23000be24e6eb69b85f58cdb1f80269",
+				"DiscoKey":   "discokey:5c55587c8898b58ad91b96a9fea61a617367b18387bde443ee48a321769b8b53",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46945", "10.65.0.27:46945", "172.17.0.1:46945"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:04:50.133684208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3355050348362585,
+				"StableID":   "ntNNT3VWCT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f2227d9c07badd5e4c3b7cdf8560fb2abd35cfd32aec0ae883988878ef87c6b",
+				"DiscoKey":   "discokey:148f2aa87e7f3c830752a2e730c5a38db8b09633a482e0a7f3c99da8dd3def05",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:55698", "10.65.0.27:55698", "172.17.0.1:55698"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:04:51.086090066Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3507107004883453,
+				"StableID":   "nzfsVjkNPU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cad4e4fa94dbfc76f7690065299cf88538f8b0628dba9ed381e4a367bdfa8469",
+				"DiscoKey":   "discokey:c7341a053c443d78e95d6614b233d943c3b24fcbd141c684f24d165b01c4db33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43569", "10.65.0.27:43569", "172.17.0.1:43569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:04:52.025650368Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8189960431026882,
+				"StableID":   "nhk66dNFx621CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7bfcbf93d5932c19ddcfa1850a56e403358cbbb349564f95727b50271142cb7d",
+				"KeyExpiry":  "2026-10-26T11:04:54Z",
+				"DiscoKey":   "discokey:205b89276d0aba9addecfe052e9dacb08fc30791a588b740508fcd6b0eedd35a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38975", "10.65.0.27:38975", "172.17.0.1:38975"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:04:54.142007269Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1600449135742171,
+				"StableID":   "nLbQev5rVD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a36bdc0999bf7cf4275ea3151929e0bdcbed74986efa80b727217720fb6bb17",
+				"KeyExpiry":  "2026-10-26T11:05:02Z",
+				"DiscoKey":   "discokey:80d9da6c6f57c7d65b807c16cae8bf3d0798047a50ce95a2953403baffeb3e4f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37669", "10.65.0.27:37669", "172.17.0.1:37669"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:05:02.411991476Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5536048968355944,
+				"StableID":   "n1ZR2ucHEk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b903addfada5afbcf60addfec92bff161025879088699f2375d325ea602fc0d",
+				"KeyExpiry":  "2026-10-26T11:05:03Z",
+				"DiscoKey":   "discokey:405da5b9891149958da51830b8edb610ae8afa874945ef8975412fd4da4b5d3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51616", "10.65.0.27:51616", "172.17.0.1:51616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:05:03.453276459Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1221129267526804": {
+				"ID":          1221129267526804,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5536048968355944,
+				"StableID":   "n1ZR2ucHEk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b903addfada5afbcf60addfec92bff161025879088699f2375d325ea602fc0d",
+				"KeyExpiry":  "2026-10-26T11:05:03Z",
+				"DiscoKey":   "discokey:405da5b9891149958da51830b8edb610ae8afa874945ef8975412fd4da4b5d3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51616", "10.65.0.27:51616", "172.17.0.1:51616"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:05:03.453276459Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7b903addfada5afbcf60addfec92bff161025879088699f2375d325ea602fc0d",
+			"MachineKey": "mkey:045abff3419158d0653e7d40f9e0e32f9a59b55a43c712c4e4fc678918eae666",
+			"Peers": [{
+				"ID":         8442035953973021,
+				"StableID":   "ncJorDyQv821CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f0ba21103efde24cbcbf8124cdfc509700f725e8fcce8bd4b6632ec996431c",
+				"DiscoKey":   "discokey:748d96ad50544f6767a184613f2c8f2fc9aa8953e723e5cab5dbba913572513b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:36510", "10.65.0.27:36510", "172.17.0.1:36510"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:04:44.303497882Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5563687250688700,
+				"StableID":   "nTnhPXdoSk11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2bfbf73d6ac68572e8efbdc282e1eeece23000be24e6eb69b85f58cdb1f80269",
+				"DiscoKey":   "discokey:5c55587c8898b58ad91b96a9fea61a617367b18387bde443ee48a321769b8b53",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46945", "10.65.0.27:46945", "172.17.0.1:46945"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:04:50.133684208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3355050348362585,
+				"StableID":   "ntNNT3VWCT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f2227d9c07badd5e4c3b7cdf8560fb2abd35cfd32aec0ae883988878ef87c6b",
+				"DiscoKey":   "discokey:148f2aa87e7f3c830752a2e730c5a38db8b09633a482e0a7f3c99da8dd3def05",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:55698", "10.65.0.27:55698", "172.17.0.1:55698"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:04:51.086090066Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3507107004883453,
+				"StableID":   "nzfsVjkNPU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cad4e4fa94dbfc76f7690065299cf88538f8b0628dba9ed381e4a367bdfa8469",
+				"DiscoKey":   "discokey:c7341a053c443d78e95d6614b233d943c3b24fcbd141c684f24d165b01c4db33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43569", "10.65.0.27:43569", "172.17.0.1:43569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:04:52.025650368Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1221129267526804,
+				"StableID":   "nBv1piz3YA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:685f33afe836b188360c6e801838f138488cc20836f3244f22aeb1dd1523e350",
+				"DiscoKey":   "discokey:7a6ded82b73a599603b3c6c93f7c530289727d311b8635e8ed2a4e38a8d24421",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53150", "10.65.0.27:53150", "172.17.0.1:53150"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:04:52.942034381Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8189960431026882,
+				"StableID":   "nhk66dNFx621CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7bfcbf93d5932c19ddcfa1850a56e403358cbbb349564f95727b50271142cb7d",
+				"KeyExpiry":  "2026-10-26T11:04:54Z",
+				"DiscoKey":   "discokey:205b89276d0aba9addecfe052e9dacb08fc30791a588b740508fcd6b0eedd35a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38975", "10.65.0.27:38975", "172.17.0.1:38975"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:04:54.142007269Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1600449135742171,
+				"StableID":   "nLbQev5rVD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a36bdc0999bf7cf4275ea3151929e0bdcbed74986efa80b727217720fb6bb17",
+				"KeyExpiry":  "2026-10-26T11:05:02Z",
+				"DiscoKey":   "discokey:80d9da6c6f57c7d65b807c16cae8bf3d0798047a50ce95a2953403baffeb3e4f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37669", "10.65.0.27:37669", "172.17.0.1:37669"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:05:02.411991476Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8442035953973021,
+				"StableID":   "ncJorDyQv821CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       8442035953973021,
+				"Key":        "nodekey:28f0ba21103efde24cbcbf8124cdfc509700f725e8fcce8bd4b6632ec996431c",
+				"DiscoKey":   "discokey:748d96ad50544f6767a184613f2c8f2fc9aa8953e723e5cab5dbba913572513b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:36510", "10.65.0.27:36510", "172.17.0.1:36510"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T11:04:44.303497882Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:28f0ba21103efde24cbcbf8124cdfc509700f725e8fcce8bd4b6632ec996431c",
+			"MachineKey": "mkey:481ec1c06ab6e2c8cc608fc64998aa2e5df0ef0dc10df32a7ce9bb71f4d3eb5e",
+			"Peers": [{
+				"ID":         5563687250688700,
+				"StableID":   "nTnhPXdoSk11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2bfbf73d6ac68572e8efbdc282e1eeece23000be24e6eb69b85f58cdb1f80269",
+				"DiscoKey":   "discokey:5c55587c8898b58ad91b96a9fea61a617367b18387bde443ee48a321769b8b53",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46945", "10.65.0.27:46945", "172.17.0.1:46945"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:04:50.133684208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3355050348362585,
+				"StableID":   "ntNNT3VWCT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f2227d9c07badd5e4c3b7cdf8560fb2abd35cfd32aec0ae883988878ef87c6b",
+				"DiscoKey":   "discokey:148f2aa87e7f3c830752a2e730c5a38db8b09633a482e0a7f3c99da8dd3def05",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:55698", "10.65.0.27:55698", "172.17.0.1:55698"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:04:51.086090066Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3507107004883453,
+				"StableID":   "nzfsVjkNPU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cad4e4fa94dbfc76f7690065299cf88538f8b0628dba9ed381e4a367bdfa8469",
+				"DiscoKey":   "discokey:c7341a053c443d78e95d6614b233d943c3b24fcbd141c684f24d165b01c4db33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43569", "10.65.0.27:43569", "172.17.0.1:43569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:04:52.025650368Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1221129267526804,
+				"StableID":   "nBv1piz3YA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:685f33afe836b188360c6e801838f138488cc20836f3244f22aeb1dd1523e350",
+				"DiscoKey":   "discokey:7a6ded82b73a599603b3c6c93f7c530289727d311b8635e8ed2a4e38a8d24421",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53150", "10.65.0.27:53150", "172.17.0.1:53150"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:04:52.942034381Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8189960431026882,
+				"StableID":   "nhk66dNFx621CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7bfcbf93d5932c19ddcfa1850a56e403358cbbb349564f95727b50271142cb7d",
+				"KeyExpiry":  "2026-10-26T11:04:54Z",
+				"DiscoKey":   "discokey:205b89276d0aba9addecfe052e9dacb08fc30791a588b740508fcd6b0eedd35a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38975", "10.65.0.27:38975", "172.17.0.1:38975"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:04:54.142007269Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1600449135742171,
+				"StableID":   "nLbQev5rVD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a36bdc0999bf7cf4275ea3151929e0bdcbed74986efa80b727217720fb6bb17",
+				"KeyExpiry":  "2026-10-26T11:05:02Z",
+				"DiscoKey":   "discokey:80d9da6c6f57c7d65b807c16cae8bf3d0798047a50ce95a2953403baffeb3e4f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37669", "10.65.0.27:37669", "172.17.0.1:37669"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:05:02.411991476Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5536048968355944,
+				"StableID":   "n1ZR2ucHEk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b903addfada5afbcf60addfec92bff161025879088699f2375d325ea602fc0d",
+				"KeyExpiry":  "2026-10-26T11:05:03Z",
+				"DiscoKey":   "discokey:405da5b9891149958da51830b8edb610ae8afa874945ef8975412fd4da4b5d3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51616", "10.65.0.27:51616", "172.17.0.1:51616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:05:03.453276459Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8442035953973021": {
+				"ID":          8442035953973021,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8189960431026882,
+				"StableID":   "nhk66dNFx621CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7bfcbf93d5932c19ddcfa1850a56e403358cbbb349564f95727b50271142cb7d",
+				"KeyExpiry":  "2026-10-26T11:04:54Z",
+				"DiscoKey":   "discokey:205b89276d0aba9addecfe052e9dacb08fc30791a588b740508fcd6b0eedd35a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38975", "10.65.0.27:38975", "172.17.0.1:38975"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:04:54.142007269Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7bfcbf93d5932c19ddcfa1850a56e403358cbbb349564f95727b50271142cb7d",
+			"MachineKey": "mkey:527c9d2a94009d4b0d3521215c999ff6c991d699c641567823f9d078c8639c38",
+			"Peers": [{
+				"ID":         8442035953973021,
+				"StableID":   "ncJorDyQv821CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f0ba21103efde24cbcbf8124cdfc509700f725e8fcce8bd4b6632ec996431c",
+				"DiscoKey":   "discokey:748d96ad50544f6767a184613f2c8f2fc9aa8953e723e5cab5dbba913572513b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:36510", "10.65.0.27:36510", "172.17.0.1:36510"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:04:44.303497882Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5563687250688700,
+				"StableID":   "nTnhPXdoSk11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2bfbf73d6ac68572e8efbdc282e1eeece23000be24e6eb69b85f58cdb1f80269",
+				"DiscoKey":   "discokey:5c55587c8898b58ad91b96a9fea61a617367b18387bde443ee48a321769b8b53",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46945", "10.65.0.27:46945", "172.17.0.1:46945"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:04:50.133684208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3355050348362585,
+				"StableID":   "ntNNT3VWCT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f2227d9c07badd5e4c3b7cdf8560fb2abd35cfd32aec0ae883988878ef87c6b",
+				"DiscoKey":   "discokey:148f2aa87e7f3c830752a2e730c5a38db8b09633a482e0a7f3c99da8dd3def05",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:55698", "10.65.0.27:55698", "172.17.0.1:55698"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:04:51.086090066Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3507107004883453,
+				"StableID":   "nzfsVjkNPU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cad4e4fa94dbfc76f7690065299cf88538f8b0628dba9ed381e4a367bdfa8469",
+				"DiscoKey":   "discokey:c7341a053c443d78e95d6614b233d943c3b24fcbd141c684f24d165b01c4db33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43569", "10.65.0.27:43569", "172.17.0.1:43569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:04:52.025650368Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1221129267526804,
+				"StableID":   "nBv1piz3YA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:685f33afe836b188360c6e801838f138488cc20836f3244f22aeb1dd1523e350",
+				"DiscoKey":   "discokey:7a6ded82b73a599603b3c6c93f7c530289727d311b8635e8ed2a4e38a8d24421",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53150", "10.65.0.27:53150", "172.17.0.1:53150"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:04:52.942034381Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1600449135742171,
+				"StableID":   "nLbQev5rVD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a36bdc0999bf7cf4275ea3151929e0bdcbed74986efa80b727217720fb6bb17",
+				"KeyExpiry":  "2026-10-26T11:05:02Z",
+				"DiscoKey":   "discokey:80d9da6c6f57c7d65b807c16cae8bf3d0798047a50ce95a2953403baffeb3e4f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37669", "10.65.0.27:37669", "172.17.0.1:37669"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:05:02.411991476Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5536048968355944,
+				"StableID":   "n1ZR2ucHEk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b903addfada5afbcf60addfec92bff161025879088699f2375d325ea602fc0d",
+				"KeyExpiry":  "2026-10-26T11:05:03Z",
+				"DiscoKey":   "discokey:405da5b9891149958da51830b8edb610ae8afa874945ef8975412fd4da4b5d3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51616", "10.65.0.27:51616", "172.17.0.1:51616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:05:03.453276459Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3507107004883453,
+				"StableID":   "nzfsVjkNPU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       3507107004883453,
+				"Key":        "nodekey:cad4e4fa94dbfc76f7690065299cf88538f8b0628dba9ed381e4a367bdfa8469",
+				"DiscoKey":   "discokey:c7341a053c443d78e95d6614b233d943c3b24fcbd141c684f24d165b01c4db33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43569", "10.65.0.27:43569", "172.17.0.1:43569"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:04:52.025650368Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cad4e4fa94dbfc76f7690065299cf88538f8b0628dba9ed381e4a367bdfa8469",
+			"MachineKey": "mkey:302fac0ff90c97b2d5897cf4ba3cbaf7f0f540003ffd499e049d1ffab2e6ca6b",
+			"Peers": [{
+				"ID":         8442035953973021,
+				"StableID":   "ncJorDyQv821CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f0ba21103efde24cbcbf8124cdfc509700f725e8fcce8bd4b6632ec996431c",
+				"DiscoKey":   "discokey:748d96ad50544f6767a184613f2c8f2fc9aa8953e723e5cab5dbba913572513b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:36510", "10.65.0.27:36510", "172.17.0.1:36510"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:04:44.303497882Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5563687250688700,
+				"StableID":   "nTnhPXdoSk11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2bfbf73d6ac68572e8efbdc282e1eeece23000be24e6eb69b85f58cdb1f80269",
+				"DiscoKey":   "discokey:5c55587c8898b58ad91b96a9fea61a617367b18387bde443ee48a321769b8b53",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46945", "10.65.0.27:46945", "172.17.0.1:46945"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:04:50.133684208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3355050348362585,
+				"StableID":   "ntNNT3VWCT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f2227d9c07badd5e4c3b7cdf8560fb2abd35cfd32aec0ae883988878ef87c6b",
+				"DiscoKey":   "discokey:148f2aa87e7f3c830752a2e730c5a38db8b09633a482e0a7f3c99da8dd3def05",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:55698", "10.65.0.27:55698", "172.17.0.1:55698"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:04:51.086090066Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1221129267526804,
+				"StableID":   "nBv1piz3YA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:685f33afe836b188360c6e801838f138488cc20836f3244f22aeb1dd1523e350",
+				"DiscoKey":   "discokey:7a6ded82b73a599603b3c6c93f7c530289727d311b8635e8ed2a4e38a8d24421",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53150", "10.65.0.27:53150", "172.17.0.1:53150"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:04:52.942034381Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8189960431026882,
+				"StableID":   "nhk66dNFx621CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7bfcbf93d5932c19ddcfa1850a56e403358cbbb349564f95727b50271142cb7d",
+				"KeyExpiry":  "2026-10-26T11:04:54Z",
+				"DiscoKey":   "discokey:205b89276d0aba9addecfe052e9dacb08fc30791a588b740508fcd6b0eedd35a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38975", "10.65.0.27:38975", "172.17.0.1:38975"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:04:54.142007269Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1600449135742171,
+				"StableID":   "nLbQev5rVD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a36bdc0999bf7cf4275ea3151929e0bdcbed74986efa80b727217720fb6bb17",
+				"KeyExpiry":  "2026-10-26T11:05:02Z",
+				"DiscoKey":   "discokey:80d9da6c6f57c7d65b807c16cae8bf3d0798047a50ce95a2953403baffeb3e4f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37669", "10.65.0.27:37669", "172.17.0.1:37669"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:05:02.411991476Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5536048968355944,
+				"StableID":   "n1ZR2ucHEk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b903addfada5afbcf60addfec92bff161025879088699f2375d325ea602fc0d",
+				"KeyExpiry":  "2026-10-26T11:05:03Z",
+				"DiscoKey":   "discokey:405da5b9891149958da51830b8edb610ae8afa874945ef8975412fd4da4b5d3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51616", "10.65.0.27:51616", "172.17.0.1:51616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:05:03.453276459Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3507107004883453": {
+				"ID":          3507107004883453,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5563687250688700,
+				"StableID":   "nTnhPXdoSk11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       5563687250688700,
+				"Key":        "nodekey:2bfbf73d6ac68572e8efbdc282e1eeece23000be24e6eb69b85f58cdb1f80269",
+				"DiscoKey":   "discokey:5c55587c8898b58ad91b96a9fea61a617367b18387bde443ee48a321769b8b53",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46945", "10.65.0.27:46945", "172.17.0.1:46945"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T11:04:50.133684208Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2bfbf73d6ac68572e8efbdc282e1eeece23000be24e6eb69b85f58cdb1f80269",
+			"MachineKey": "mkey:ee0d56f072b66cdd04c635c372e280b119edf932303324781541004e0fdd3324",
+			"Peers": [{
+				"ID":         8442035953973021,
+				"StableID":   "ncJorDyQv821CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f0ba21103efde24cbcbf8124cdfc509700f725e8fcce8bd4b6632ec996431c",
+				"DiscoKey":   "discokey:748d96ad50544f6767a184613f2c8f2fc9aa8953e723e5cab5dbba913572513b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:36510", "10.65.0.27:36510", "172.17.0.1:36510"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:04:44.303497882Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3355050348362585,
+				"StableID":   "ntNNT3VWCT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f2227d9c07badd5e4c3b7cdf8560fb2abd35cfd32aec0ae883988878ef87c6b",
+				"DiscoKey":   "discokey:148f2aa87e7f3c830752a2e730c5a38db8b09633a482e0a7f3c99da8dd3def05",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:55698", "10.65.0.27:55698", "172.17.0.1:55698"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:04:51.086090066Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3507107004883453,
+				"StableID":   "nzfsVjkNPU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cad4e4fa94dbfc76f7690065299cf88538f8b0628dba9ed381e4a367bdfa8469",
+				"DiscoKey":   "discokey:c7341a053c443d78e95d6614b233d943c3b24fcbd141c684f24d165b01c4db33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43569", "10.65.0.27:43569", "172.17.0.1:43569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:04:52.025650368Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1221129267526804,
+				"StableID":   "nBv1piz3YA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:685f33afe836b188360c6e801838f138488cc20836f3244f22aeb1dd1523e350",
+				"DiscoKey":   "discokey:7a6ded82b73a599603b3c6c93f7c530289727d311b8635e8ed2a4e38a8d24421",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53150", "10.65.0.27:53150", "172.17.0.1:53150"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:04:52.942034381Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8189960431026882,
+				"StableID":   "nhk66dNFx621CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7bfcbf93d5932c19ddcfa1850a56e403358cbbb349564f95727b50271142cb7d",
+				"KeyExpiry":  "2026-10-26T11:04:54Z",
+				"DiscoKey":   "discokey:205b89276d0aba9addecfe052e9dacb08fc30791a588b740508fcd6b0eedd35a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38975", "10.65.0.27:38975", "172.17.0.1:38975"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:04:54.142007269Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1600449135742171,
+				"StableID":   "nLbQev5rVD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a36bdc0999bf7cf4275ea3151929e0bdcbed74986efa80b727217720fb6bb17",
+				"KeyExpiry":  "2026-10-26T11:05:02Z",
+				"DiscoKey":   "discokey:80d9da6c6f57c7d65b807c16cae8bf3d0798047a50ce95a2953403baffeb3e4f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37669", "10.65.0.27:37669", "172.17.0.1:37669"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:05:02.411991476Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5536048968355944,
+				"StableID":   "n1ZR2ucHEk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b903addfada5afbcf60addfec92bff161025879088699f2375d325ea602fc0d",
+				"KeyExpiry":  "2026-10-26T11:05:03Z",
+				"DiscoKey":   "discokey:405da5b9891149958da51830b8edb610ae8afa874945ef8975412fd4da4b5d3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51616", "10.65.0.27:51616", "172.17.0.1:51616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:05:03.453276459Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5563687250688700": {
+				"ID":          5563687250688700,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1600449135742171,
+				"StableID":   "nLbQev5rVD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a36bdc0999bf7cf4275ea3151929e0bdcbed74986efa80b727217720fb6bb17",
+				"KeyExpiry":  "2026-10-26T11:05:02Z",
+				"DiscoKey":   "discokey:80d9da6c6f57c7d65b807c16cae8bf3d0798047a50ce95a2953403baffeb3e4f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37669", "10.65.0.27:37669", "172.17.0.1:37669"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:05:02.411991476Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2a36bdc0999bf7cf4275ea3151929e0bdcbed74986efa80b727217720fb6bb17",
+			"MachineKey": "mkey:caae48c03e06142e862cf6ac94ece694ac2c729b7b15e776d772ed5404762e1a",
+			"Peers": [{
+				"ID":         8442035953973021,
+				"StableID":   "ncJorDyQv821CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f0ba21103efde24cbcbf8124cdfc509700f725e8fcce8bd4b6632ec996431c",
+				"DiscoKey":   "discokey:748d96ad50544f6767a184613f2c8f2fc9aa8953e723e5cab5dbba913572513b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:36510", "10.65.0.27:36510", "172.17.0.1:36510"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:04:44.303497882Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5563687250688700,
+				"StableID":   "nTnhPXdoSk11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2bfbf73d6ac68572e8efbdc282e1eeece23000be24e6eb69b85f58cdb1f80269",
+				"DiscoKey":   "discokey:5c55587c8898b58ad91b96a9fea61a617367b18387bde443ee48a321769b8b53",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46945", "10.65.0.27:46945", "172.17.0.1:46945"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:04:50.133684208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3355050348362585,
+				"StableID":   "ntNNT3VWCT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f2227d9c07badd5e4c3b7cdf8560fb2abd35cfd32aec0ae883988878ef87c6b",
+				"DiscoKey":   "discokey:148f2aa87e7f3c830752a2e730c5a38db8b09633a482e0a7f3c99da8dd3def05",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:55698", "10.65.0.27:55698", "172.17.0.1:55698"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:04:51.086090066Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3507107004883453,
+				"StableID":   "nzfsVjkNPU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cad4e4fa94dbfc76f7690065299cf88538f8b0628dba9ed381e4a367bdfa8469",
+				"DiscoKey":   "discokey:c7341a053c443d78e95d6614b233d943c3b24fcbd141c684f24d165b01c4db33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43569", "10.65.0.27:43569", "172.17.0.1:43569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:04:52.025650368Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1221129267526804,
+				"StableID":   "nBv1piz3YA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:685f33afe836b188360c6e801838f138488cc20836f3244f22aeb1dd1523e350",
+				"DiscoKey":   "discokey:7a6ded82b73a599603b3c6c93f7c530289727d311b8635e8ed2a4e38a8d24421",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53150", "10.65.0.27:53150", "172.17.0.1:53150"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:04:52.942034381Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8189960431026882,
+				"StableID":   "nhk66dNFx621CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7bfcbf93d5932c19ddcfa1850a56e403358cbbb349564f95727b50271142cb7d",
+				"KeyExpiry":  "2026-10-26T11:04:54Z",
+				"DiscoKey":   "discokey:205b89276d0aba9addecfe052e9dacb08fc30791a588b740508fcd6b0eedd35a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38975", "10.65.0.27:38975", "172.17.0.1:38975"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:04:54.142007269Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5536048968355944,
+				"StableID":   "n1ZR2ucHEk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b903addfada5afbcf60addfec92bff161025879088699f2375d325ea602fc0d",
+				"KeyExpiry":  "2026-10-26T11:05:03Z",
+				"DiscoKey":   "discokey:405da5b9891149958da51830b8edb610ae8afa874945ef8975412fd4da4b5d3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51616", "10.65.0.27:51616", "172.17.0.1:51616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:05:03.453276459Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3355050348362585,
+				"StableID":   "ntNNT3VWCT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       3355050348362585,
+				"Key":        "nodekey:0f2227d9c07badd5e4c3b7cdf8560fb2abd35cfd32aec0ae883988878ef87c6b",
+				"DiscoKey":   "discokey:148f2aa87e7f3c830752a2e730c5a38db8b09633a482e0a7f3c99da8dd3def05",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:55698", "10.65.0.27:55698", "172.17.0.1:55698"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:04:51.086090066Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0f2227d9c07badd5e4c3b7cdf8560fb2abd35cfd32aec0ae883988878ef87c6b",
+			"MachineKey": "mkey:458714486ed83cf939444cd857caa78ca48ba6bd2df6a0cb8d9fcdc761770d7c",
+			"Peers": [{
+				"ID":         8442035953973021,
+				"StableID":   "ncJorDyQv821CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f0ba21103efde24cbcbf8124cdfc509700f725e8fcce8bd4b6632ec996431c",
+				"DiscoKey":   "discokey:748d96ad50544f6767a184613f2c8f2fc9aa8953e723e5cab5dbba913572513b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:36510", "10.65.0.27:36510", "172.17.0.1:36510"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:04:44.303497882Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5563687250688700,
+				"StableID":   "nTnhPXdoSk11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2bfbf73d6ac68572e8efbdc282e1eeece23000be24e6eb69b85f58cdb1f80269",
+				"DiscoKey":   "discokey:5c55587c8898b58ad91b96a9fea61a617367b18387bde443ee48a321769b8b53",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46945", "10.65.0.27:46945", "172.17.0.1:46945"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:04:50.133684208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3507107004883453,
+				"StableID":   "nzfsVjkNPU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cad4e4fa94dbfc76f7690065299cf88538f8b0628dba9ed381e4a367bdfa8469",
+				"DiscoKey":   "discokey:c7341a053c443d78e95d6614b233d943c3b24fcbd141c684f24d165b01c4db33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43569", "10.65.0.27:43569", "172.17.0.1:43569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:04:52.025650368Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1221129267526804,
+				"StableID":   "nBv1piz3YA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:685f33afe836b188360c6e801838f138488cc20836f3244f22aeb1dd1523e350",
+				"DiscoKey":   "discokey:7a6ded82b73a599603b3c6c93f7c530289727d311b8635e8ed2a4e38a8d24421",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53150", "10.65.0.27:53150", "172.17.0.1:53150"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:04:52.942034381Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8189960431026882,
+				"StableID":   "nhk66dNFx621CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7bfcbf93d5932c19ddcfa1850a56e403358cbbb349564f95727b50271142cb7d",
+				"KeyExpiry":  "2026-10-26T11:04:54Z",
+				"DiscoKey":   "discokey:205b89276d0aba9addecfe052e9dacb08fc30791a588b740508fcd6b0eedd35a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:38975", "10.65.0.27:38975", "172.17.0.1:38975"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:04:54.142007269Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1600449135742171,
+				"StableID":   "nLbQev5rVD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a36bdc0999bf7cf4275ea3151929e0bdcbed74986efa80b727217720fb6bb17",
+				"KeyExpiry":  "2026-10-26T11:05:02Z",
+				"DiscoKey":   "discokey:80d9da6c6f57c7d65b807c16cae8bf3d0798047a50ce95a2953403baffeb3e4f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37669", "10.65.0.27:37669", "172.17.0.1:37669"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:05:02.411991476Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5536048968355944,
+				"StableID":   "n1ZR2ucHEk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b903addfada5afbcf60addfec92bff161025879088699f2375d325ea602fc0d",
+				"KeyExpiry":  "2026-10-26T11:05:03Z",
+				"DiscoKey":   "discokey:405da5b9891149958da51830b8edb610ae8afa874945ef8975412fd4da4b5d3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51616", "10.65.0.27:51616", "172.17.0.1:51616"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:05:03.453276459Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3355050348362585": {
+				"ID":          3355050348362585,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-src-unknown-host.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-src-unknown-host.hujson
@@ -1,0 +1,8843 @@
+// policytest-src-unknown-host
+//
+// tests block src-unknown: host alias not declared in hosts
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T11:05:39Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-src-unknown-host",
+	"description":    "tests block src-unknown: host alias not declared in hosts",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T11:05:39.079530064Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                              \n  \n                                                            \n                                                              \n{\n\t\"id\":          \"policytest-src-unknown-host\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block src-unknown: host alias not declared in hosts\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"webserver\"], \"dst\": [\"tag:server:22\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"phantomhost\", \"accept\": [\"tag:server:22\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-src-unknown-host.hujson",
+		"full_policy": {
+			"acls": [{"action": "accept", "dst": ["tag:server:22"], "src": ["webserver"]}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["tag:server:22"], "src": "phantomhost"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6660761836834819,
+				"StableID":   "nGRCpHvf1u11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6660761836834819,
+				"Key":        "nodekey:2055a7dccd4be011562ea0304e00c637f78ab802d5a732bbcdc3b33a78251955",
+				"DiscoKey":   "discokey:c8b1d5f156e5465c813c8ff8873b8f6d85b0625944c70431678d268c4ebaf119",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:05:42.64561436Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2055a7dccd4be011562ea0304e00c637f78ab802d5a732bbcdc3b33a78251955",
+			"MachineKey": "mkey:b76eaae81b04736791db0cb6bcce922505769b08b48324f3e91abc36db2b922e",
+			"Peers": [{
+				"ID":         6123747798352395,
+				"StableID":   "ngjm9JUTpp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ffc1f1c8e711c16bf40ab357d2a3533166128f7741fd5ce949d138963b61fc29",
+				"DiscoKey":   "discokey:aee917635a82dcd4874e201d7d90427e2cb60197d1c1e7a98e811da57a8f4766",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37430", "10.65.0.27:37430", "172.17.0.1:37430"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:05:40.50512414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7696384467098269,
+				"StableID":   "nQ8yKDyh6321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95ced0dfc22f0840aa066dddd3c8af15e5784f31b875fb3aac05b93b9d03ba6c",
+				"DiscoKey":   "discokey:465b20ea522a1c638f34c6b5ffd9a228be0d51b5f8aea757423c9b5e762c2376",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35910", "10.65.0.27:35910", "172.17.0.1:35910"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:05:41.04962256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3259665214823251,
+				"StableID":   "nLHRqusJTS11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a1c2eabe1e15092629bdf58f54e99498a0308d8fa1619115d3b956fa594db29",
+				"DiscoKey":   "discokey:2af5f540a05f6a5920ddf6acd146715d431a359c3a937a9190eec0277ac7907f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60147", "10.65.0.27:60147", "172.17.0.1:60147"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:05:41.584114827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2125315379255773,
+				"StableID":   "nAsKG1SZbH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9e20bb9690c6a9bbf6381fd96e44da1e76e5bb0a47071cdf22e11954d505364b",
+				"DiscoKey":   "discokey:59f1412c4ae565b4d461c168b784d4f47c13b3a43ebd7648454574ff63155e44",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:57657", "10.65.0.27:57657", "172.17.0.1:57657"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:05:42.129544448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7391130739506240,
+				"StableID":   "nZBJiLUTiz11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a66e36b84c396f87bc9cfc611c86aa2bd5c015f9f4cfb9c903806fc8251b350e",
+				"KeyExpiry":  "2026-10-26T11:05:43Z",
+				"DiscoKey":   "discokey:2f5359aa618e91496d2a38fe4bc4d10f9144262d63a5e0820631d1149a2aa75a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51415", "10.65.0.27:51415", "172.17.0.1:51415"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:05:43.194904349Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5110391788473803,
+				"StableID":   "nL3idwKWug11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c05d3de7f5001ed10687b13aeb4ba154c2812fca6e4888193ccf57e6dbc55b2e",
+				"KeyExpiry":  "2026-10-26T11:05:43Z",
+				"DiscoKey":   "discokey:184cd5fd40a1e3b804bd47d81dafc69ae5b1be0b18b5bca48a337968fea50b3c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60290", "10.65.0.27:60290", "172.17.0.1:60290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:05:43.773569285Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         318543249261603,
+				"StableID":   "n2Lx8HbGV311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9eba45b7a47fb55d0a3cc2323ee63bf371747b4549f51615f2c5e465fa764d30",
+				"KeyExpiry":  "2026-10-26T11:05:44Z",
+				"DiscoKey":   "discokey:6fe03ea293dd78da0ad462dcce5bb8e4bd53d538e5feca6a6183f46001f2d054",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39492", "10.65.0.27:39492", "172.17.0.1:39492"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:05:44.275546228Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6660761836834819": {
+				"ID":          6660761836834819,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         318543249261603,
+				"StableID":   "n2Lx8HbGV311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9eba45b7a47fb55d0a3cc2323ee63bf371747b4549f51615f2c5e465fa764d30",
+				"KeyExpiry":  "2026-10-26T11:05:44Z",
+				"DiscoKey":   "discokey:6fe03ea293dd78da0ad462dcce5bb8e4bd53d538e5feca6a6183f46001f2d054",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39492", "10.65.0.27:39492", "172.17.0.1:39492"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:05:44.275546228Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9eba45b7a47fb55d0a3cc2323ee63bf371747b4549f51615f2c5e465fa764d30",
+			"MachineKey": "mkey:d2fe46edc67b456b840c0d5183fdaacdd0ccad84e127f9a60e1f920a7a3eb72e",
+			"Peers": [{
+				"ID":         6123747798352395,
+				"StableID":   "ngjm9JUTpp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ffc1f1c8e711c16bf40ab357d2a3533166128f7741fd5ce949d138963b61fc29",
+				"DiscoKey":   "discokey:aee917635a82dcd4874e201d7d90427e2cb60197d1c1e7a98e811da57a8f4766",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37430", "10.65.0.27:37430", "172.17.0.1:37430"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:05:40.50512414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7696384467098269,
+				"StableID":   "nQ8yKDyh6321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95ced0dfc22f0840aa066dddd3c8af15e5784f31b875fb3aac05b93b9d03ba6c",
+				"DiscoKey":   "discokey:465b20ea522a1c638f34c6b5ffd9a228be0d51b5f8aea757423c9b5e762c2376",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35910", "10.65.0.27:35910", "172.17.0.1:35910"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:05:41.04962256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3259665214823251,
+				"StableID":   "nLHRqusJTS11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a1c2eabe1e15092629bdf58f54e99498a0308d8fa1619115d3b956fa594db29",
+				"DiscoKey":   "discokey:2af5f540a05f6a5920ddf6acd146715d431a359c3a937a9190eec0277ac7907f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60147", "10.65.0.27:60147", "172.17.0.1:60147"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:05:41.584114827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2125315379255773,
+				"StableID":   "nAsKG1SZbH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9e20bb9690c6a9bbf6381fd96e44da1e76e5bb0a47071cdf22e11954d505364b",
+				"DiscoKey":   "discokey:59f1412c4ae565b4d461c168b784d4f47c13b3a43ebd7648454574ff63155e44",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:57657", "10.65.0.27:57657", "172.17.0.1:57657"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:05:42.129544448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6660761836834819,
+				"StableID":   "nGRCpHvf1u11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2055a7dccd4be011562ea0304e00c637f78ab802d5a732bbcdc3b33a78251955",
+				"DiscoKey":   "discokey:c8b1d5f156e5465c813c8ff8873b8f6d85b0625944c70431678d268c4ebaf119",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:05:42.64561436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7391130739506240,
+				"StableID":   "nZBJiLUTiz11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a66e36b84c396f87bc9cfc611c86aa2bd5c015f9f4cfb9c903806fc8251b350e",
+				"KeyExpiry":  "2026-10-26T11:05:43Z",
+				"DiscoKey":   "discokey:2f5359aa618e91496d2a38fe4bc4d10f9144262d63a5e0820631d1149a2aa75a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51415", "10.65.0.27:51415", "172.17.0.1:51415"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:05:43.194904349Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5110391788473803,
+				"StableID":   "nL3idwKWug11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c05d3de7f5001ed10687b13aeb4ba154c2812fca6e4888193ccf57e6dbc55b2e",
+				"KeyExpiry":  "2026-10-26T11:05:43Z",
+				"DiscoKey":   "discokey:184cd5fd40a1e3b804bd47d81dafc69ae5b1be0b18b5bca48a337968fea50b3c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60290", "10.65.0.27:60290", "172.17.0.1:60290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:05:43.773569285Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6123747798352395,
+				"StableID":   "ngjm9JUTpp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       6123747798352395,
+				"Key":        "nodekey:ffc1f1c8e711c16bf40ab357d2a3533166128f7741fd5ce949d138963b61fc29",
+				"DiscoKey":   "discokey:aee917635a82dcd4874e201d7d90427e2cb60197d1c1e7a98e811da57a8f4766",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37430", "10.65.0.27:37430", "172.17.0.1:37430"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T11:05:40.50512414Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ffc1f1c8e711c16bf40ab357d2a3533166128f7741fd5ce949d138963b61fc29",
+			"MachineKey": "mkey:03daa6323bcd5411f745a3e8cd39b2873a09a6a41d3058295f9000c296fb7633",
+			"Peers": [{
+				"ID":         7696384467098269,
+				"StableID":   "nQ8yKDyh6321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95ced0dfc22f0840aa066dddd3c8af15e5784f31b875fb3aac05b93b9d03ba6c",
+				"DiscoKey":   "discokey:465b20ea522a1c638f34c6b5ffd9a228be0d51b5f8aea757423c9b5e762c2376",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35910", "10.65.0.27:35910", "172.17.0.1:35910"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:05:41.04962256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3259665214823251,
+				"StableID":   "nLHRqusJTS11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a1c2eabe1e15092629bdf58f54e99498a0308d8fa1619115d3b956fa594db29",
+				"DiscoKey":   "discokey:2af5f540a05f6a5920ddf6acd146715d431a359c3a937a9190eec0277ac7907f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60147", "10.65.0.27:60147", "172.17.0.1:60147"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:05:41.584114827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2125315379255773,
+				"StableID":   "nAsKG1SZbH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9e20bb9690c6a9bbf6381fd96e44da1e76e5bb0a47071cdf22e11954d505364b",
+				"DiscoKey":   "discokey:59f1412c4ae565b4d461c168b784d4f47c13b3a43ebd7648454574ff63155e44",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:57657", "10.65.0.27:57657", "172.17.0.1:57657"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:05:42.129544448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6660761836834819,
+				"StableID":   "nGRCpHvf1u11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2055a7dccd4be011562ea0304e00c637f78ab802d5a732bbcdc3b33a78251955",
+				"DiscoKey":   "discokey:c8b1d5f156e5465c813c8ff8873b8f6d85b0625944c70431678d268c4ebaf119",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:05:42.64561436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7391130739506240,
+				"StableID":   "nZBJiLUTiz11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a66e36b84c396f87bc9cfc611c86aa2bd5c015f9f4cfb9c903806fc8251b350e",
+				"KeyExpiry":  "2026-10-26T11:05:43Z",
+				"DiscoKey":   "discokey:2f5359aa618e91496d2a38fe4bc4d10f9144262d63a5e0820631d1149a2aa75a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51415", "10.65.0.27:51415", "172.17.0.1:51415"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:05:43.194904349Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5110391788473803,
+				"StableID":   "nL3idwKWug11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c05d3de7f5001ed10687b13aeb4ba154c2812fca6e4888193ccf57e6dbc55b2e",
+				"KeyExpiry":  "2026-10-26T11:05:43Z",
+				"DiscoKey":   "discokey:184cd5fd40a1e3b804bd47d81dafc69ae5b1be0b18b5bca48a337968fea50b3c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60290", "10.65.0.27:60290", "172.17.0.1:60290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:05:43.773569285Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         318543249261603,
+				"StableID":   "n2Lx8HbGV311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9eba45b7a47fb55d0a3cc2323ee63bf371747b4549f51615f2c5e465fa764d30",
+				"KeyExpiry":  "2026-10-26T11:05:44Z",
+				"DiscoKey":   "discokey:6fe03ea293dd78da0ad462dcce5bb8e4bd53d538e5feca6a6183f46001f2d054",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39492", "10.65.0.27:39492", "172.17.0.1:39492"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:05:44.275546228Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6123747798352395": {
+				"ID":          6123747798352395,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7391130739506240,
+				"StableID":   "nZBJiLUTiz11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a66e36b84c396f87bc9cfc611c86aa2bd5c015f9f4cfb9c903806fc8251b350e",
+				"KeyExpiry":  "2026-10-26T11:05:43Z",
+				"DiscoKey":   "discokey:2f5359aa618e91496d2a38fe4bc4d10f9144262d63a5e0820631d1149a2aa75a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51415", "10.65.0.27:51415", "172.17.0.1:51415"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:05:43.194904349Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a66e36b84c396f87bc9cfc611c86aa2bd5c015f9f4cfb9c903806fc8251b350e",
+			"MachineKey": "mkey:c91ba8238cbb815c88de01e401d6f6393d54487f6c7e0ed80f3b6f8ac4c4e146",
+			"Peers": [{
+				"ID":         6123747798352395,
+				"StableID":   "ngjm9JUTpp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ffc1f1c8e711c16bf40ab357d2a3533166128f7741fd5ce949d138963b61fc29",
+				"DiscoKey":   "discokey:aee917635a82dcd4874e201d7d90427e2cb60197d1c1e7a98e811da57a8f4766",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37430", "10.65.0.27:37430", "172.17.0.1:37430"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:05:40.50512414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7696384467098269,
+				"StableID":   "nQ8yKDyh6321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95ced0dfc22f0840aa066dddd3c8af15e5784f31b875fb3aac05b93b9d03ba6c",
+				"DiscoKey":   "discokey:465b20ea522a1c638f34c6b5ffd9a228be0d51b5f8aea757423c9b5e762c2376",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35910", "10.65.0.27:35910", "172.17.0.1:35910"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:05:41.04962256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3259665214823251,
+				"StableID":   "nLHRqusJTS11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a1c2eabe1e15092629bdf58f54e99498a0308d8fa1619115d3b956fa594db29",
+				"DiscoKey":   "discokey:2af5f540a05f6a5920ddf6acd146715d431a359c3a937a9190eec0277ac7907f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60147", "10.65.0.27:60147", "172.17.0.1:60147"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:05:41.584114827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2125315379255773,
+				"StableID":   "nAsKG1SZbH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9e20bb9690c6a9bbf6381fd96e44da1e76e5bb0a47071cdf22e11954d505364b",
+				"DiscoKey":   "discokey:59f1412c4ae565b4d461c168b784d4f47c13b3a43ebd7648454574ff63155e44",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:57657", "10.65.0.27:57657", "172.17.0.1:57657"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:05:42.129544448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6660761836834819,
+				"StableID":   "nGRCpHvf1u11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2055a7dccd4be011562ea0304e00c637f78ab802d5a732bbcdc3b33a78251955",
+				"DiscoKey":   "discokey:c8b1d5f156e5465c813c8ff8873b8f6d85b0625944c70431678d268c4ebaf119",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:05:42.64561436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5110391788473803,
+				"StableID":   "nL3idwKWug11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c05d3de7f5001ed10687b13aeb4ba154c2812fca6e4888193ccf57e6dbc55b2e",
+				"KeyExpiry":  "2026-10-26T11:05:43Z",
+				"DiscoKey":   "discokey:184cd5fd40a1e3b804bd47d81dafc69ae5b1be0b18b5bca48a337968fea50b3c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60290", "10.65.0.27:60290", "172.17.0.1:60290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:05:43.773569285Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         318543249261603,
+				"StableID":   "n2Lx8HbGV311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9eba45b7a47fb55d0a3cc2323ee63bf371747b4549f51615f2c5e465fa764d30",
+				"KeyExpiry":  "2026-10-26T11:05:44Z",
+				"DiscoKey":   "discokey:6fe03ea293dd78da0ad462dcce5bb8e4bd53d538e5feca6a6183f46001f2d054",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39492", "10.65.0.27:39492", "172.17.0.1:39492"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:05:44.275546228Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2125315379255773,
+				"StableID":   "nAsKG1SZbH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       2125315379255773,
+				"Key":        "nodekey:9e20bb9690c6a9bbf6381fd96e44da1e76e5bb0a47071cdf22e11954d505364b",
+				"DiscoKey":   "discokey:59f1412c4ae565b4d461c168b784d4f47c13b3a43ebd7648454574ff63155e44",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:57657", "10.65.0.27:57657", "172.17.0.1:57657"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:05:42.129544448Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9e20bb9690c6a9bbf6381fd96e44da1e76e5bb0a47071cdf22e11954d505364b",
+			"MachineKey": "mkey:836cbc1bcd9267ba1290c3b90f6cc03621d26f6d5e108411a9bc64d52294f322",
+			"Peers": [{
+				"ID":         6123747798352395,
+				"StableID":   "ngjm9JUTpp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ffc1f1c8e711c16bf40ab357d2a3533166128f7741fd5ce949d138963b61fc29",
+				"DiscoKey":   "discokey:aee917635a82dcd4874e201d7d90427e2cb60197d1c1e7a98e811da57a8f4766",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37430", "10.65.0.27:37430", "172.17.0.1:37430"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:05:40.50512414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7696384467098269,
+				"StableID":   "nQ8yKDyh6321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95ced0dfc22f0840aa066dddd3c8af15e5784f31b875fb3aac05b93b9d03ba6c",
+				"DiscoKey":   "discokey:465b20ea522a1c638f34c6b5ffd9a228be0d51b5f8aea757423c9b5e762c2376",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35910", "10.65.0.27:35910", "172.17.0.1:35910"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:05:41.04962256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3259665214823251,
+				"StableID":   "nLHRqusJTS11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a1c2eabe1e15092629bdf58f54e99498a0308d8fa1619115d3b956fa594db29",
+				"DiscoKey":   "discokey:2af5f540a05f6a5920ddf6acd146715d431a359c3a937a9190eec0277ac7907f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60147", "10.65.0.27:60147", "172.17.0.1:60147"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:05:41.584114827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6660761836834819,
+				"StableID":   "nGRCpHvf1u11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2055a7dccd4be011562ea0304e00c637f78ab802d5a732bbcdc3b33a78251955",
+				"DiscoKey":   "discokey:c8b1d5f156e5465c813c8ff8873b8f6d85b0625944c70431678d268c4ebaf119",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:05:42.64561436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7391130739506240,
+				"StableID":   "nZBJiLUTiz11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a66e36b84c396f87bc9cfc611c86aa2bd5c015f9f4cfb9c903806fc8251b350e",
+				"KeyExpiry":  "2026-10-26T11:05:43Z",
+				"DiscoKey":   "discokey:2f5359aa618e91496d2a38fe4bc4d10f9144262d63a5e0820631d1149a2aa75a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51415", "10.65.0.27:51415", "172.17.0.1:51415"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:05:43.194904349Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5110391788473803,
+				"StableID":   "nL3idwKWug11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c05d3de7f5001ed10687b13aeb4ba154c2812fca6e4888193ccf57e6dbc55b2e",
+				"KeyExpiry":  "2026-10-26T11:05:43Z",
+				"DiscoKey":   "discokey:184cd5fd40a1e3b804bd47d81dafc69ae5b1be0b18b5bca48a337968fea50b3c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60290", "10.65.0.27:60290", "172.17.0.1:60290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:05:43.773569285Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         318543249261603,
+				"StableID":   "n2Lx8HbGV311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9eba45b7a47fb55d0a3cc2323ee63bf371747b4549f51615f2c5e465fa764d30",
+				"KeyExpiry":  "2026-10-26T11:05:44Z",
+				"DiscoKey":   "discokey:6fe03ea293dd78da0ad462dcce5bb8e4bd53d538e5feca6a6183f46001f2d054",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39492", "10.65.0.27:39492", "172.17.0.1:39492"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:05:44.275546228Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2125315379255773": {
+				"ID":          2125315379255773,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7696384467098269,
+				"StableID":   "nQ8yKDyh6321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       7696384467098269,
+				"Key":        "nodekey:95ced0dfc22f0840aa066dddd3c8af15e5784f31b875fb3aac05b93b9d03ba6c",
+				"DiscoKey":   "discokey:465b20ea522a1c638f34c6b5ffd9a228be0d51b5f8aea757423c9b5e762c2376",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35910", "10.65.0.27:35910", "172.17.0.1:35910"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T11:05:41.04962256Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:95ced0dfc22f0840aa066dddd3c8af15e5784f31b875fb3aac05b93b9d03ba6c",
+			"MachineKey": "mkey:5227f93f13c61139d75a55ab4e6a6da0192df6441e412cffc0adb038cbcafe34",
+			"Peers": [{
+				"ID":         6123747798352395,
+				"StableID":   "ngjm9JUTpp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ffc1f1c8e711c16bf40ab357d2a3533166128f7741fd5ce949d138963b61fc29",
+				"DiscoKey":   "discokey:aee917635a82dcd4874e201d7d90427e2cb60197d1c1e7a98e811da57a8f4766",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37430", "10.65.0.27:37430", "172.17.0.1:37430"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:05:40.50512414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3259665214823251,
+				"StableID":   "nLHRqusJTS11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a1c2eabe1e15092629bdf58f54e99498a0308d8fa1619115d3b956fa594db29",
+				"DiscoKey":   "discokey:2af5f540a05f6a5920ddf6acd146715d431a359c3a937a9190eec0277ac7907f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60147", "10.65.0.27:60147", "172.17.0.1:60147"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:05:41.584114827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2125315379255773,
+				"StableID":   "nAsKG1SZbH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9e20bb9690c6a9bbf6381fd96e44da1e76e5bb0a47071cdf22e11954d505364b",
+				"DiscoKey":   "discokey:59f1412c4ae565b4d461c168b784d4f47c13b3a43ebd7648454574ff63155e44",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:57657", "10.65.0.27:57657", "172.17.0.1:57657"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:05:42.129544448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6660761836834819,
+				"StableID":   "nGRCpHvf1u11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2055a7dccd4be011562ea0304e00c637f78ab802d5a732bbcdc3b33a78251955",
+				"DiscoKey":   "discokey:c8b1d5f156e5465c813c8ff8873b8f6d85b0625944c70431678d268c4ebaf119",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:05:42.64561436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7391130739506240,
+				"StableID":   "nZBJiLUTiz11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a66e36b84c396f87bc9cfc611c86aa2bd5c015f9f4cfb9c903806fc8251b350e",
+				"KeyExpiry":  "2026-10-26T11:05:43Z",
+				"DiscoKey":   "discokey:2f5359aa618e91496d2a38fe4bc4d10f9144262d63a5e0820631d1149a2aa75a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51415", "10.65.0.27:51415", "172.17.0.1:51415"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:05:43.194904349Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5110391788473803,
+				"StableID":   "nL3idwKWug11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c05d3de7f5001ed10687b13aeb4ba154c2812fca6e4888193ccf57e6dbc55b2e",
+				"KeyExpiry":  "2026-10-26T11:05:43Z",
+				"DiscoKey":   "discokey:184cd5fd40a1e3b804bd47d81dafc69ae5b1be0b18b5bca48a337968fea50b3c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60290", "10.65.0.27:60290", "172.17.0.1:60290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:05:43.773569285Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         318543249261603,
+				"StableID":   "n2Lx8HbGV311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9eba45b7a47fb55d0a3cc2323ee63bf371747b4549f51615f2c5e465fa764d30",
+				"KeyExpiry":  "2026-10-26T11:05:44Z",
+				"DiscoKey":   "discokey:6fe03ea293dd78da0ad462dcce5bb8e4bd53d538e5feca6a6183f46001f2d054",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39492", "10.65.0.27:39492", "172.17.0.1:39492"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:05:44.275546228Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7696384467098269": {
+				"ID":          7696384467098269,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5110391788473803,
+				"StableID":   "nL3idwKWug11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c05d3de7f5001ed10687b13aeb4ba154c2812fca6e4888193ccf57e6dbc55b2e",
+				"KeyExpiry":  "2026-10-26T11:05:43Z",
+				"DiscoKey":   "discokey:184cd5fd40a1e3b804bd47d81dafc69ae5b1be0b18b5bca48a337968fea50b3c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60290", "10.65.0.27:60290", "172.17.0.1:60290"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:05:43.773569285Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c05d3de7f5001ed10687b13aeb4ba154c2812fca6e4888193ccf57e6dbc55b2e",
+			"MachineKey": "mkey:007c3cb7b7f46d9fb330c0b94f68cf626abc798f553af0c3a48b22502c738f79",
+			"Peers": [{
+				"ID":         6123747798352395,
+				"StableID":   "ngjm9JUTpp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ffc1f1c8e711c16bf40ab357d2a3533166128f7741fd5ce949d138963b61fc29",
+				"DiscoKey":   "discokey:aee917635a82dcd4874e201d7d90427e2cb60197d1c1e7a98e811da57a8f4766",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37430", "10.65.0.27:37430", "172.17.0.1:37430"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:05:40.50512414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7696384467098269,
+				"StableID":   "nQ8yKDyh6321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95ced0dfc22f0840aa066dddd3c8af15e5784f31b875fb3aac05b93b9d03ba6c",
+				"DiscoKey":   "discokey:465b20ea522a1c638f34c6b5ffd9a228be0d51b5f8aea757423c9b5e762c2376",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35910", "10.65.0.27:35910", "172.17.0.1:35910"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:05:41.04962256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3259665214823251,
+				"StableID":   "nLHRqusJTS11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a1c2eabe1e15092629bdf58f54e99498a0308d8fa1619115d3b956fa594db29",
+				"DiscoKey":   "discokey:2af5f540a05f6a5920ddf6acd146715d431a359c3a937a9190eec0277ac7907f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60147", "10.65.0.27:60147", "172.17.0.1:60147"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:05:41.584114827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2125315379255773,
+				"StableID":   "nAsKG1SZbH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9e20bb9690c6a9bbf6381fd96e44da1e76e5bb0a47071cdf22e11954d505364b",
+				"DiscoKey":   "discokey:59f1412c4ae565b4d461c168b784d4f47c13b3a43ebd7648454574ff63155e44",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:57657", "10.65.0.27:57657", "172.17.0.1:57657"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:05:42.129544448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6660761836834819,
+				"StableID":   "nGRCpHvf1u11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2055a7dccd4be011562ea0304e00c637f78ab802d5a732bbcdc3b33a78251955",
+				"DiscoKey":   "discokey:c8b1d5f156e5465c813c8ff8873b8f6d85b0625944c70431678d268c4ebaf119",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:05:42.64561436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7391130739506240,
+				"StableID":   "nZBJiLUTiz11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a66e36b84c396f87bc9cfc611c86aa2bd5c015f9f4cfb9c903806fc8251b350e",
+				"KeyExpiry":  "2026-10-26T11:05:43Z",
+				"DiscoKey":   "discokey:2f5359aa618e91496d2a38fe4bc4d10f9144262d63a5e0820631d1149a2aa75a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51415", "10.65.0.27:51415", "172.17.0.1:51415"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:05:43.194904349Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         318543249261603,
+				"StableID":   "n2Lx8HbGV311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9eba45b7a47fb55d0a3cc2323ee63bf371747b4549f51615f2c5e465fa764d30",
+				"KeyExpiry":  "2026-10-26T11:05:44Z",
+				"DiscoKey":   "discokey:6fe03ea293dd78da0ad462dcce5bb8e4bd53d538e5feca6a6183f46001f2d054",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39492", "10.65.0.27:39492", "172.17.0.1:39492"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:05:44.275546228Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3259665214823251,
+				"StableID":   "nLHRqusJTS11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       3259665214823251,
+				"Key":        "nodekey:3a1c2eabe1e15092629bdf58f54e99498a0308d8fa1619115d3b956fa594db29",
+				"DiscoKey":   "discokey:2af5f540a05f6a5920ddf6acd146715d431a359c3a937a9190eec0277ac7907f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:60147", "10.65.0.27:60147", "172.17.0.1:60147"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:05:41.584114827Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3a1c2eabe1e15092629bdf58f54e99498a0308d8fa1619115d3b956fa594db29",
+			"MachineKey": "mkey:092df906900c0d815d4668130fc613c280ef0306a684c847f1a1fd7b4fd4f218",
+			"Peers": [{
+				"ID":         6123747798352395,
+				"StableID":   "ngjm9JUTpp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ffc1f1c8e711c16bf40ab357d2a3533166128f7741fd5ce949d138963b61fc29",
+				"DiscoKey":   "discokey:aee917635a82dcd4874e201d7d90427e2cb60197d1c1e7a98e811da57a8f4766",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:37430", "10.65.0.27:37430", "172.17.0.1:37430"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:05:40.50512414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7696384467098269,
+				"StableID":   "nQ8yKDyh6321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95ced0dfc22f0840aa066dddd3c8af15e5784f31b875fb3aac05b93b9d03ba6c",
+				"DiscoKey":   "discokey:465b20ea522a1c638f34c6b5ffd9a228be0d51b5f8aea757423c9b5e762c2376",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35910", "10.65.0.27:35910", "172.17.0.1:35910"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:05:41.04962256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2125315379255773,
+				"StableID":   "nAsKG1SZbH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9e20bb9690c6a9bbf6381fd96e44da1e76e5bb0a47071cdf22e11954d505364b",
+				"DiscoKey":   "discokey:59f1412c4ae565b4d461c168b784d4f47c13b3a43ebd7648454574ff63155e44",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:57657", "10.65.0.27:57657", "172.17.0.1:57657"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:05:42.129544448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6660761836834819,
+				"StableID":   "nGRCpHvf1u11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2055a7dccd4be011562ea0304e00c637f78ab802d5a732bbcdc3b33a78251955",
+				"DiscoKey":   "discokey:c8b1d5f156e5465c813c8ff8873b8f6d85b0625944c70431678d268c4ebaf119",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:05:42.64561436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7391130739506240,
+				"StableID":   "nZBJiLUTiz11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a66e36b84c396f87bc9cfc611c86aa2bd5c015f9f4cfb9c903806fc8251b350e",
+				"KeyExpiry":  "2026-10-26T11:05:43Z",
+				"DiscoKey":   "discokey:2f5359aa618e91496d2a38fe4bc4d10f9144262d63a5e0820631d1149a2aa75a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51415", "10.65.0.27:51415", "172.17.0.1:51415"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:05:43.194904349Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5110391788473803,
+				"StableID":   "nL3idwKWug11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c05d3de7f5001ed10687b13aeb4ba154c2812fca6e4888193ccf57e6dbc55b2e",
+				"KeyExpiry":  "2026-10-26T11:05:43Z",
+				"DiscoKey":   "discokey:184cd5fd40a1e3b804bd47d81dafc69ae5b1be0b18b5bca48a337968fea50b3c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60290", "10.65.0.27:60290", "172.17.0.1:60290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:05:43.773569285Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         318543249261603,
+				"StableID":   "n2Lx8HbGV311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9eba45b7a47fb55d0a3cc2323ee63bf371747b4549f51615f2c5e465fa764d30",
+				"KeyExpiry":  "2026-10-26T11:05:44Z",
+				"DiscoKey":   "discokey:6fe03ea293dd78da0ad462dcce5bb8e4bd53d538e5feca6a6183f46001f2d054",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:39492", "10.65.0.27:39492", "172.17.0.1:39492"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:05:44.275546228Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3259665214823251": {
+				"ID":          3259665214823251,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-src-unknown-tag.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-src-unknown-tag.hujson
@@ -1,0 +1,8843 @@
+// policytest-src-unknown-tag
+//
+// tests block src-unknown: tag not declared in tagOwners
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T11:06:06Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-src-unknown-tag",
+	"description":    "tests block src-unknown: tag not declared in tagOwners",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T11:06:06.117222611Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                             \n  \n                                                                     \n                                                      \n{\n\t\"id\":          \"policytest-src-unknown-tag\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block src-unknown: tag not declared in tagOwners\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"tag:client\"], \"dst\": [\"webserver:80\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"tag:phantom\", \"accept\": [\"webserver:80\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-src-unknown-tag.hujson",
+		"full_policy": {
+			"acls": [{"action": "accept", "dst": ["webserver:80"], "src": ["tag:client"]}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["webserver:80"], "src": "tag:phantom"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7390971188181415,
+				"StableID":   "nnz3iFHPiz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       7390971188181415,
+				"Key":        "nodekey:0ff06db3e2380f50f0bf0f89d3865a5c50378c648a48a98bc0daff2177e7122b",
+				"DiscoKey":   "discokey:14478a343137dc5c03c63875740e79b910c52962b0b27af84b7f0a253e386124",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:41504", "10.65.0.27:41504", "172.17.0.1:41504"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:06:09.745379627Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0ff06db3e2380f50f0bf0f89d3865a5c50378c648a48a98bc0daff2177e7122b",
+			"MachineKey": "mkey:d537712d90f7f8e27811d8b9dd8c065bf4de723804af1724b7e4012a9b376573",
+			"Peers": [{
+				"ID":         4059592169868724,
+				"StableID":   "nVhbdwbbhY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb51a6675b308d01b78bcb30f2a0cc50fa33d0831df1de360f6538e8e5b6aa1d",
+				"DiscoKey":   "discokey:4b75167e5e52e3a1347d19bfbfbeb8e8eedfc158749e30edd5f6001591f57603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41039", "10.65.0.27:41039", "172.17.0.1:41039"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:06:07.639634818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         59158681840964,
+				"StableID":   "n5op8uznT111CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8387370dc4cc2ab77ad896999e2c9b1c9300eef3d4ddfef6368401508ac8f917",
+				"DiscoKey":   "discokey:79cdf22144c57419f35bb21bb5041427b763515f5eada09cfe472d472361c161",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58055", "10.65.0.27:58055", "172.17.0.1:58055"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:06:08.13247166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6185352225581314,
+				"StableID":   "n1tzRSiMJq11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49b20f3d05ca67827202ccdfbf63d7f50db6b6c170dfba6e78addb085a0cc163",
+				"DiscoKey":   "discokey:0866ab96e456732caba2ded26174e4a7a183e3d37181ec9074b5e87788fe057c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:48534", "10.65.0.27:48534", "172.17.0.1:48534"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:06:08.676098067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6578521131935565,
+				"StableID":   "n61qLWbRNt11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b36aca8beec68ebe2f5976e825a63425266c345ad35a957aa14bef8489e641f",
+				"DiscoKey":   "discokey:4dc2d4df1fac4f357b34f63c94b4e163b0d388135de5cd5632f779972dc1db14",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:51861", "10.65.0.27:51861", "172.17.0.1:51861"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:06:09.210173503Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8600576601881995,
+				"StableID":   "n4R12gZDAA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9627374c5d3fb9c58b1f038f2204c59fac7173df444ab2c640d32d21aee11027",
+				"KeyExpiry":  "2026-10-26T11:06:10Z",
+				"DiscoKey":   "discokey:75379c9356e62fdbafbac5fc04bb388605e958c16395cab206b69663d8db0d21",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52878", "10.65.0.27:52878", "172.17.0.1:52878"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:06:10.28750417Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8795597879864271,
+				"StableID":   "ngFxXcSYgB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e4219f40f308d131ba2cd5b3cc27135cd52a75cc27b3dc827572367ac63e4b76",
+				"KeyExpiry":  "2026-10-26T11:06:10Z",
+				"DiscoKey":   "discokey:b85e2f8e3e55c08c6a132806e266709e194ce6b086c3fa1a8fa3406f790b4b09",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43120", "10.65.0.27:43120", "172.17.0.1:43120"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:06:10.862641975Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6789179882545657,
+				"StableID":   "n2jSm6Fq1v11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:84aca5d080c7ec83aabf10b4fb6785dea345d98537aaf73bf582f2dbdca0a212",
+				"KeyExpiry":  "2026-10-26T11:06:11Z",
+				"DiscoKey":   "discokey:2db0e882f3581bbcaea5e22cfb22c3f8876d49c30d7d5128604bc8d3114e9506",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59675", "10.65.0.27:59675", "172.17.0.1:59675"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:06:11.348756243Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7390971188181415": {
+				"ID":          7390971188181415,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6789179882545657,
+				"StableID":   "n2jSm6Fq1v11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:84aca5d080c7ec83aabf10b4fb6785dea345d98537aaf73bf582f2dbdca0a212",
+				"KeyExpiry":  "2026-10-26T11:06:11Z",
+				"DiscoKey":   "discokey:2db0e882f3581bbcaea5e22cfb22c3f8876d49c30d7d5128604bc8d3114e9506",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59675", "10.65.0.27:59675", "172.17.0.1:59675"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:06:11.348756243Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:84aca5d080c7ec83aabf10b4fb6785dea345d98537aaf73bf582f2dbdca0a212",
+			"MachineKey": "mkey:cbaaff0e408816b8e0c16cd2ca0e49c3b9734a3b8bb16ac884ff20f2c3cdab0d",
+			"Peers": [{
+				"ID":         4059592169868724,
+				"StableID":   "nVhbdwbbhY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb51a6675b308d01b78bcb30f2a0cc50fa33d0831df1de360f6538e8e5b6aa1d",
+				"DiscoKey":   "discokey:4b75167e5e52e3a1347d19bfbfbeb8e8eedfc158749e30edd5f6001591f57603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41039", "10.65.0.27:41039", "172.17.0.1:41039"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:06:07.639634818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         59158681840964,
+				"StableID":   "n5op8uznT111CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8387370dc4cc2ab77ad896999e2c9b1c9300eef3d4ddfef6368401508ac8f917",
+				"DiscoKey":   "discokey:79cdf22144c57419f35bb21bb5041427b763515f5eada09cfe472d472361c161",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58055", "10.65.0.27:58055", "172.17.0.1:58055"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:06:08.13247166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6185352225581314,
+				"StableID":   "n1tzRSiMJq11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49b20f3d05ca67827202ccdfbf63d7f50db6b6c170dfba6e78addb085a0cc163",
+				"DiscoKey":   "discokey:0866ab96e456732caba2ded26174e4a7a183e3d37181ec9074b5e87788fe057c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:48534", "10.65.0.27:48534", "172.17.0.1:48534"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:06:08.676098067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6578521131935565,
+				"StableID":   "n61qLWbRNt11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b36aca8beec68ebe2f5976e825a63425266c345ad35a957aa14bef8489e641f",
+				"DiscoKey":   "discokey:4dc2d4df1fac4f357b34f63c94b4e163b0d388135de5cd5632f779972dc1db14",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:51861", "10.65.0.27:51861", "172.17.0.1:51861"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:06:09.210173503Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7390971188181415,
+				"StableID":   "nnz3iFHPiz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ff06db3e2380f50f0bf0f89d3865a5c50378c648a48a98bc0daff2177e7122b",
+				"DiscoKey":   "discokey:14478a343137dc5c03c63875740e79b910c52962b0b27af84b7f0a253e386124",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:41504", "10.65.0.27:41504", "172.17.0.1:41504"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:06:09.745379627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8600576601881995,
+				"StableID":   "n4R12gZDAA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9627374c5d3fb9c58b1f038f2204c59fac7173df444ab2c640d32d21aee11027",
+				"KeyExpiry":  "2026-10-26T11:06:10Z",
+				"DiscoKey":   "discokey:75379c9356e62fdbafbac5fc04bb388605e958c16395cab206b69663d8db0d21",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52878", "10.65.0.27:52878", "172.17.0.1:52878"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:06:10.28750417Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8795597879864271,
+				"StableID":   "ngFxXcSYgB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e4219f40f308d131ba2cd5b3cc27135cd52a75cc27b3dc827572367ac63e4b76",
+				"KeyExpiry":  "2026-10-26T11:06:10Z",
+				"DiscoKey":   "discokey:b85e2f8e3e55c08c6a132806e266709e194ce6b086c3fa1a8fa3406f790b4b09",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43120", "10.65.0.27:43120", "172.17.0.1:43120"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:06:10.862641975Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4059592169868724,
+				"StableID":   "nVhbdwbbhY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       4059592169868724,
+				"Key":        "nodekey:cb51a6675b308d01b78bcb30f2a0cc50fa33d0831df1de360f6538e8e5b6aa1d",
+				"DiscoKey":   "discokey:4b75167e5e52e3a1347d19bfbfbeb8e8eedfc158749e30edd5f6001591f57603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41039", "10.65.0.27:41039", "172.17.0.1:41039"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T11:06:07.639634818Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cb51a6675b308d01b78bcb30f2a0cc50fa33d0831df1de360f6538e8e5b6aa1d",
+			"MachineKey": "mkey:8bb3b4c5e56dc947f973eafb741af69ccdcc13349f4654656898f157caaf4f63",
+			"Peers": [{
+				"ID":         59158681840964,
+				"StableID":   "n5op8uznT111CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8387370dc4cc2ab77ad896999e2c9b1c9300eef3d4ddfef6368401508ac8f917",
+				"DiscoKey":   "discokey:79cdf22144c57419f35bb21bb5041427b763515f5eada09cfe472d472361c161",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58055", "10.65.0.27:58055", "172.17.0.1:58055"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:06:08.13247166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6185352225581314,
+				"StableID":   "n1tzRSiMJq11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49b20f3d05ca67827202ccdfbf63d7f50db6b6c170dfba6e78addb085a0cc163",
+				"DiscoKey":   "discokey:0866ab96e456732caba2ded26174e4a7a183e3d37181ec9074b5e87788fe057c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:48534", "10.65.0.27:48534", "172.17.0.1:48534"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:06:08.676098067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6578521131935565,
+				"StableID":   "n61qLWbRNt11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b36aca8beec68ebe2f5976e825a63425266c345ad35a957aa14bef8489e641f",
+				"DiscoKey":   "discokey:4dc2d4df1fac4f357b34f63c94b4e163b0d388135de5cd5632f779972dc1db14",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:51861", "10.65.0.27:51861", "172.17.0.1:51861"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:06:09.210173503Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7390971188181415,
+				"StableID":   "nnz3iFHPiz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ff06db3e2380f50f0bf0f89d3865a5c50378c648a48a98bc0daff2177e7122b",
+				"DiscoKey":   "discokey:14478a343137dc5c03c63875740e79b910c52962b0b27af84b7f0a253e386124",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:41504", "10.65.0.27:41504", "172.17.0.1:41504"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:06:09.745379627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8600576601881995,
+				"StableID":   "n4R12gZDAA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9627374c5d3fb9c58b1f038f2204c59fac7173df444ab2c640d32d21aee11027",
+				"KeyExpiry":  "2026-10-26T11:06:10Z",
+				"DiscoKey":   "discokey:75379c9356e62fdbafbac5fc04bb388605e958c16395cab206b69663d8db0d21",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52878", "10.65.0.27:52878", "172.17.0.1:52878"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:06:10.28750417Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8795597879864271,
+				"StableID":   "ngFxXcSYgB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e4219f40f308d131ba2cd5b3cc27135cd52a75cc27b3dc827572367ac63e4b76",
+				"KeyExpiry":  "2026-10-26T11:06:10Z",
+				"DiscoKey":   "discokey:b85e2f8e3e55c08c6a132806e266709e194ce6b086c3fa1a8fa3406f790b4b09",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43120", "10.65.0.27:43120", "172.17.0.1:43120"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:06:10.862641975Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6789179882545657,
+				"StableID":   "n2jSm6Fq1v11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:84aca5d080c7ec83aabf10b4fb6785dea345d98537aaf73bf582f2dbdca0a212",
+				"KeyExpiry":  "2026-10-26T11:06:11Z",
+				"DiscoKey":   "discokey:2db0e882f3581bbcaea5e22cfb22c3f8876d49c30d7d5128604bc8d3114e9506",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59675", "10.65.0.27:59675", "172.17.0.1:59675"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:06:11.348756243Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4059592169868724": {
+				"ID":          4059592169868724,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8600576601881995,
+				"StableID":   "n4R12gZDAA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9627374c5d3fb9c58b1f038f2204c59fac7173df444ab2c640d32d21aee11027",
+				"KeyExpiry":  "2026-10-26T11:06:10Z",
+				"DiscoKey":   "discokey:75379c9356e62fdbafbac5fc04bb388605e958c16395cab206b69663d8db0d21",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52878", "10.65.0.27:52878", "172.17.0.1:52878"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:06:10.28750417Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9627374c5d3fb9c58b1f038f2204c59fac7173df444ab2c640d32d21aee11027",
+			"MachineKey": "mkey:0e2bbf2184127ab37cadad10011badfb53a2411e3e081f0013684e5ca71b9e74",
+			"Peers": [{
+				"ID":         4059592169868724,
+				"StableID":   "nVhbdwbbhY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb51a6675b308d01b78bcb30f2a0cc50fa33d0831df1de360f6538e8e5b6aa1d",
+				"DiscoKey":   "discokey:4b75167e5e52e3a1347d19bfbfbeb8e8eedfc158749e30edd5f6001591f57603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41039", "10.65.0.27:41039", "172.17.0.1:41039"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:06:07.639634818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         59158681840964,
+				"StableID":   "n5op8uznT111CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8387370dc4cc2ab77ad896999e2c9b1c9300eef3d4ddfef6368401508ac8f917",
+				"DiscoKey":   "discokey:79cdf22144c57419f35bb21bb5041427b763515f5eada09cfe472d472361c161",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58055", "10.65.0.27:58055", "172.17.0.1:58055"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:06:08.13247166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6185352225581314,
+				"StableID":   "n1tzRSiMJq11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49b20f3d05ca67827202ccdfbf63d7f50db6b6c170dfba6e78addb085a0cc163",
+				"DiscoKey":   "discokey:0866ab96e456732caba2ded26174e4a7a183e3d37181ec9074b5e87788fe057c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:48534", "10.65.0.27:48534", "172.17.0.1:48534"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:06:08.676098067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6578521131935565,
+				"StableID":   "n61qLWbRNt11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b36aca8beec68ebe2f5976e825a63425266c345ad35a957aa14bef8489e641f",
+				"DiscoKey":   "discokey:4dc2d4df1fac4f357b34f63c94b4e163b0d388135de5cd5632f779972dc1db14",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:51861", "10.65.0.27:51861", "172.17.0.1:51861"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:06:09.210173503Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7390971188181415,
+				"StableID":   "nnz3iFHPiz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ff06db3e2380f50f0bf0f89d3865a5c50378c648a48a98bc0daff2177e7122b",
+				"DiscoKey":   "discokey:14478a343137dc5c03c63875740e79b910c52962b0b27af84b7f0a253e386124",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:41504", "10.65.0.27:41504", "172.17.0.1:41504"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:06:09.745379627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8795597879864271,
+				"StableID":   "ngFxXcSYgB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e4219f40f308d131ba2cd5b3cc27135cd52a75cc27b3dc827572367ac63e4b76",
+				"KeyExpiry":  "2026-10-26T11:06:10Z",
+				"DiscoKey":   "discokey:b85e2f8e3e55c08c6a132806e266709e194ce6b086c3fa1a8fa3406f790b4b09",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43120", "10.65.0.27:43120", "172.17.0.1:43120"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:06:10.862641975Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6789179882545657,
+				"StableID":   "n2jSm6Fq1v11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:84aca5d080c7ec83aabf10b4fb6785dea345d98537aaf73bf582f2dbdca0a212",
+				"KeyExpiry":  "2026-10-26T11:06:11Z",
+				"DiscoKey":   "discokey:2db0e882f3581bbcaea5e22cfb22c3f8876d49c30d7d5128604bc8d3114e9506",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59675", "10.65.0.27:59675", "172.17.0.1:59675"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:06:11.348756243Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6578521131935565,
+				"StableID":   "n61qLWbRNt11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       6578521131935565,
+				"Key":        "nodekey:9b36aca8beec68ebe2f5976e825a63425266c345ad35a957aa14bef8489e641f",
+				"DiscoKey":   "discokey:4dc2d4df1fac4f357b34f63c94b4e163b0d388135de5cd5632f779972dc1db14",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:51861", "10.65.0.27:51861", "172.17.0.1:51861"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:06:09.210173503Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9b36aca8beec68ebe2f5976e825a63425266c345ad35a957aa14bef8489e641f",
+			"MachineKey": "mkey:5e9cf56a55d7e86bf8c239b00ee9e8db9b55bdbecd23e3eea2b69b19ca01b952",
+			"Peers": [{
+				"ID":         4059592169868724,
+				"StableID":   "nVhbdwbbhY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb51a6675b308d01b78bcb30f2a0cc50fa33d0831df1de360f6538e8e5b6aa1d",
+				"DiscoKey":   "discokey:4b75167e5e52e3a1347d19bfbfbeb8e8eedfc158749e30edd5f6001591f57603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41039", "10.65.0.27:41039", "172.17.0.1:41039"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:06:07.639634818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         59158681840964,
+				"StableID":   "n5op8uznT111CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8387370dc4cc2ab77ad896999e2c9b1c9300eef3d4ddfef6368401508ac8f917",
+				"DiscoKey":   "discokey:79cdf22144c57419f35bb21bb5041427b763515f5eada09cfe472d472361c161",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58055", "10.65.0.27:58055", "172.17.0.1:58055"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:06:08.13247166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6185352225581314,
+				"StableID":   "n1tzRSiMJq11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49b20f3d05ca67827202ccdfbf63d7f50db6b6c170dfba6e78addb085a0cc163",
+				"DiscoKey":   "discokey:0866ab96e456732caba2ded26174e4a7a183e3d37181ec9074b5e87788fe057c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:48534", "10.65.0.27:48534", "172.17.0.1:48534"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:06:08.676098067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7390971188181415,
+				"StableID":   "nnz3iFHPiz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ff06db3e2380f50f0bf0f89d3865a5c50378c648a48a98bc0daff2177e7122b",
+				"DiscoKey":   "discokey:14478a343137dc5c03c63875740e79b910c52962b0b27af84b7f0a253e386124",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:41504", "10.65.0.27:41504", "172.17.0.1:41504"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:06:09.745379627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8600576601881995,
+				"StableID":   "n4R12gZDAA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9627374c5d3fb9c58b1f038f2204c59fac7173df444ab2c640d32d21aee11027",
+				"KeyExpiry":  "2026-10-26T11:06:10Z",
+				"DiscoKey":   "discokey:75379c9356e62fdbafbac5fc04bb388605e958c16395cab206b69663d8db0d21",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52878", "10.65.0.27:52878", "172.17.0.1:52878"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:06:10.28750417Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8795597879864271,
+				"StableID":   "ngFxXcSYgB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e4219f40f308d131ba2cd5b3cc27135cd52a75cc27b3dc827572367ac63e4b76",
+				"KeyExpiry":  "2026-10-26T11:06:10Z",
+				"DiscoKey":   "discokey:b85e2f8e3e55c08c6a132806e266709e194ce6b086c3fa1a8fa3406f790b4b09",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43120", "10.65.0.27:43120", "172.17.0.1:43120"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:06:10.862641975Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6789179882545657,
+				"StableID":   "n2jSm6Fq1v11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:84aca5d080c7ec83aabf10b4fb6785dea345d98537aaf73bf582f2dbdca0a212",
+				"KeyExpiry":  "2026-10-26T11:06:11Z",
+				"DiscoKey":   "discokey:2db0e882f3581bbcaea5e22cfb22c3f8876d49c30d7d5128604bc8d3114e9506",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59675", "10.65.0.27:59675", "172.17.0.1:59675"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:06:11.348756243Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6578521131935565": {
+				"ID":          6578521131935565,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         59158681840964,
+				"StableID":   "n5op8uznT111CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       59158681840964,
+				"Key":        "nodekey:8387370dc4cc2ab77ad896999e2c9b1c9300eef3d4ddfef6368401508ac8f917",
+				"DiscoKey":   "discokey:79cdf22144c57419f35bb21bb5041427b763515f5eada09cfe472d472361c161",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58055", "10.65.0.27:58055", "172.17.0.1:58055"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T11:06:08.13247166Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8387370dc4cc2ab77ad896999e2c9b1c9300eef3d4ddfef6368401508ac8f917",
+			"MachineKey": "mkey:a4ddfb45e96df0edccd21f0e3d9968831e0a94832a933334325040716836de06",
+			"Peers": [{
+				"ID":         4059592169868724,
+				"StableID":   "nVhbdwbbhY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb51a6675b308d01b78bcb30f2a0cc50fa33d0831df1de360f6538e8e5b6aa1d",
+				"DiscoKey":   "discokey:4b75167e5e52e3a1347d19bfbfbeb8e8eedfc158749e30edd5f6001591f57603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41039", "10.65.0.27:41039", "172.17.0.1:41039"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:06:07.639634818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6185352225581314,
+				"StableID":   "n1tzRSiMJq11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49b20f3d05ca67827202ccdfbf63d7f50db6b6c170dfba6e78addb085a0cc163",
+				"DiscoKey":   "discokey:0866ab96e456732caba2ded26174e4a7a183e3d37181ec9074b5e87788fe057c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:48534", "10.65.0.27:48534", "172.17.0.1:48534"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:06:08.676098067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6578521131935565,
+				"StableID":   "n61qLWbRNt11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b36aca8beec68ebe2f5976e825a63425266c345ad35a957aa14bef8489e641f",
+				"DiscoKey":   "discokey:4dc2d4df1fac4f357b34f63c94b4e163b0d388135de5cd5632f779972dc1db14",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:51861", "10.65.0.27:51861", "172.17.0.1:51861"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:06:09.210173503Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7390971188181415,
+				"StableID":   "nnz3iFHPiz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ff06db3e2380f50f0bf0f89d3865a5c50378c648a48a98bc0daff2177e7122b",
+				"DiscoKey":   "discokey:14478a343137dc5c03c63875740e79b910c52962b0b27af84b7f0a253e386124",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:41504", "10.65.0.27:41504", "172.17.0.1:41504"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:06:09.745379627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8600576601881995,
+				"StableID":   "n4R12gZDAA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9627374c5d3fb9c58b1f038f2204c59fac7173df444ab2c640d32d21aee11027",
+				"KeyExpiry":  "2026-10-26T11:06:10Z",
+				"DiscoKey":   "discokey:75379c9356e62fdbafbac5fc04bb388605e958c16395cab206b69663d8db0d21",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52878", "10.65.0.27:52878", "172.17.0.1:52878"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:06:10.28750417Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8795597879864271,
+				"StableID":   "ngFxXcSYgB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e4219f40f308d131ba2cd5b3cc27135cd52a75cc27b3dc827572367ac63e4b76",
+				"KeyExpiry":  "2026-10-26T11:06:10Z",
+				"DiscoKey":   "discokey:b85e2f8e3e55c08c6a132806e266709e194ce6b086c3fa1a8fa3406f790b4b09",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43120", "10.65.0.27:43120", "172.17.0.1:43120"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:06:10.862641975Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6789179882545657,
+				"StableID":   "n2jSm6Fq1v11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:84aca5d080c7ec83aabf10b4fb6785dea345d98537aaf73bf582f2dbdca0a212",
+				"KeyExpiry":  "2026-10-26T11:06:11Z",
+				"DiscoKey":   "discokey:2db0e882f3581bbcaea5e22cfb22c3f8876d49c30d7d5128604bc8d3114e9506",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59675", "10.65.0.27:59675", "172.17.0.1:59675"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:06:11.348756243Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "59158681840964": {
+				"ID":          59158681840964,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8795597879864271,
+				"StableID":   "ngFxXcSYgB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e4219f40f308d131ba2cd5b3cc27135cd52a75cc27b3dc827572367ac63e4b76",
+				"KeyExpiry":  "2026-10-26T11:06:10Z",
+				"DiscoKey":   "discokey:b85e2f8e3e55c08c6a132806e266709e194ce6b086c3fa1a8fa3406f790b4b09",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43120", "10.65.0.27:43120", "172.17.0.1:43120"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:06:10.862641975Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e4219f40f308d131ba2cd5b3cc27135cd52a75cc27b3dc827572367ac63e4b76",
+			"MachineKey": "mkey:e0caf3b00d40fe560712574347828e973c91d6df8ce303875efede21de2ab222",
+			"Peers": [{
+				"ID":         4059592169868724,
+				"StableID":   "nVhbdwbbhY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb51a6675b308d01b78bcb30f2a0cc50fa33d0831df1de360f6538e8e5b6aa1d",
+				"DiscoKey":   "discokey:4b75167e5e52e3a1347d19bfbfbeb8e8eedfc158749e30edd5f6001591f57603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41039", "10.65.0.27:41039", "172.17.0.1:41039"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:06:07.639634818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         59158681840964,
+				"StableID":   "n5op8uznT111CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8387370dc4cc2ab77ad896999e2c9b1c9300eef3d4ddfef6368401508ac8f917",
+				"DiscoKey":   "discokey:79cdf22144c57419f35bb21bb5041427b763515f5eada09cfe472d472361c161",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58055", "10.65.0.27:58055", "172.17.0.1:58055"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:06:08.13247166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6185352225581314,
+				"StableID":   "n1tzRSiMJq11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49b20f3d05ca67827202ccdfbf63d7f50db6b6c170dfba6e78addb085a0cc163",
+				"DiscoKey":   "discokey:0866ab96e456732caba2ded26174e4a7a183e3d37181ec9074b5e87788fe057c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:48534", "10.65.0.27:48534", "172.17.0.1:48534"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:06:08.676098067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6578521131935565,
+				"StableID":   "n61qLWbRNt11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b36aca8beec68ebe2f5976e825a63425266c345ad35a957aa14bef8489e641f",
+				"DiscoKey":   "discokey:4dc2d4df1fac4f357b34f63c94b4e163b0d388135de5cd5632f779972dc1db14",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:51861", "10.65.0.27:51861", "172.17.0.1:51861"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:06:09.210173503Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7390971188181415,
+				"StableID":   "nnz3iFHPiz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ff06db3e2380f50f0bf0f89d3865a5c50378c648a48a98bc0daff2177e7122b",
+				"DiscoKey":   "discokey:14478a343137dc5c03c63875740e79b910c52962b0b27af84b7f0a253e386124",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:41504", "10.65.0.27:41504", "172.17.0.1:41504"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:06:09.745379627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8600576601881995,
+				"StableID":   "n4R12gZDAA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9627374c5d3fb9c58b1f038f2204c59fac7173df444ab2c640d32d21aee11027",
+				"KeyExpiry":  "2026-10-26T11:06:10Z",
+				"DiscoKey":   "discokey:75379c9356e62fdbafbac5fc04bb388605e958c16395cab206b69663d8db0d21",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52878", "10.65.0.27:52878", "172.17.0.1:52878"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:06:10.28750417Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6789179882545657,
+				"StableID":   "n2jSm6Fq1v11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:84aca5d080c7ec83aabf10b4fb6785dea345d98537aaf73bf582f2dbdca0a212",
+				"KeyExpiry":  "2026-10-26T11:06:11Z",
+				"DiscoKey":   "discokey:2db0e882f3581bbcaea5e22cfb22c3f8876d49c30d7d5128604bc8d3114e9506",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59675", "10.65.0.27:59675", "172.17.0.1:59675"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:06:11.348756243Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6185352225581314,
+				"StableID":   "n1tzRSiMJq11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       6185352225581314,
+				"Key":        "nodekey:49b20f3d05ca67827202ccdfbf63d7f50db6b6c170dfba6e78addb085a0cc163",
+				"DiscoKey":   "discokey:0866ab96e456732caba2ded26174e4a7a183e3d37181ec9074b5e87788fe057c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:48534", "10.65.0.27:48534", "172.17.0.1:48534"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:06:08.676098067Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:49b20f3d05ca67827202ccdfbf63d7f50db6b6c170dfba6e78addb085a0cc163",
+			"MachineKey": "mkey:000a4fd8ed02285257610ee24cc222bbd418e1db38c1c2aa61caa603041c835b",
+			"Peers": [{
+				"ID":         4059592169868724,
+				"StableID":   "nVhbdwbbhY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb51a6675b308d01b78bcb30f2a0cc50fa33d0831df1de360f6538e8e5b6aa1d",
+				"DiscoKey":   "discokey:4b75167e5e52e3a1347d19bfbfbeb8e8eedfc158749e30edd5f6001591f57603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41039", "10.65.0.27:41039", "172.17.0.1:41039"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:06:07.639634818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         59158681840964,
+				"StableID":   "n5op8uznT111CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8387370dc4cc2ab77ad896999e2c9b1c9300eef3d4ddfef6368401508ac8f917",
+				"DiscoKey":   "discokey:79cdf22144c57419f35bb21bb5041427b763515f5eada09cfe472d472361c161",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:58055", "10.65.0.27:58055", "172.17.0.1:58055"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:06:08.13247166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6578521131935565,
+				"StableID":   "n61qLWbRNt11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b36aca8beec68ebe2f5976e825a63425266c345ad35a957aa14bef8489e641f",
+				"DiscoKey":   "discokey:4dc2d4df1fac4f357b34f63c94b4e163b0d388135de5cd5632f779972dc1db14",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:51861", "10.65.0.27:51861", "172.17.0.1:51861"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:06:09.210173503Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7390971188181415,
+				"StableID":   "nnz3iFHPiz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ff06db3e2380f50f0bf0f89d3865a5c50378c648a48a98bc0daff2177e7122b",
+				"DiscoKey":   "discokey:14478a343137dc5c03c63875740e79b910c52962b0b27af84b7f0a253e386124",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:41504", "10.65.0.27:41504", "172.17.0.1:41504"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:06:09.745379627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8600576601881995,
+				"StableID":   "n4R12gZDAA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9627374c5d3fb9c58b1f038f2204c59fac7173df444ab2c640d32d21aee11027",
+				"KeyExpiry":  "2026-10-26T11:06:10Z",
+				"DiscoKey":   "discokey:75379c9356e62fdbafbac5fc04bb388605e958c16395cab206b69663d8db0d21",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:52878", "10.65.0.27:52878", "172.17.0.1:52878"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:06:10.28750417Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8795597879864271,
+				"StableID":   "ngFxXcSYgB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e4219f40f308d131ba2cd5b3cc27135cd52a75cc27b3dc827572367ac63e4b76",
+				"KeyExpiry":  "2026-10-26T11:06:10Z",
+				"DiscoKey":   "discokey:b85e2f8e3e55c08c6a132806e266709e194ce6b086c3fa1a8fa3406f790b4b09",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:43120", "10.65.0.27:43120", "172.17.0.1:43120"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:06:10.862641975Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6789179882545657,
+				"StableID":   "n2jSm6Fq1v11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:84aca5d080c7ec83aabf10b4fb6785dea345d98537aaf73bf582f2dbdca0a212",
+				"KeyExpiry":  "2026-10-26T11:06:11Z",
+				"DiscoKey":   "discokey:2db0e882f3581bbcaea5e22cfb22c3f8876d49c30d7d5128604bc8d3114e9506",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:59675", "10.65.0.27:59675", "172.17.0.1:59675"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:06:11.348756243Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6185352225581314": {
+				"ID":          6185352225581314,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/policytest_results/policytest-src-unknown-user-email.hujson
+++ b/hscontrol/policy/v2/testdata/policytest_results/policytest-src-unknown-user-email.hujson
@@ -1,0 +1,8847 @@
+// policytest-src-unknown-user-email
+//
+// tests block src-unknown: user email not present in policy
+//
+// Nodes with filter rules: 8 of 8
+// Captured at:    2026-04-29T11:09:16Z
+// tscap version:  tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "policytest-src-unknown-user-email",
+	"description":    "tests block src-unknown: user email not present in policy",
+	"category":       "policytest",
+	"captured_at":    "2026-04-29T11:09:16.730572441Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                    \n  \n                                                            \n                                                                       \n{\n\t\"id\":          \"policytest-src-unknown-user-email\",\n\t\"category\":    \"policytest\",\n\t\"description\": \"tests block src-unknown: user email not present in policy\",\n\n\t\"topology\": \"../_topologies/acl.hujson\",\n\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\n\t\"options\": {\"expect_api_error\": true},\n\n\t\"policy\": {\n\t\t\"groups\": {\n\t\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"],\n\t\t\t\"group:empty\":      [],\n\t\t\t\"group:monitors\":   [\"freya@example.com\"]\n\t\t},\n\t\t\"tagOwners\": {\n\t\t\t\"tag:client\":   [\"odin@example.com\"],\n\t\t\t\"tag:exit\":     [\"odin@example.com\"],\n\t\t\t\"tag:pidgey\":   [\"odin@example.com\"],\n\t\t\t\"tag:pidgeotto\":   [\"odin@example.com\"],\n\t\t\t\"tag:group-a\":  [\"odin@example.com\"],\n\t\t\t\"tag:group-b\":  [\"odin@example.com\"],\n\t\t\t\"tag:ha\":       [\"odin@example.com\"],\n\t\t\t\"tag:prod\":     [\"odin@example.com\"],\n\t\t\t\"tag:router\":   [\"odin@example.com\"],\n\t\t\t\"tag:spearow\": [\"odin@example.com\"],\n\t\t\t\"tag:fearow\": [\"odin@example.com\"],\n\t\t\t\"tag:server\":   [\"odin@example.com\"]\n\t\t},\n\t\t\"hosts\": {\n\t\t\t\"internal\":  \"10.0.0.0/8\",\n\t\t\t\"prodbox\":   \"100.103.8.15\",\n\t\t\t\"subnet24\":  \"192.168.1.0/24\",\n\t\t\t\"webserver\": \"100.64.0.16\"\n\t\t},\n\t\t\"acls\": [\n\t\t\t{\"action\": \"accept\", \"src\": [\"thor@example.org\"], \"dst\": [\"tag:server:22\"]}\n\t\t],\n\t\t\"tests\": [\n\t\t\t{\"src\": \"ghost@nowhere.invalid\", \"accept\": [\"tag:server:22\"]}\n\t\t]\n\t}\n}\n",
+		"scenario_path":   "scenarios/policytest/policytest-src-unknown-user-email.hujson",
+		"full_policy": {
+			"acls": [{
+				"action": "accept",
+				"dst":    ["tag:server:22"],
+				"src":    ["thor@example.org"]
+			}],
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"],
+				"group:empty":      [],
+				"group:monitors":   ["freya@example.com"]
+			},
+			"hosts": {
+				"internal":  "10.0.0.0/8",
+				"prodbox":   "100.103.8.15",
+				"subnet24":  "192.168.1.0/24",
+				"webserver": "100.64.0.16"
+			},
+			"tagOwners": {
+				"tag:client":    ["odin@example.com"],
+				"tag:exit":      ["odin@example.com"],
+				"tag:pidgey":    ["odin@example.com"],
+				"tag:pidgeotto": ["odin@example.com"],
+				"tag:group-a":   ["odin@example.com"],
+				"tag:group-b":   ["odin@example.com"],
+				"tag:ha":        ["odin@example.com"],
+				"tag:prod":      ["odin@example.com"],
+				"tag:router":    ["odin@example.com"],
+				"tag:spearow":   ["odin@example.com"],
+				"tag:fearow":    ["odin@example.com"],
+				"tag:server":    ["odin@example.com"]
+			},
+			"tests": [{"accept": ["tag:server:22"], "src": "ghost@nowhere.invalid"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1959379250698017,
+				"StableID":   "nkYho5aQJG11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1959379250698017,
+				"Key":        "nodekey:903ddeb11ea65265b4b8eb92d1c0ccb31f2b92d5859da0f7e40fae6214a14e5e",
+				"DiscoKey":   "discokey:e241d9b246613f9272862d4044159fe98d693529feeb6e624d4410d82d0d3b52",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:51226", "10.65.0.27:51226", "172.17.0.1:51226"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:09:24.485432025Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:903ddeb11ea65265b4b8eb92d1c0ccb31f2b92d5859da0f7e40fae6214a14e5e",
+			"MachineKey": "mkey:ee62dc12fbf7d7fc8958378fefdeaf4982f392bc61225856eb74be031afa1236",
+			"Peers": [{
+				"ID":         8727498203809198,
+				"StableID":   "nZAiMZah9B21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf684fe791604ddd860d15360f012dcdc23b88fbb9ed22e69fc2a6e0ba181528",
+				"DiscoKey":   "discokey:78f7a1c58c689716c0aa60dc32c77d45ceb38e7e3d7c42520bc0d29428f4b245",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:50341", "10.65.0.27:50341", "172.17.0.1:50341"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:09:22.299930531Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4329185102760981,
+				"StableID":   "nEq7wPMhoa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2f522f47ee736ab1b8b8270e11de1cd90aa642e447f8646c1c162bcac482290a",
+				"DiscoKey":   "discokey:6e0722f327e384e9fe76272289c8bacd48f89d30fe382bc4fde8766c92744d2e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54928", "10.65.0.27:54928", "172.17.0.1:54928"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:09:22.832722472Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7314967480462500,
+				"StableID":   "nPaWKvnx7z11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66be1509ade05fb01e57b5763182f3b5c4deb52ecd87c4676830443ff5658e32",
+				"DiscoKey":   "discokey:7fc4a1a0ffbd54ec61cc455888e8e917706a54f7fc7387e02c36491e28df1f56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53994", "10.65.0.27:53994", "172.17.0.1:53994"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:09:23.453376671Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         275919037510456,
+				"StableID":   "n3xFWfvx9311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1d8001467552849da264fd574521a38081b52780ff76361b1810623f9faa3900",
+				"DiscoKey":   "discokey:b0142569b00d615d28bd1bfd83af22afcb496b9411ca522bd77d3655f25bff0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36196", "10.65.0.27:36196", "172.17.0.1:36196"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:09:23.938108054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7131323554041054,
+				"StableID":   "nBoDQ5nngx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:583c6549253742d5187854dc03c5e444f1616a7c66867bcfbb582dc6e63d7915",
+				"KeyExpiry":  "2026-10-26T11:09:25Z",
+				"DiscoKey":   "discokey:dce7e98c2cb482fbaeceff205e80b853ef7db4c8de32bff46026dbd4d6f30620",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51514", "10.65.0.27:51514", "172.17.0.1:51514"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:09:25.052545864Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2758752188497194,
+				"StableID":   "n3Kgz2kSYN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2c15cbcb2a6cc3c8bd3b96755486f1650e46c723ad5c71a5535bc2b73bec9d7e",
+				"KeyExpiry":  "2026-10-26T11:09:25Z",
+				"DiscoKey":   "discokey:c4cf69dc42761e2b93a40140001c16fc1c931ea0642abb43fef5e64afd97303c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41484", "10.65.0.27:41484", "172.17.0.1:41484"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:09:25.590729478Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5020795885021167,
+				"StableID":   "nQyBT4ovCg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e377a5950ad45df6e9c62d30d11462fb8487bf191f6650c0d7359e7ca084ef3c",
+				"KeyExpiry":  "2026-10-26T11:09:26Z",
+				"DiscoKey":   "discokey:241cc82377cbc61816e4ca4195e4f55367e5c14d95695dead7f6f4a9b86ef07e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43966", "10.65.0.27:43966", "172.17.0.1:43966"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:09:26.125929521Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1959379250698017": {
+				"ID":          1959379250698017,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5020795885021167,
+				"StableID":   "nQyBT4ovCg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e377a5950ad45df6e9c62d30d11462fb8487bf191f6650c0d7359e7ca084ef3c",
+				"KeyExpiry":  "2026-10-26T11:09:26Z",
+				"DiscoKey":   "discokey:241cc82377cbc61816e4ca4195e4f55367e5c14d95695dead7f6f4a9b86ef07e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43966", "10.65.0.27:43966", "172.17.0.1:43966"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:09:26.125929521Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e377a5950ad45df6e9c62d30d11462fb8487bf191f6650c0d7359e7ca084ef3c",
+			"MachineKey": "mkey:8e1925ab9d604e1270f182347903c991b8e7c60d529f6627ad688adf78914018",
+			"Peers": [{
+				"ID":         8727498203809198,
+				"StableID":   "nZAiMZah9B21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf684fe791604ddd860d15360f012dcdc23b88fbb9ed22e69fc2a6e0ba181528",
+				"DiscoKey":   "discokey:78f7a1c58c689716c0aa60dc32c77d45ceb38e7e3d7c42520bc0d29428f4b245",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:50341", "10.65.0.27:50341", "172.17.0.1:50341"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:09:22.299930531Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4329185102760981,
+				"StableID":   "nEq7wPMhoa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2f522f47ee736ab1b8b8270e11de1cd90aa642e447f8646c1c162bcac482290a",
+				"DiscoKey":   "discokey:6e0722f327e384e9fe76272289c8bacd48f89d30fe382bc4fde8766c92744d2e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54928", "10.65.0.27:54928", "172.17.0.1:54928"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:09:22.832722472Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7314967480462500,
+				"StableID":   "nPaWKvnx7z11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66be1509ade05fb01e57b5763182f3b5c4deb52ecd87c4676830443ff5658e32",
+				"DiscoKey":   "discokey:7fc4a1a0ffbd54ec61cc455888e8e917706a54f7fc7387e02c36491e28df1f56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53994", "10.65.0.27:53994", "172.17.0.1:53994"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:09:23.453376671Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         275919037510456,
+				"StableID":   "n3xFWfvx9311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1d8001467552849da264fd574521a38081b52780ff76361b1810623f9faa3900",
+				"DiscoKey":   "discokey:b0142569b00d615d28bd1bfd83af22afcb496b9411ca522bd77d3655f25bff0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36196", "10.65.0.27:36196", "172.17.0.1:36196"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:09:23.938108054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1959379250698017,
+				"StableID":   "nkYho5aQJG11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:903ddeb11ea65265b4b8eb92d1c0ccb31f2b92d5859da0f7e40fae6214a14e5e",
+				"DiscoKey":   "discokey:e241d9b246613f9272862d4044159fe98d693529feeb6e624d4410d82d0d3b52",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:51226", "10.65.0.27:51226", "172.17.0.1:51226"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:09:24.485432025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7131323554041054,
+				"StableID":   "nBoDQ5nngx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:583c6549253742d5187854dc03c5e444f1616a7c66867bcfbb582dc6e63d7915",
+				"KeyExpiry":  "2026-10-26T11:09:25Z",
+				"DiscoKey":   "discokey:dce7e98c2cb482fbaeceff205e80b853ef7db4c8de32bff46026dbd4d6f30620",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51514", "10.65.0.27:51514", "172.17.0.1:51514"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:09:25.052545864Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2758752188497194,
+				"StableID":   "n3Kgz2kSYN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2c15cbcb2a6cc3c8bd3b96755486f1650e46c723ad5c71a5535bc2b73bec9d7e",
+				"KeyExpiry":  "2026-10-26T11:09:25Z",
+				"DiscoKey":   "discokey:c4cf69dc42761e2b93a40140001c16fc1c931ea0642abb43fef5e64afd97303c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41484", "10.65.0.27:41484", "172.17.0.1:41484"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:09:25.590729478Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8727498203809198,
+				"StableID":   "nZAiMZah9B21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       8727498203809198,
+				"Key":        "nodekey:bf684fe791604ddd860d15360f012dcdc23b88fbb9ed22e69fc2a6e0ba181528",
+				"DiscoKey":   "discokey:78f7a1c58c689716c0aa60dc32c77d45ceb38e7e3d7c42520bc0d29428f4b245",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:50341", "10.65.0.27:50341", "172.17.0.1:50341"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T11:09:22.299930531Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bf684fe791604ddd860d15360f012dcdc23b88fbb9ed22e69fc2a6e0ba181528",
+			"MachineKey": "mkey:d1ddc2521d6cd5793569ef39bc5bfcfc289fffbce5d01e235699660e03be023f",
+			"Peers": [{
+				"ID":         4329185102760981,
+				"StableID":   "nEq7wPMhoa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2f522f47ee736ab1b8b8270e11de1cd90aa642e447f8646c1c162bcac482290a",
+				"DiscoKey":   "discokey:6e0722f327e384e9fe76272289c8bacd48f89d30fe382bc4fde8766c92744d2e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54928", "10.65.0.27:54928", "172.17.0.1:54928"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:09:22.832722472Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7314967480462500,
+				"StableID":   "nPaWKvnx7z11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66be1509ade05fb01e57b5763182f3b5c4deb52ecd87c4676830443ff5658e32",
+				"DiscoKey":   "discokey:7fc4a1a0ffbd54ec61cc455888e8e917706a54f7fc7387e02c36491e28df1f56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53994", "10.65.0.27:53994", "172.17.0.1:53994"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:09:23.453376671Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         275919037510456,
+				"StableID":   "n3xFWfvx9311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1d8001467552849da264fd574521a38081b52780ff76361b1810623f9faa3900",
+				"DiscoKey":   "discokey:b0142569b00d615d28bd1bfd83af22afcb496b9411ca522bd77d3655f25bff0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36196", "10.65.0.27:36196", "172.17.0.1:36196"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:09:23.938108054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1959379250698017,
+				"StableID":   "nkYho5aQJG11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:903ddeb11ea65265b4b8eb92d1c0ccb31f2b92d5859da0f7e40fae6214a14e5e",
+				"DiscoKey":   "discokey:e241d9b246613f9272862d4044159fe98d693529feeb6e624d4410d82d0d3b52",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:51226", "10.65.0.27:51226", "172.17.0.1:51226"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:09:24.485432025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7131323554041054,
+				"StableID":   "nBoDQ5nngx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:583c6549253742d5187854dc03c5e444f1616a7c66867bcfbb582dc6e63d7915",
+				"KeyExpiry":  "2026-10-26T11:09:25Z",
+				"DiscoKey":   "discokey:dce7e98c2cb482fbaeceff205e80b853ef7db4c8de32bff46026dbd4d6f30620",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51514", "10.65.0.27:51514", "172.17.0.1:51514"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:09:25.052545864Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2758752188497194,
+				"StableID":   "n3Kgz2kSYN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2c15cbcb2a6cc3c8bd3b96755486f1650e46c723ad5c71a5535bc2b73bec9d7e",
+				"KeyExpiry":  "2026-10-26T11:09:25Z",
+				"DiscoKey":   "discokey:c4cf69dc42761e2b93a40140001c16fc1c931ea0642abb43fef5e64afd97303c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41484", "10.65.0.27:41484", "172.17.0.1:41484"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:09:25.590729478Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5020795885021167,
+				"StableID":   "nQyBT4ovCg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e377a5950ad45df6e9c62d30d11462fb8487bf191f6650c0d7359e7ca084ef3c",
+				"KeyExpiry":  "2026-10-26T11:09:26Z",
+				"DiscoKey":   "discokey:241cc82377cbc61816e4ca4195e4f55367e5c14d95695dead7f6f4a9b86ef07e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43966", "10.65.0.27:43966", "172.17.0.1:43966"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:09:26.125929521Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8727498203809198": {
+				"ID":          8727498203809198,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7131323554041054,
+				"StableID":   "nBoDQ5nngx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:583c6549253742d5187854dc03c5e444f1616a7c66867bcfbb582dc6e63d7915",
+				"KeyExpiry":  "2026-10-26T11:09:25Z",
+				"DiscoKey":   "discokey:dce7e98c2cb482fbaeceff205e80b853ef7db4c8de32bff46026dbd4d6f30620",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51514", "10.65.0.27:51514", "172.17.0.1:51514"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:09:25.052545864Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:583c6549253742d5187854dc03c5e444f1616a7c66867bcfbb582dc6e63d7915",
+			"MachineKey": "mkey:ba7e5583e0600fbc8377e88f0197445b69d6d655a91b743af5eda37acb336535",
+			"Peers": [{
+				"ID":         8727498203809198,
+				"StableID":   "nZAiMZah9B21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf684fe791604ddd860d15360f012dcdc23b88fbb9ed22e69fc2a6e0ba181528",
+				"DiscoKey":   "discokey:78f7a1c58c689716c0aa60dc32c77d45ceb38e7e3d7c42520bc0d29428f4b245",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:50341", "10.65.0.27:50341", "172.17.0.1:50341"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:09:22.299930531Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4329185102760981,
+				"StableID":   "nEq7wPMhoa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2f522f47ee736ab1b8b8270e11de1cd90aa642e447f8646c1c162bcac482290a",
+				"DiscoKey":   "discokey:6e0722f327e384e9fe76272289c8bacd48f89d30fe382bc4fde8766c92744d2e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54928", "10.65.0.27:54928", "172.17.0.1:54928"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:09:22.832722472Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7314967480462500,
+				"StableID":   "nPaWKvnx7z11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66be1509ade05fb01e57b5763182f3b5c4deb52ecd87c4676830443ff5658e32",
+				"DiscoKey":   "discokey:7fc4a1a0ffbd54ec61cc455888e8e917706a54f7fc7387e02c36491e28df1f56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53994", "10.65.0.27:53994", "172.17.0.1:53994"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:09:23.453376671Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         275919037510456,
+				"StableID":   "n3xFWfvx9311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1d8001467552849da264fd574521a38081b52780ff76361b1810623f9faa3900",
+				"DiscoKey":   "discokey:b0142569b00d615d28bd1bfd83af22afcb496b9411ca522bd77d3655f25bff0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36196", "10.65.0.27:36196", "172.17.0.1:36196"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:09:23.938108054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1959379250698017,
+				"StableID":   "nkYho5aQJG11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:903ddeb11ea65265b4b8eb92d1c0ccb31f2b92d5859da0f7e40fae6214a14e5e",
+				"DiscoKey":   "discokey:e241d9b246613f9272862d4044159fe98d693529feeb6e624d4410d82d0d3b52",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:51226", "10.65.0.27:51226", "172.17.0.1:51226"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:09:24.485432025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2758752188497194,
+				"StableID":   "n3Kgz2kSYN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2c15cbcb2a6cc3c8bd3b96755486f1650e46c723ad5c71a5535bc2b73bec9d7e",
+				"KeyExpiry":  "2026-10-26T11:09:25Z",
+				"DiscoKey":   "discokey:c4cf69dc42761e2b93a40140001c16fc1c931ea0642abb43fef5e64afd97303c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41484", "10.65.0.27:41484", "172.17.0.1:41484"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:09:25.590729478Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5020795885021167,
+				"StableID":   "nQyBT4ovCg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e377a5950ad45df6e9c62d30d11462fb8487bf191f6650c0d7359e7ca084ef3c",
+				"KeyExpiry":  "2026-10-26T11:09:26Z",
+				"DiscoKey":   "discokey:241cc82377cbc61816e4ca4195e4f55367e5c14d95695dead7f6f4a9b86ef07e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43966", "10.65.0.27:43966", "172.17.0.1:43966"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:09:26.125929521Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         275919037510456,
+				"StableID":   "n3xFWfvx9311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       275919037510456,
+				"Key":        "nodekey:1d8001467552849da264fd574521a38081b52780ff76361b1810623f9faa3900",
+				"DiscoKey":   "discokey:b0142569b00d615d28bd1bfd83af22afcb496b9411ca522bd77d3655f25bff0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36196", "10.65.0.27:36196", "172.17.0.1:36196"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:09:23.938108054Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1d8001467552849da264fd574521a38081b52780ff76361b1810623f9faa3900",
+			"MachineKey": "mkey:9a6b8ddc444c4fd164a083a64d1e98c4d18586a054e26f329c57cceebdb3570f",
+			"Peers": [{
+				"ID":         8727498203809198,
+				"StableID":   "nZAiMZah9B21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf684fe791604ddd860d15360f012dcdc23b88fbb9ed22e69fc2a6e0ba181528",
+				"DiscoKey":   "discokey:78f7a1c58c689716c0aa60dc32c77d45ceb38e7e3d7c42520bc0d29428f4b245",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:50341", "10.65.0.27:50341", "172.17.0.1:50341"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:09:22.299930531Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4329185102760981,
+				"StableID":   "nEq7wPMhoa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2f522f47ee736ab1b8b8270e11de1cd90aa642e447f8646c1c162bcac482290a",
+				"DiscoKey":   "discokey:6e0722f327e384e9fe76272289c8bacd48f89d30fe382bc4fde8766c92744d2e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54928", "10.65.0.27:54928", "172.17.0.1:54928"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:09:22.832722472Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7314967480462500,
+				"StableID":   "nPaWKvnx7z11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66be1509ade05fb01e57b5763182f3b5c4deb52ecd87c4676830443ff5658e32",
+				"DiscoKey":   "discokey:7fc4a1a0ffbd54ec61cc455888e8e917706a54f7fc7387e02c36491e28df1f56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53994", "10.65.0.27:53994", "172.17.0.1:53994"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:09:23.453376671Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1959379250698017,
+				"StableID":   "nkYho5aQJG11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:903ddeb11ea65265b4b8eb92d1c0ccb31f2b92d5859da0f7e40fae6214a14e5e",
+				"DiscoKey":   "discokey:e241d9b246613f9272862d4044159fe98d693529feeb6e624d4410d82d0d3b52",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:51226", "10.65.0.27:51226", "172.17.0.1:51226"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:09:24.485432025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7131323554041054,
+				"StableID":   "nBoDQ5nngx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:583c6549253742d5187854dc03c5e444f1616a7c66867bcfbb582dc6e63d7915",
+				"KeyExpiry":  "2026-10-26T11:09:25Z",
+				"DiscoKey":   "discokey:dce7e98c2cb482fbaeceff205e80b853ef7db4c8de32bff46026dbd4d6f30620",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51514", "10.65.0.27:51514", "172.17.0.1:51514"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:09:25.052545864Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2758752188497194,
+				"StableID":   "n3Kgz2kSYN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2c15cbcb2a6cc3c8bd3b96755486f1650e46c723ad5c71a5535bc2b73bec9d7e",
+				"KeyExpiry":  "2026-10-26T11:09:25Z",
+				"DiscoKey":   "discokey:c4cf69dc42761e2b93a40140001c16fc1c931ea0642abb43fef5e64afd97303c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41484", "10.65.0.27:41484", "172.17.0.1:41484"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:09:25.590729478Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5020795885021167,
+				"StableID":   "nQyBT4ovCg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e377a5950ad45df6e9c62d30d11462fb8487bf191f6650c0d7359e7ca084ef3c",
+				"KeyExpiry":  "2026-10-26T11:09:26Z",
+				"DiscoKey":   "discokey:241cc82377cbc61816e4ca4195e4f55367e5c14d95695dead7f6f4a9b86ef07e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43966", "10.65.0.27:43966", "172.17.0.1:43966"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:09:26.125929521Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "275919037510456": {
+				"ID":          275919037510456,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4329185102760981,
+				"StableID":   "nEq7wPMhoa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       4329185102760981,
+				"Key":        "nodekey:2f522f47ee736ab1b8b8270e11de1cd90aa642e447f8646c1c162bcac482290a",
+				"DiscoKey":   "discokey:6e0722f327e384e9fe76272289c8bacd48f89d30fe382bc4fde8766c92744d2e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54928", "10.65.0.27:54928", "172.17.0.1:54928"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-04-29T11:09:22.832722472Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2f522f47ee736ab1b8b8270e11de1cd90aa642e447f8646c1c162bcac482290a",
+			"MachineKey": "mkey:78dd70cbc3618b3604f798ca0bf49e404397021675bdedcbd58de3dab834f121",
+			"Peers": [{
+				"ID":         8727498203809198,
+				"StableID":   "nZAiMZah9B21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf684fe791604ddd860d15360f012dcdc23b88fbb9ed22e69fc2a6e0ba181528",
+				"DiscoKey":   "discokey:78f7a1c58c689716c0aa60dc32c77d45ceb38e7e3d7c42520bc0d29428f4b245",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:50341", "10.65.0.27:50341", "172.17.0.1:50341"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:09:22.299930531Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7314967480462500,
+				"StableID":   "nPaWKvnx7z11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66be1509ade05fb01e57b5763182f3b5c4deb52ecd87c4676830443ff5658e32",
+				"DiscoKey":   "discokey:7fc4a1a0ffbd54ec61cc455888e8e917706a54f7fc7387e02c36491e28df1f56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53994", "10.65.0.27:53994", "172.17.0.1:53994"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:09:23.453376671Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         275919037510456,
+				"StableID":   "n3xFWfvx9311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1d8001467552849da264fd574521a38081b52780ff76361b1810623f9faa3900",
+				"DiscoKey":   "discokey:b0142569b00d615d28bd1bfd83af22afcb496b9411ca522bd77d3655f25bff0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36196", "10.65.0.27:36196", "172.17.0.1:36196"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:09:23.938108054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1959379250698017,
+				"StableID":   "nkYho5aQJG11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:903ddeb11ea65265b4b8eb92d1c0ccb31f2b92d5859da0f7e40fae6214a14e5e",
+				"DiscoKey":   "discokey:e241d9b246613f9272862d4044159fe98d693529feeb6e624d4410d82d0d3b52",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:51226", "10.65.0.27:51226", "172.17.0.1:51226"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:09:24.485432025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7131323554041054,
+				"StableID":   "nBoDQ5nngx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:583c6549253742d5187854dc03c5e444f1616a7c66867bcfbb582dc6e63d7915",
+				"KeyExpiry":  "2026-10-26T11:09:25Z",
+				"DiscoKey":   "discokey:dce7e98c2cb482fbaeceff205e80b853ef7db4c8de32bff46026dbd4d6f30620",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51514", "10.65.0.27:51514", "172.17.0.1:51514"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:09:25.052545864Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2758752188497194,
+				"StableID":   "n3Kgz2kSYN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2c15cbcb2a6cc3c8bd3b96755486f1650e46c723ad5c71a5535bc2b73bec9d7e",
+				"KeyExpiry":  "2026-10-26T11:09:25Z",
+				"DiscoKey":   "discokey:c4cf69dc42761e2b93a40140001c16fc1c931ea0642abb43fef5e64afd97303c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41484", "10.65.0.27:41484", "172.17.0.1:41484"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:09:25.590729478Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5020795885021167,
+				"StableID":   "nQyBT4ovCg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e377a5950ad45df6e9c62d30d11462fb8487bf191f6650c0d7359e7ca084ef3c",
+				"KeyExpiry":  "2026-10-26T11:09:26Z",
+				"DiscoKey":   "discokey:241cc82377cbc61816e4ca4195e4f55367e5c14d95695dead7f6f4a9b86ef07e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43966", "10.65.0.27:43966", "172.17.0.1:43966"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:09:26.125929521Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4329185102760981": {
+				"ID":          4329185102760981,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2758752188497194,
+				"StableID":   "n3Kgz2kSYN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2c15cbcb2a6cc3c8bd3b96755486f1650e46c723ad5c71a5535bc2b73bec9d7e",
+				"KeyExpiry":  "2026-10-26T11:09:25Z",
+				"DiscoKey":   "discokey:c4cf69dc42761e2b93a40140001c16fc1c931ea0642abb43fef5e64afd97303c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41484", "10.65.0.27:41484", "172.17.0.1:41484"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:09:25.590729478Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2c15cbcb2a6cc3c8bd3b96755486f1650e46c723ad5c71a5535bc2b73bec9d7e",
+			"MachineKey": "mkey:ae2438afdf02f74ef7a4bc76b7fe449edbb71b03ceaefe3346b08c86817f5341",
+			"Peers": [{
+				"ID":         8727498203809198,
+				"StableID":   "nZAiMZah9B21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf684fe791604ddd860d15360f012dcdc23b88fbb9ed22e69fc2a6e0ba181528",
+				"DiscoKey":   "discokey:78f7a1c58c689716c0aa60dc32c77d45ceb38e7e3d7c42520bc0d29428f4b245",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:50341", "10.65.0.27:50341", "172.17.0.1:50341"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:09:22.299930531Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4329185102760981,
+				"StableID":   "nEq7wPMhoa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2f522f47ee736ab1b8b8270e11de1cd90aa642e447f8646c1c162bcac482290a",
+				"DiscoKey":   "discokey:6e0722f327e384e9fe76272289c8bacd48f89d30fe382bc4fde8766c92744d2e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54928", "10.65.0.27:54928", "172.17.0.1:54928"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:09:22.832722472Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7314967480462500,
+				"StableID":   "nPaWKvnx7z11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66be1509ade05fb01e57b5763182f3b5c4deb52ecd87c4676830443ff5658e32",
+				"DiscoKey":   "discokey:7fc4a1a0ffbd54ec61cc455888e8e917706a54f7fc7387e02c36491e28df1f56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53994", "10.65.0.27:53994", "172.17.0.1:53994"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-04-29T11:09:23.453376671Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         275919037510456,
+				"StableID":   "n3xFWfvx9311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1d8001467552849da264fd574521a38081b52780ff76361b1810623f9faa3900",
+				"DiscoKey":   "discokey:b0142569b00d615d28bd1bfd83af22afcb496b9411ca522bd77d3655f25bff0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36196", "10.65.0.27:36196", "172.17.0.1:36196"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:09:23.938108054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1959379250698017,
+				"StableID":   "nkYho5aQJG11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:903ddeb11ea65265b4b8eb92d1c0ccb31f2b92d5859da0f7e40fae6214a14e5e",
+				"DiscoKey":   "discokey:e241d9b246613f9272862d4044159fe98d693529feeb6e624d4410d82d0d3b52",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:51226", "10.65.0.27:51226", "172.17.0.1:51226"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:09:24.485432025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7131323554041054,
+				"StableID":   "nBoDQ5nngx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:583c6549253742d5187854dc03c5e444f1616a7c66867bcfbb582dc6e63d7915",
+				"KeyExpiry":  "2026-10-26T11:09:25Z",
+				"DiscoKey":   "discokey:dce7e98c2cb482fbaeceff205e80b853ef7db4c8de32bff46026dbd4d6f30620",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51514", "10.65.0.27:51514", "172.17.0.1:51514"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:09:25.052545864Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5020795885021167,
+				"StableID":   "nQyBT4ovCg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e377a5950ad45df6e9c62d30d11462fb8487bf191f6650c0d7359e7ca084ef3c",
+				"KeyExpiry":  "2026-10-26T11:09:26Z",
+				"DiscoKey":   "discokey:241cc82377cbc61816e4ca4195e4f55367e5c14d95695dead7f6f4a9b86ef07e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43966", "10.65.0.27:43966", "172.17.0.1:43966"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:09:26.125929521Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7314967480462500,
+				"StableID":   "nPaWKvnx7z11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       7314967480462500,
+				"Key":        "nodekey:66be1509ade05fb01e57b5763182f3b5c4deb52ecd87c4676830443ff5658e32",
+				"DiscoKey":   "discokey:7fc4a1a0ffbd54ec61cc455888e8e917706a54f7fc7387e02c36491e28df1f56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53994", "10.65.0.27:53994", "172.17.0.1:53994"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-04-29T11:09:23.453376671Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:66be1509ade05fb01e57b5763182f3b5c4deb52ecd87c4676830443ff5658e32",
+			"MachineKey": "mkey:f3455305d6af5d84962aee2f12febfd08e90c37b4baefe820d549292fa11221c",
+			"Peers": [{
+				"ID":         8727498203809198,
+				"StableID":   "nZAiMZah9B21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf684fe791604ddd860d15360f012dcdc23b88fbb9ed22e69fc2a6e0ba181528",
+				"DiscoKey":   "discokey:78f7a1c58c689716c0aa60dc32c77d45ceb38e7e3d7c42520bc0d29428f4b245",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:50341", "10.65.0.27:50341", "172.17.0.1:50341"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-04-29T11:09:22.299930531Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4329185102760981,
+				"StableID":   "nEq7wPMhoa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2f522f47ee736ab1b8b8270e11de1cd90aa642e447f8646c1c162bcac482290a",
+				"DiscoKey":   "discokey:6e0722f327e384e9fe76272289c8bacd48f89d30fe382bc4fde8766c92744d2e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54928", "10.65.0.27:54928", "172.17.0.1:54928"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-04-29T11:09:22.832722472Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         275919037510456,
+				"StableID":   "n3xFWfvx9311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1d8001467552849da264fd574521a38081b52780ff76361b1810623f9faa3900",
+				"DiscoKey":   "discokey:b0142569b00d615d28bd1bfd83af22afcb496b9411ca522bd77d3655f25bff0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36196", "10.65.0.27:36196", "172.17.0.1:36196"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-04-29T11:09:23.938108054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1959379250698017,
+				"StableID":   "nkYho5aQJG11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:903ddeb11ea65265b4b8eb92d1c0ccb31f2b92d5859da0f7e40fae6214a14e5e",
+				"DiscoKey":   "discokey:e241d9b246613f9272862d4044159fe98d693529feeb6e624d4410d82d0d3b52",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:51226", "10.65.0.27:51226", "172.17.0.1:51226"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-04-29T11:09:24.485432025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7131323554041054,
+				"StableID":   "nBoDQ5nngx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:583c6549253742d5187854dc03c5e444f1616a7c66867bcfbb582dc6e63d7915",
+				"KeyExpiry":  "2026-10-26T11:09:25Z",
+				"DiscoKey":   "discokey:dce7e98c2cb482fbaeceff205e80b853ef7db4c8de32bff46026dbd4d6f30620",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:51514", "10.65.0.27:51514", "172.17.0.1:51514"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-04-29T11:09:25.052545864Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2758752188497194,
+				"StableID":   "n3Kgz2kSYN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2c15cbcb2a6cc3c8bd3b96755486f1650e46c723ad5c71a5535bc2b73bec9d7e",
+				"KeyExpiry":  "2026-10-26T11:09:25Z",
+				"DiscoKey":   "discokey:c4cf69dc42761e2b93a40140001c16fc1c931ea0642abb43fef5e64afd97303c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41484", "10.65.0.27:41484", "172.17.0.1:41484"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-04-29T11:09:25.590729478Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5020795885021167,
+				"StableID":   "nQyBT4ovCg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e377a5950ad45df6e9c62d30d11462fb8487bf191f6650c0d7359e7ca084ef3c",
+				"KeyExpiry":  "2026-10-26T11:09:26Z",
+				"DiscoKey":   "discokey:241cc82377cbc61816e4ca4195e4f55367e5c14d95695dead7f6f4a9b86ef07e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:43966", "10.65.0.27:43966", "172.17.0.1:43966"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-04-29T11:09:26.125929521Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7314967480462500": {
+				"ID":          7314967480462500,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/types.go
+++ b/hscontrol/policy/v2/types.go
@@ -125,6 +125,11 @@ var (
 	ErrUnknownSSHSrcAlias          = errors.New("unknown SSH source alias type")
 	ErrUnknownField                = errors.New("unknown field")
 	ErrProtocolNoSpecificPorts     = errors.New("protocol does not support specific ports")
+	ErrTestEmptyAssertions         = errors.New("test entry must have at least one of \"accept\" or \"deny\"")
+	ErrTestProtocolNotAllowed      = errors.New("test protocol must be tcp, udp, sctp, or empty")
+	ErrTestDestinationMultiPort    = errors.New("test destination port must be a single port")
+	ErrTestDestinationCIDR         = errors.New("test destination must be a single host, not a CIDR range")
+	ErrAutogroupInternetTestDst    = errors.New("autogroup:internet not valid as a test destination")
 )
 
 type resolved struct {
@@ -2676,6 +2681,10 @@ func (p *Policy) validate() error {
 		}
 	}
 
+	if err := validateTests(p, p.Tests); err != nil { //nolint:noinlineerr
+		errs = append(errs, err)
+	}
+
 	if len(errs) > 0 {
 		return multierr.New(errs...)
 	}
@@ -3046,6 +3055,88 @@ func validateProtocolPortCompatibility(protocol Protocol, destinations []AliasWi
 			// Check if it's not a wildcard port (0-65535)
 			if portRange.First != 0 || portRange.Last != 65535 {
 				return fmt.Errorf("%w: %q, only \"*\" is allowed", ErrProtocolNoSpecificPorts, protocol)
+			}
+		}
+	}
+
+	return nil
+}
+
+// validateTests enforces the four shape rules a tests-block entry must
+// follow: a tests entry describes one connection attempt to one specific
+// destination port over a connection-oriented protocol and asserts
+// whether that attempt is allowed or denied. The same shapes remain
+// valid inside ACL or Grant destinations where the rule does not apply.
+func validateTests(pol *Policy, tests []PolicyTest) error {
+	var errs []error
+
+	for i, t := range tests {
+		if len(t.Accept) == 0 && len(t.Deny) == 0 {
+			errs = append(errs, fmt.Errorf("test %d: %w", i, ErrTestEmptyAssertions))
+		}
+
+		if t.Proto != "" &&
+			t.Proto != ProtocolNameTCP &&
+			t.Proto != ProtocolNameUDP &&
+			t.Proto != ProtocolNameSCTP {
+			errs = append(errs, fmt.Errorf("test %d: %w: %q", i, ErrTestProtocolNotAllowed, t.Proto))
+		}
+
+		for _, dst := range t.Accept {
+			err := validateTestDestination(pol, dst)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("test %d, accept %q: %w", i, dst, err))
+			}
+		}
+
+		for _, dst := range t.Deny {
+			err := validateTestDestination(pol, dst)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("test %d, deny %q: %w", i, dst, err))
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%w:\n%w", errPolicyTestsFailed, multierr.New(errs...))
+	}
+
+	return nil
+}
+
+// validateTestDestination enforces that a tests-block dst describes one
+// connection attempt to one specific host on one specific port. SaaS
+// rejects three shapes that violate the rule: autogroup:internet (routed
+// by exit-node AllowedIPs, not the packet filter); multi-port
+// (range/list/wildcard, no single allow/deny answer); and CIDR ranges
+// — both raw `/N` syntax and `hosts:`-table aliases whose RHS is a
+// multi-host prefix. Bare IP literals reach this function as *Prefix
+// /32 or /128 just like explicit `/32` / `/128` does, so the CIDR
+// check inspects the raw input string for `/` rather than the parsed
+// alias type.
+func validateTestDestination(pol *Policy, dst string) error {
+	awp, err := parseDestinationAlias(dst)
+	if err != nil {
+		return err
+	}
+
+	if ag, ok := awp.Alias.(*AutoGroup); ok && *ag == AutoGroupInternet {
+		return ErrAutogroupInternetTestDst
+	}
+
+	if len(awp.Ports) != 1 || awp.Ports[0].First != awp.Ports[0].Last {
+		return ErrTestDestinationMultiPort
+	}
+
+	if _, isPrefix := awp.Alias.(*Prefix); isPrefix && strings.Contains(dst, "/") {
+		return ErrTestDestinationCIDR
+	}
+
+	if h, isHost := awp.Alias.(*Host); isHost && pol != nil {
+		if pref, ok := pol.Hosts[*h]; ok {
+			p := netip.Prefix(pref)
+			if p.Bits() < p.Addr().BitLen() {
+				return ErrTestDestinationCIDR
 			}
 		}
 	}

--- a/hscontrol/policy/v2/types.go
+++ b/hscontrol/policy/v2/types.go
@@ -1756,13 +1756,27 @@ func (p *Protocol) toIANAProtocolNumbers() []int {
 }
 
 // UnmarshalJSON implements JSON unmarshaling for Protocol.
+//
+// Tailscale accepts both named ("tcp") and numeric IANA ("6") forms.
+// Storing whichever form the user wrote leaves downstream code with
+// two equivalents to handle separately, and any consumer that
+// branches on the named form would silently mishandle the numeric
+// equivalent. Canonicalising to the named form here makes Protocol
+// hold one value post-parse — every downstream consumer sees the
+// same form regardless of what the user wrote.
 func (p *Protocol) UnmarshalJSON(b []byte) error {
 	str := strings.Trim(string(b), `"`)
 
 	// Normalize to lowercase for case-insensitive matching
 	*p = Protocol(strings.ToLower(str))
 
-	// Validate the protocol
+	num, atoiErr := strconv.Atoi(string(*p))
+	if atoiErr == nil && num >= 0 && num <= 255 {
+		if name, ok := ProtocolNumberToName[num]; ok {
+			*p = name
+		}
+	}
+
 	err := p.validate()
 	if err != nil {
 		return err

--- a/hscontrol/policy/v2/types.go
+++ b/hscontrol/policy/v2/types.go
@@ -1986,6 +1986,7 @@ type Policy struct {
 	Grants        []Grant            `json:"grants,omitempty"`
 	AutoApprovers AutoApproverPolicy `json:"autoApprovers"`
 	SSHs          []SSH              `json:"ssh,omitempty"`
+	Tests         []PolicyTest       `json:"tests,omitempty"`
 }
 
 // MarshalJSON is deliberately not implemented for Policy.

--- a/hscontrol/policy/v2/types_test.go
+++ b/hscontrol/policy/v2/types_test.go
@@ -2051,6 +2051,142 @@ func TestUnmarshalPolicy(t *testing.T) {
 `,
 			wantErr: "invalid localpart format",
 		},
+		// A test entry with neither accept nor deny asserts nothing
+		// and is silently accepted today. Tailscale rejects the policy.
+		{
+			name: "tests-empty-assertions",
+			input: `
+{
+	"acls": [
+		{"action": "accept", "src": ["*"], "dst": ["*:22"]}
+	],
+	"tests": [
+		{"src": "*"}
+	]
+}
+`,
+			wantErr: `test entry must have at least one of "accept" or "deny"`,
+		},
+		// Tests can only describe connection-oriented reachability, so
+		// proto must be tcp, udp, sctp, or empty. Tailscale rejects
+		// proto=icmp on a test entry even though icmp is valid in rules.
+		{
+			name: "tests-proto-icmp-not-allowed",
+			input: `
+{
+	"acls": [
+		{"action": "accept", "proto": "icmp", "src": ["*"], "dst": ["*:*"]}
+	],
+	"tests": [
+		{"src": "*", "proto": "icmp", "accept": ["*:*"]}
+	]
+}
+`,
+			wantErr: `test protocol must be tcp, udp, sctp, or empty`,
+		},
+		// A test asserts one connection attempt to one specific port.
+		// Port ranges, lists, and wildcards conflate multiple attempts
+		// and have no single answer; Tailscale rejects them in tests.
+		{
+			name: "tests-dst-port-range-not-allowed",
+			input: `
+{
+	"acls": [
+		{"action": "accept", "src": ["*"], "dst": ["*:8000-8100"]}
+	],
+	"tests": [
+		{"src": "*", "accept": ["*:8000-8100"]}
+	]
+}
+`,
+			wantErr: `test destination port must be a single port`,
+		},
+		// autogroup:internet is delivered via exit-node AllowedIPs, not
+		// packet-filter rules, so reachability to it has no meaning in
+		// the filter model used by tests. Tailscale rejects it in
+		// test destinations even though it is valid in rule destinations.
+		{
+			name: "tests-dst-autogroup-internet-not-allowed",
+			input: `
+{
+	"tagOwners": {
+		"tag:client": ["admin@example.com"]
+	},
+	"acls": [
+		{"action": "accept", "src": ["tag:client"], "dst": ["autogroup:internet:*"]}
+	],
+	"tests": [
+		{"src": "tag:client", "deny": ["autogroup:internet:*"]}
+	]
+}
+`,
+			wantErr: `autogroup:internet not valid as a test destination`,
+		},
+		// A test asserts one connection attempt to one specific host.
+		// Tailscale rejects raw `/N` notation in test dsts even when
+		// the prefix is `/32` — the alias parser distinguishes a bare
+		// IP literal from an explicit single-host CIDR even though
+		// they cover the same address.
+		{
+			name: "tests-dst-cidr-prefix32-not-allowed",
+			input: `
+{
+	"tagOwners": {
+		"tag:client": ["admin@example.com"]
+	},
+	"acls": [
+		{"action": "accept", "src": ["tag:client"], "dst": ["100.64.0.16/32:22"]}
+	],
+	"tests": [
+		{"src": "tag:client", "accept": ["100.64.0.16/32:22"]}
+	]
+}
+`,
+			wantErr: `test destination must be a single host, not a CIDR range`,
+		},
+		// Multi-host prefixes in test dsts are rejected for the same
+		// reason port ranges are: the assertion has no single answer
+		// once the prefix covers more than one host.
+		{
+			name: "tests-dst-cidr-multi-host-not-allowed",
+			input: `
+{
+	"tagOwners": {
+		"tag:client": ["admin@example.com"]
+	},
+	"acls": [
+		{"action": "accept", "src": ["tag:client"], "dst": ["10.0.0.0/8:22"]}
+	],
+	"tests": [
+		{"src": "tag:client", "accept": ["10.0.0.0/8:22"]}
+	]
+}
+`,
+			wantErr: `test destination must be a single host, not a CIDR range`,
+		},
+		// hosts: aliases with a multi-host RHS are rejected after
+		// resolution. The alias text has no slash but the alias still
+		// resolves to a range, which is the rule SaaS enforces.
+		{
+			name: "tests-dst-host-alias-cidr-not-allowed",
+			input: `
+{
+	"tagOwners": {
+		"tag:client": ["admin@example.com"]
+	},
+	"hosts": {
+		"internal": "10.0.0.0/8"
+	},
+	"acls": [
+		{"action": "accept", "src": ["tag:client"], "dst": ["internal:22"]}
+	],
+	"tests": [
+		{"src": "tag:client", "accept": ["internal:22"]}
+	]
+}
+`,
+			wantErr: `test destination must be a single host, not a CIDR range`,
+		},
 	}
 
 	cmps := append(util.Comparers,

--- a/hscontrol/policy/v2/types_test.go
+++ b/hscontrol/policy/v2/types_test.go
@@ -2187,6 +2187,42 @@ func TestUnmarshalPolicy(t *testing.T) {
 `,
 			wantErr: `test destination must be a single host, not a CIDR range`,
 		},
+		// Tailscale accepts numeric IANA protocol form ("6", "17",
+		// "132") wherever the named form is allowed, including with
+		// specific ports. validateProtocolPortCompatibility today only
+		// recognises the named constants and rejects the numeric form.
+		{
+			name: "protocol-numeric-tcp-with-specific-port-allowed",
+			input: `
+{
+	"acls": [
+		{
+			"action": "accept",
+			"proto": "6",
+			"src": ["*"],
+			"dst": ["*:443"]
+		}
+	]
+}
+`,
+			want: &Policy{
+				ACLs: []ACL{
+					{
+						Action:   "accept",
+						Protocol: "tcp",
+						Sources: Aliases{
+							Wildcard,
+						},
+						Destinations: []AliasWithPorts{
+							{
+								Alias: Wildcard,
+								Ports: []tailcfg.PortRange{{First: 443, Last: 443}},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	cmps := append(util.Comparers,

--- a/integration/cli_policy_test.go
+++ b/integration/cli_policy_test.go
@@ -1,0 +1,166 @@
+package integration
+
+import (
+	"encoding/json"
+	"testing"
+
+	policyv2 "github.com/juanfont/headscale/hscontrol/policy/v2"
+	"github.com/juanfont/headscale/integration/hsic"
+	"github.com/juanfont/headscale/integration/tsic"
+	"github.com/stretchr/testify/require"
+	"tailscale.com/tailcfg"
+)
+
+// TestPolicyCheckCommand exercises `headscale policy check` across the
+// matrix that nblock asked about on PR #3229:
+//
+//   - policyMode: server runs with policy_mode=file vs policy_mode=database.
+//     `check` reads from `--file`, so the server-side mode should not
+//     change the outcome; running both proves that.
+//   - fixture: ACL only, ACL with passing tests, ACL with failing tests.
+//   - bypass: no-bypass talks to the server over gRPC; bypass opens the
+//     database directly.
+//
+// Each row spins up its own scenario because policy_mode is fixed at boot
+// via `HEADSCALE_POLICY_MODE`. The two users + two nodes give the tests
+// block real `user@` aliases to resolve against.
+func TestPolicyCheckCommand(t *testing.T) {
+	IntegrationSkip(t)
+
+	type fixture struct {
+		name   string
+		policy policyv2.Policy
+	}
+
+	const (
+		user1 = "user1@"
+		user2 = "user2@"
+	)
+
+	aclOnly := policyv2.Policy{
+		ACLs: []policyv2.ACL{
+			{
+				Action:   policyv2.ActionAccept,
+				Protocol: "tcp", //nolint:goconst // protocol literal, used inline once
+				Sources:  []policyv2.Alias{usernamep(user1)},
+				Destinations: []policyv2.AliasWithPorts{
+					aliasWithPorts(usernamep(user2), tailcfg.PortRange{First: 22, Last: 22}),
+				},
+			},
+		},
+	}
+
+	aclPlusPassingTests := aclOnly
+	aclPlusPassingTests.Tests = []policyv2.PolicyTest{
+		{
+			Src:    user1,
+			Accept: []string{user2 + ":22"},
+		},
+	}
+
+	aclPlusFailingTests := aclOnly
+	aclPlusFailingTests.Tests = []policyv2.PolicyTest{
+		{
+			// Reverse direction is not allowed by the ACL; the test
+			// asserts ALLOWED, so it must fail.
+			Src:    user2,
+			Accept: []string{user1 + ":22"},
+		},
+	}
+
+	fixtures := []fixture{
+		{name: "acl-only", policy: aclOnly},
+		{name: "acl-plus-passing-tests", policy: aclPlusPassingTests},
+		{name: "acl-plus-failing-tests", policy: aclPlusFailingTests},
+	}
+
+	type row struct {
+		name       string
+		policyMode string
+		fixture    fixture
+		bypass     bool
+		wantErr    string
+		wantStdout string
+	}
+
+	modes := []string{"file", "database"} //nolint:goconst // axis labels match HEADSCALE_POLICY_MODE values
+	bypasses := []bool{false, true}
+	rows := make([]row, 0, len(modes)*len(fixtures)*len(bypasses))
+
+	for _, mode := range modes {
+		for _, f := range fixtures {
+			for _, bypass := range bypasses {
+				suffix := "no-bypass"
+				if bypass {
+					suffix = "bypass"
+				}
+
+				r := row{
+					name:       mode + "-" + f.name + "-" + suffix,
+					policyMode: mode,
+					fixture:    f,
+					bypass:     bypass,
+					wantStdout: "Policy is valid",
+				}
+				if f.name == "acl-plus-failing-tests" {
+					r.wantErr = "test(s) failed"
+					r.wantStdout = ""
+				}
+
+				rows = append(rows, r)
+			}
+		}
+	}
+
+	for _, tt := range rows {
+		t.Run(tt.name, func(t *testing.T) {
+			spec := ScenarioSpec{
+				NodesPerUser: 1,
+				Users:        []string{"user1", "user2"}, //nolint:goconst // matches usernamep("user1@")/("user2@") above
+			}
+
+			scenario, err := NewScenario(spec)
+			require.NoError(t, err)
+
+			defer scenario.ShutdownAssertNoPanics(t)
+
+			err = scenario.CreateHeadscaleEnv(
+				[]tsic.Option{},
+				hsic.WithTestName("cli-policycheck"),
+				hsic.WithConfigEnv(map[string]string{
+					"HEADSCALE_POLICY_MODE": tt.policyMode, //nolint:goconst // env var name from hscontrol/types/config.go
+				}),
+			)
+			require.NoError(t, err)
+
+			headscale, err := scenario.Headscale()
+			require.NoError(t, err)
+
+			pBytes, err := json.Marshal(tt.fixture.policy)
+			require.NoError(t, err)
+
+			policyFilePath := "/etc/headscale/policy.json" //nolint:goconst // standard headscale policy path
+			err = headscale.WriteFile(policyFilePath, pBytes)
+			require.NoError(t, err)
+
+			cmd := []string{"headscale", "policy", "check", "-f", policyFilePath} //nolint:goconst // CLI invocation
+			if tt.bypass {
+				// --force suppresses the "is the server running?"
+				// confirmation prompt so the command can run
+				// non-interactively under the test harness.
+				cmd = append(cmd, "--bypass-grpc-and-access-database-directly", "--force")
+			}
+
+			stdout, err := headscale.Execute(cmd)
+
+			if tt.wantErr != "" {
+				require.ErrorContains(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Contains(t, stdout, tt.wantStdout)
+		})
+	}
+}

--- a/proto/headscale/v1/headscale.proto
+++ b/proto/headscale/v1/headscale.proto
@@ -204,6 +204,13 @@ service HeadscaleService {
       body : "*"
     };
   }
+
+  rpc CheckPolicy(CheckPolicyRequest) returns (CheckPolicyResponse) {
+    option (google.api.http) = {
+      post : "/api/v1/policy/check"
+      body : "*"
+    };
+  }
   // --- Policy end ---
 
   // --- Health start ---

--- a/proto/headscale/v1/policy.proto
+++ b/proto/headscale/v1/policy.proto
@@ -17,3 +17,7 @@ message GetPolicyResponse {
   string policy = 1;
   google.protobuf.Timestamp updated_at = 2;
 }
+
+message CheckPolicyRequest { string policy = 1; }
+
+message CheckPolicyResponse {}


### PR DESCRIPTION
Tailscale policies have a `tests` block where the operator says, for a given source, what should be reachable. v2 ignored it — a policy whose tests contradicted its own ACLs would still apply.

`SetPolicy` now compiles the new policy in a sandbox, runs the tests, and rejects on failure without touching the live `PolicyManager`. `NewPolicyManager` skips evaluation so a stale stored policy whose referenced user was deleted does not block boot. `headscale policy check` opens the database under `--bypass-grpc-and-access-database-directly` (same flag `set` and `get` already accept) and runs tests against live data.

Error messages match Tailscale SaaS so policies move between control planes without rewriting. Comparing against captured SaaS responses surfaced two engine bugs. `Protocol.UnmarshalJSON` stored whichever form the user wrote, so `proto: "6", dst: "host:443"` was rejected at parse though SaaS accepts it — `UnmarshalJSON` now canonicalises numeric IANA forms to the name. `srcReachesDst` passed empty Protocol through to `ruleMatchesProto`, which short-circuited any rule with an `IPProto` restriction, so a TCP-only grant could not satisfy a default-proto test — empty Protocol now expands to `{TCP, UDP, ICMP, ICMPv6}` at the call site.

Parse-time schema validation rejects test shapes SaaS rejects: single-port dst, proto in `{tcp, udp, sctp, ""}`, no `autogroup:internet` dst, no CIDR-typed dst, at least one of `accept`/`deny`.

Closes #3005

Fixes #1803

> Generated with the help of an AI assistant